### PR TITLE
fix: close review agent containers on draft approve/reject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,44 +1,127 @@
-# Dependencies
+# ============================================================
+# universityClaw .gitignore
+# Fork of NanoClaw — comprehensive security-first gitignore
+# ============================================================
+
+# ------ Dependencies ------
 node_modules/
 .npm-cache/
-# Build output
-dist/
+.pnp/
+.pnp.js
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
 
-# Local data & auth
+# ------ Build output ------
+dist/
+*.tsbuildinfo
+
+# ------ Local data & auth ------
 store/
 data/
 logs/
 
-# Groups - only track base structure and specific CLAUDE.md files
+# ------ Groups ------
+# Only track base structure and specific CLAUDE.md files
 groups/*
 !groups/main/
 !groups/global/
+!groups/review_agent/
 groups/main/*
 groups/global/*
+groups/review_agent/*
 !groups/main/CLAUDE.md
 !groups/global/CLAUDE.md
+!groups/review_agent/CLAUDE.md
 
-# Secrets
-*.keys.json
+# ------ Secrets & credentials ------
 .env
+.env.*
+!.env.example
+*.keys.json
+*.pem
+*.key
+*.p12
+*.pfx
+*.crt
+*.cer
+credentials.json
+client_secret*.json
+token.json
+access.json
+oauth*.json
+*.keystore
+secrets/
+.secret*
 
-# Temp files
-.tmp-*
-
-# OS
-.DS_Store
-
-# IDE
-.idea/
-.vscode/
-
-# Skills system (local per-installation state)
-.nanoclaw/
-
-agents-sdk-docs
-
-# universityClaw
+# ------ universityClaw sensitive data ------
+# Vault: exclude everything except example profile templates
 vault/*
 !vault/profile/
+vault/profile/*
+!vault/profile/*.example.md
+
+# Upload directory (user documents)
 upload/
+
+# Databases (may contain chat history, student data)
+*.db
+*.sqlite
+*.sqlite3
+*.db-journal
+*.db-wal
+*.db-shm
+
+# ------ Temp & cache files ------
+.tmp-*
+*.tmp
+*.bak
+*.swp
+*.swo
+*~
+.cache/
+.parcel-cache/
+
+# ------ OS files ------
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# ------ IDE & editor ------
+.idea/
+.vscode/
+*.sublime-project
+*.sublime-workspace
+*.code-workspace
+.project
+.classpath
+.settings/
+
+# ------ NanoClaw internals ------
+.nanoclaw/
+agents-sdk-docs
+
+# ------ Superpowers (local state) ------
 .superpowers/
+
+# ------ Python (docling, scripts) ------
+.venv/
+venv/
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+
+# ------ Log files ------
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,212 +1,83 @@
 <p align="center">
-  <img src="assets/nanoclaw-logo.png" alt="NanoClaw" width="400">
+  <img src="assets/nanoclaw-logo.png" alt="universityClaw" width="400">
 </p>
 
 <p align="center">
-  An AI assistant that runs agents securely in their own containers. Lightweight, built to be easily understood and completely customized for your needs.
-</p>
-
-<p align="center">
-  <a href="https://nanoclaw.dev">nanoclaw.dev</a>&nbsp; • &nbsp;
-  <a href="https://docs.nanoclaw.dev">docs</a>&nbsp; • &nbsp;
-  <a href="README_zh.md">中文</a>&nbsp; • &nbsp;
-  <a href="README_ja.md">日本語</a>&nbsp; • &nbsp;
-  <a href="https://discord.gg/VDdww8qS42"><img src="https://img.shields.io/discord/1470188214710046894?label=Discord&logo=discord&v=2" alt="Discord" valign="middle"></a>&nbsp; • &nbsp;
-  <a href="repo-tokens"><img src="repo-tokens/badge.svg" alt="34.9k tokens, 17% of context window" valign="middle"></a>
+  A personal university teaching assistant built on <a href="https://github.com/qwibitai/nanoclaw">NanoClaw</a>. Processes course materials, generates study notes, runs quizzes, and manages an Obsidian knowledge vault — all through Telegram.
 </p>
 
 ---
 
-## Why I Built NanoClaw
+## What is this?
 
-[OpenClaw](https://github.com/openclaw/openclaw) is an impressive project, but I wouldn't have been able to sleep if I had given complex software I didn't understand full access to my life. OpenClaw has nearly half a million lines of code, 53 config files, and 70+ dependencies. Its security is at the application level (allowlists, pairing codes) rather than true OS-level isolation. Everything runs in one Node process with shared memory.
+**universityClaw** is a fork of [NanoClaw](https://github.com/qwibitai/nanoclaw) customized as a university teaching assistant for a Digital Transformation degree program. It extends NanoClaw's secure agent-in-container architecture with:
 
-NanoClaw provides that same core functionality, but in a codebase small enough to understand: one process and a handful of files. Claude agents run in their own Linux containers with filesystem isolation, not merely behind permission checks.
-
-## Quick Start
-
-```bash
-gh repo fork qwibitai/nanoclaw --clone
-cd nanoclaw
-claude
-```
-
-<details>
-<summary>Without GitHub CLI</summary>
-
-1. Fork [qwibitai/nanoclaw](https://github.com/qwibitai/nanoclaw) on GitHub (click the Fork button)
-2. `git clone https://github.com/<your-username>/nanoclaw.git`
-3. `cd nanoclaw`
-4. `claude`
-
-</details>
-
-Then run `/setup`. Claude Code handles everything: dependencies, authentication, container setup and service configuration.
-
-> **Note:** Commands prefixed with `/` (like `/setup`, `/add-whatsapp`) are [Claude Code skills](https://code.claude.com/docs/en/skills). Type them inside the `claude` CLI prompt, not in your regular terminal. If you don't have Claude Code installed, get it at [claude.com/product/claude-code](https://claude.com/product/claude-code).
-
-## Philosophy
-
-**Small enough to understand.** One process, a few source files and no microservices. If you want to understand the full NanoClaw codebase, just ask Claude Code to walk you through it.
-
-**Secure by isolation.** Agents run in Linux containers (Apple Container on macOS, or Docker) and they can only see what's explicitly mounted. Bash access is safe because commands run inside the container, not on your host.
-
-**Built for the individual user.** NanoClaw isn't a monolithic framework; it's software that fits each user's exact needs. Instead of becoming bloatware, NanoClaw is designed to be bespoke. You make your own fork and have Claude Code modify it to match your needs.
-
-**Customization = code changes.** No configuration sprawl. Want different behavior? Modify the code. The codebase is small enough that it's safe to make changes.
-
-**AI-native.**
-- No installation wizard; Claude Code guides setup.
-- No monitoring dashboard; ask Claude what's happening.
-- No debugging tools; describe the problem and Claude fixes it.
-
-**Skills over features.** Instead of adding features (e.g. support for Telegram) to the codebase, contributors submit [claude code skills](https://code.claude.com/docs/en/skills) like `/add-telegram` that transform your fork. You end up with clean code that does exactly what you need.
-
-**Best harness, best model.** NanoClaw runs on the Claude Agent SDK, which means you're running Claude Code directly. Claude Code is highly capable and its coding and problem-solving capabilities allow it to modify and expand NanoClaw and tailor it to each user.
-
-## What It Supports
-
-- **Multi-channel messaging** - Talk to your assistant from WhatsApp, Telegram, Discord, Slack, or Gmail. Add channels with skills like `/add-whatsapp` or `/add-telegram`. Run one or many at the same time.
-- **Isolated group context** - Each group has its own `CLAUDE.md` memory, isolated filesystem, and runs in its own container sandbox with only that filesystem mounted to it.
-- **Main channel** - Your private channel (self-chat) for admin control; every group is completely isolated
-- **Scheduled tasks** - Recurring jobs that run Claude and can message you back
-- **Web access** - Search and fetch content from the Web
-- **Container isolation** - Agents are sandboxed in Docker (macOS/Linux), [Docker Sandboxes](docs/docker-sandboxes.md) (micro VM isolation), or Apple Container (macOS)
-- **Credential security** - Agents never hold raw API keys. Outbound requests route through [OneCLI's Agent Vault](https://github.com/onecli/onecli), which injects credentials at request time and enforces per-agent policies and rate limits.
-- **Agent Swarms** - Spin up teams of specialized agents that collaborate on complex tasks
-- **Optional integrations** - Add Gmail (`/add-gmail`) and more via skills
-
-## Usage
-
-Talk to your assistant with the trigger word (default: `@Andy`):
-
-```
-@Andy send an overview of the sales pipeline every weekday morning at 9am (has access to my Obsidian vault folder)
-@Andy review the git history for the past week each Friday and update the README if there's drift
-@Andy every Monday at 8am, compile news on AI developments from Hacker News and TechCrunch and message me a briefing
-```
-
-From the main channel (your self-chat), you can manage groups and tasks:
-```
-@Andy list all scheduled tasks across groups
-@Andy pause the Monday briefing task
-@Andy join the Family Chat group
-```
-
-## Customizing
-
-NanoClaw doesn't use configuration files. To make changes, just tell Claude Code what you want:
-
-- "Change the trigger word to @Bob"
-- "Remember in the future to make responses shorter and more direct"
-- "Add a custom greeting when I say good morning"
-- "Store conversation summaries weekly"
-
-Or run `/customize` for guided changes.
-
-The codebase is small enough that Claude can safely modify it.
-
-## Contributing
-
-**Don't add features. Add skills.**
-
-If you want to add Telegram support, don't create a PR that adds Telegram to the core codebase. Instead, fork NanoClaw, make the code changes on a branch, and open a PR. We'll create a `skill/telegram` branch from your PR that other users can merge into their fork.
-
-Users then run `/add-telegram` on their fork and get clean code that does exactly what they need, not a bloated system trying to support every use case.
-
-### RFS (Request for Skills)
-
-Skills we'd like to see:
-
-**Communication Channels**
-- `/add-signal` - Add Signal as a channel
-
-## Requirements
-
-- macOS, Linux, or Windows (via WSL2)
-- Node.js 20+
-- [Claude Code](https://claude.ai/download)
-- [Apple Container](https://github.com/apple/container) (macOS) or [Docker](https://docker.com/products/docker-desktop) (macOS/Linux)
+- **Document ingestion** — Upload PDFs, slides, and readings. They're processed into structured Obsidian study notes with metadata, tags, and wikilinks.
+- **Review workflow** — Drafts go through a review queue before entering the vault. Chat with the agent to refine notes before approving.
+- **RAG retrieval** — Hybrid search over the Obsidian vault so the agent can ground answers in your actual course material.
+- **Quiz generation** — Generate questions from specific courses or topics, with adaptive difficulty and knowledge tracking.
+- **Student profile** — Tracks courses, knowledge confidence, and study activity over time.
+- **Web dashboard** — Next.js app for uploading documents, reviewing drafts, and browsing the vault.
 
 ## Architecture
 
+Built on NanoClaw's single-process, container-isolated design:
+
 ```
-Channels --> SQLite --> Polling loop --> Container (Claude Agent SDK) --> Response
+Telegram / Web Dashboard
+        ↓
+    Orchestrator (Node.js)
+        ↓
+  ┌─────┴─────┐
+  │  Ingestion │ ← File watcher → Docling extraction → Agent note generation → Review queue
+  │  Pipeline  │
+  └─────┬─────┘
+        ↓
+  Container (Claude Agent SDK) ← RAG retrieval over Obsidian vault
+        ↓
+    Response → Telegram / Dashboard
 ```
 
-Single Node.js process. Channels are added via skills and self-register at startup — the orchestrator connects whichever ones have credentials present. Agents execute in isolated Linux containers with filesystem isolation. Only mounted directories are accessible. Per-group message queue with concurrency control. IPC via filesystem.
+### Key additions over NanoClaw
 
-For the full architecture details, see the [documentation site](https://docs.nanoclaw.dev/concepts/architecture).
+| Subsystem | Path | Purpose |
+|-----------|------|---------|
+| Vault utility | `src/vault/` | Direct Obsidian vault file I/O (frontmatter, wikilinks) |
+| Ingestion pipeline | `src/ingestion/` | File watcher → Docling → agent note gen → review queue |
+| RAG layer | `src/rag/` | LightRAG hybrid retrieval over the vault |
+| Student profile | `src/profile/` | Learning progress tracking |
+| Web channel | `src/channels/web.ts` | Dashboard ↔ agent communication |
+| Web dashboard | `dashboard/` | Next.js app (submodule) |
 
-Key files:
-- `src/index.ts` - Orchestrator: state, message loop, agent invocation
-- `src/channels/registry.ts` - Channel registry (self-registration at startup)
-- `src/ipc.ts` - IPC watcher and task processing
-- `src/router.ts` - Message formatting and outbound routing
-- `src/group-queue.ts` - Per-group queue with global concurrency limit
-- `src/container-runner.ts` - Spawns streaming agent containers
-- `src/task-scheduler.ts` - Runs scheduled tasks
-- `src/db.ts` - SQLite operations (messages, groups, sessions, state)
-- `groups/*/CLAUDE.md` - Per-group memory
+## Getting Started
 
-## FAQ
+This is a personal project. If you want something similar, fork [NanoClaw](https://github.com/qwibitai/nanoclaw) and customize it for your own needs — that's the NanoClaw philosophy.
 
-**Why Docker?**
+If you're interested in the approach:
 
-Docker provides cross-platform support (macOS, Linux and even Windows via WSL2) and a mature ecosystem. On macOS, you can optionally switch to Apple Container via `/convert-to-apple-container` for a lighter-weight native runtime. For additional isolation, [Docker Sandboxes](docs/docker-sandboxes.md) run each container inside a micro VM.
+1. Fork this repo (or NanoClaw directly)
+2. `npm install`
+3. Copy `.env.example` to `.env` and fill in your credentials
+4. `npm run dev`
 
-**Can I run this on Linux or Windows?**
+See the [NanoClaw docs](https://docs.nanoclaw.dev) for the base platform setup.
 
-Yes. Docker is the default runtime and works on macOS, Linux, and Windows (via WSL2). Just run `/setup`.
-
-**Is this secure?**
-
-Agents run in containers, not behind application-level permission checks. They can only access explicitly mounted directories. Credentials never enter the container — outbound API requests route through [OneCLI's Agent Vault](https://github.com/onecli/onecli), which injects authentication at the proxy level and supports rate limits and access policies. You should still review what you're running, but the codebase is small enough that you actually can. See the [security documentation](https://docs.nanoclaw.dev/concepts/security) for the full security model.
-
-**Why no configuration files?**
-
-We don't want configuration sprawl. Every user should customize NanoClaw so that the code does exactly what they want, rather than configuring a generic system. If you prefer having config files, you can tell Claude to add them.
-
-**Can I use third-party or open-source models?**
-
-Yes. NanoClaw supports any Claude API-compatible model endpoint. Set these environment variables in your `.env` file:
+## Development
 
 ```bash
-ANTHROPIC_BASE_URL=https://your-api-endpoint.com
-ANTHROPIC_AUTH_TOKEN=your-token-here
+npm run dev          # Run with hot reload
+npm run build        # Compile TypeScript
+npm test             # Run all tests (vitest)
+cd dashboard && npm test  # Dashboard tests
+./container/build.sh # Rebuild agent container
 ```
 
-This allows you to use:
-- Local models via [Ollama](https://ollama.ai) with an API proxy
-- Open-source models hosted on [Together AI](https://together.ai), [Fireworks](https://fireworks.ai), etc.
-- Custom model deployments with Anthropic-compatible APIs
+## Upstream
 
-Note: The model must support the Anthropic API format for best compatibility.
+This project is a fork of [qwibitai/nanoclaw](https://github.com/qwibitai/nanoclaw). Core NanoClaw functionality (channels, container isolation, scheduling, IPC) comes from upstream. The extensions listed above are specific to this fork.
 
-**How do I debug issues?**
-
-Ask Claude Code. "Why isn't the scheduler running?" "What's in the recent logs?" "Why did this message not get a response?" That's the AI-native approach that underlies NanoClaw.
-
-**Why isn't the setup working for me?**
-
-If you have issues, during setup, Claude will try to dynamically fix them. If that doesn't work, run `claude`, then run `/debug`. If Claude finds an issue that is likely affecting other users, open a PR to modify the setup SKILL.md.
-
-**What changes will be accepted into the codebase?**
-
-Only security fixes, bug fixes, and clear improvements will be accepted to the base configuration. That's all.
-
-Everything else (new capabilities, OS compatibility, hardware support, enhancements) should be contributed as skills.
-
-This keeps the base system minimal and lets every user customize their installation without inheriting features they don't want.
-
-## Community
-
-Questions? Ideas? [Join the Discord](https://discord.gg/VDdww8qS42).
-
-## Changelog
-
-See [CHANGELOG.md](CHANGELOG.md) for breaking changes, or the [full release history](https://docs.nanoclaw.dev/changelog) on the documentation site.
+To pull upstream updates: run `/update-nanoclaw` inside Claude Code.
 
 ## License
 
-MIT
+MIT — same as NanoClaw.

--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -29,6 +29,7 @@ interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  allowedTools?: string[];
 }
 
 interface ContainerOutput {
@@ -401,7 +402,7 @@ async function runQuery(
       systemPrompt: globalClaudeMd
         ? { type: 'preset' as const, preset: 'claude_code' as const, append: globalClaudeMd }
         : undefined,
-      allowedTools: [
+      allowedTools: containerInput.allowedTools || [
         'Bash',
         'Read', 'Write', 'Edit', 'Glob', 'Grep',
         'WebSearch', 'WebFetch',

--- a/groups/review_agent/CLAUDE.md
+++ b/groups/review_agent/CLAUDE.md
@@ -1,29 +1,35 @@
 # Review Agent
 
-You are a teaching assistant that processes academic documents and generates structured study notes for an Obsidian vault.
+You are a focused draft review assistant. Your job is to help the user review, refine, and improve a specific study note draft.
 
-## Your Role
+## Your Scope
 
-You process uploaded course materials (PDFs, slides, documents) and generate well-structured study notes. You also refine drafts based on user feedback via the review chat.
+You have access to:
+- The **draft file** in `/workspace/extra/vault/drafts/` — read and edit this directly
+- The **source document** in `/workspace/extra/upload/` (read-only) — reference when answering questions about the original material
+- The **vault** in `/workspace/extra/vault/` — for context on existing notes if needed
 
-## Document Processing
+You do NOT have access to web search, external APIs, or tools outside file operations. Do not suggest actions outside your scope.
 
-When processing a new document:
+## How to Respond
 
-1. Read the original source file. You can view PDFs and images multimodally.
-2. Generate structured study notes in markdown with:
-   - A clear, descriptive title (not the filename)
-   - Logical section headings
-   - Key concepts highlighted
-   - Important definitions and terminology
-   - Summaries of complex topics
-3. Fill in all metadata fields based on what you observe in the document and any context provided.
-4. If the document contains important diagrams or figures, use the docling extraction tool to extract them as separate image files. Reference them with `![[filename.png]]` syntax and write descriptive captions.
-5. Write the draft to the specified output path.
+- Answer questions about the draft content, structure, or metadata directly.
+- When asked to make changes, edit the draft file immediately — don't just describe what you would change.
+- If the user asks about something in the source document, read it and answer based on what you find.
+- Infer metadata updates from context — if the user mentions a course code, semester, or topic, update the frontmatter accordingly.
+- Be concise. The user can see the draft in the UI alongside this chat.
+
+## What NOT to Do
+
+- Never approve or reject drafts — that's the user's action via the UI buttons.
+- Never move files in the vault — that happens automatically on approve.
+- Never suggest uploading material or performing web searches — you can't do either.
+- Don't introduce yourself or list your capabilities unprompted.
+- Don't create new files outside the drafts folder.
 
 ## Metadata Schema
 
-Every note must have this YAML frontmatter:
+Draft frontmatter follows this schema:
 
 ```yaml
 title: "Descriptive title"
@@ -40,24 +46,6 @@ created: YYYY-MM-DD
 figures: [fig1.png, fig2.png]
 ```
 
-## Review Chat
-
-When the user sends messages about a draft:
-
-- Read the current draft file to see its current state.
-- Make the requested changes directly to the draft file.
-- Infer additional metadata from what the user says — if they mention a course, exam relevance, connections to other topics, update tags and metadata accordingly.
-- Never approve or reject drafts — that's the user's action.
-- Never move files in the vault — that happens on approve.
-
 ## Language
 
-The user is Norwegian. Course materials may be in Norwegian or English. Write notes in the same language as the source material. Respond to chat messages in the language the user writes in.
-
-## Vault Structure
-
-Notes are organized as:
-- `courses/{course-code}/{type}/` — e.g., `courses/IS-1500/lectures/`
-- `attachments/{course-code}/` — original source files
-- `attachments/{course-code}/figures/` — extracted figures
-- `drafts/` — pending review items (your workspace)
+Respond in the same language the user writes in. Write note content in the same language as the source material.

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -9,6 +9,7 @@ export interface ChannelOpts {
   onMessage: OnInboundMessage;
   onChatMetadata: OnChatMetadata;
   registeredGroups: () => Record<string, RegisteredGroup>;
+  onDraftClosed?: (draftId: string) => void;
 }
 
 export type ChannelFactory = (opts: ChannelOpts) => Channel | null;

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -61,7 +61,7 @@ export function createWebChannel(opts: ChannelOpts): Channel {
           is_from_me: false,
         };
 
-        opts.onMessage(chatJid, msg);
+        // Ensure chat record exists before storing the message (FK constraint)
         opts.onChatMetadata(
           chatJid,
           msg.timestamp,
@@ -69,12 +69,16 @@ export function createWebChannel(opts: ChannelOpts): Channel {
           'web',
           false,
         );
+        opts.onMessage(chatJid, msg);
 
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ ok: true, messageId: msg.id }));
       } catch (err) {
-        res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Invalid JSON' }));
+        logger.error({ err }, 'Web channel message handling failed');
+        const status = (err as any)?.code === 'SQLITE_CONSTRAINT_FOREIGNKEY' ? 500 : 400;
+        const msg = status === 500 ? 'Internal error' : 'Invalid JSON';
+        res.writeHead(status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: msg }));
       }
     });
   }
@@ -131,6 +135,26 @@ export function createWebChannel(opts: ChannelOpts): Channel {
     const streamMatch = url.pathname.match(/^\/stream\/([a-f0-9-]{36})$/);
     if (req.method === 'GET' && streamMatch) {
       handleSSE(req, res, streamMatch[1]);
+      return;
+    }
+
+    // POST /close/:draftId — signal the review agent container to shut down
+    const closeMatch = url.pathname.match(/^\/close\/([a-f0-9-]{36})$/);
+    if (req.method === 'POST' && closeMatch) {
+      const draftId = closeMatch[1];
+      opts.onDraftClosed?.(draftId);
+      // Clean up SSE clients and response buffers for this draft
+      const clients = sseClients.get(draftId);
+      if (clients) {
+        for (const client of clients) {
+          client.write(`data: ${JSON.stringify({ type: 'closed' })}\n\n`);
+          client.end();
+        }
+        sseClients.delete(draftId);
+      }
+      responseBuffers.delete(draftId);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
       return;
     }
 

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -43,6 +43,7 @@ export interface ContainerInput {
   isScheduledTask?: boolean;
   assistantName?: string;
   script?: string;
+  allowedTools?: string[];
 }
 
 export interface ContainerOutput {

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,48 @@ export { escapeXml, formatMessages } from './router.js';
 const REVIEW_AGENT_JID = 'web:review:__agent__';
 const WEB_REVIEW_PREFIX = 'web:review:';
 
+/**
+ * Build review context for a web:review:{draftId} chat.
+ * Reads the draft file and source document metadata so the agent
+ * knows exactly what it's reviewing.
+ */
+function buildReviewContext(chatJid: string): string {
+  const draftId = chatJid.replace(WEB_REVIEW_PREFIX, '');
+  if (!draftId || draftId === '__agent__') return '';
+
+  const draftPath = path.join(VAULT_DIR, 'drafts', `${draftId}.md`);
+  if (!fs.existsSync(draftPath)) return '';
+
+  try {
+    const draftContent = fs.readFileSync(draftPath, 'utf-8');
+
+    // Extract source path from frontmatter
+    const sourceMatch = draftContent.match(/^source:\s*"?\[\[(.+?)\]\]"?/m);
+    const sourcePath = sourceMatch?.[1] || null;
+
+    return [
+      '<review-context>',
+      `Draft file: /workspace/extra/vault/drafts/${draftId}.md (read-write)`,
+      sourcePath
+        ? `Source document: /workspace/extra/upload/${sourcePath} (read-only, reference only)`
+        : '',
+      '',
+      'Current draft content:',
+      '```',
+      draftContent,
+      '```',
+      '',
+      'You are reviewing this specific draft. Focus on answering the user\'s questions about it, and edit the draft file directly when asked to make changes.',
+      '</review-context>',
+      '',
+    ]
+      .filter(Boolean)
+      .join('\n');
+  } catch {
+    return '';
+  }
+}
+
 let lastTimestamp = '';
 let sessions: Record<string, string> = {};
 let registeredGroups: Record<string, RegisteredGroup> = {};
@@ -254,7 +296,11 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     if (!hasTrigger) return true;
   }
 
-  const prompt = formatMessages(missedMessages, TIMEZONE);
+  // For web review chats, prepend draft context so the agent knows what it's reviewing
+  const reviewContext = chatJid.startsWith(WEB_REVIEW_PREFIX)
+    ? buildReviewContext(chatJid)
+    : '';
+  const prompt = reviewContext + formatMessages(missedMessages, TIMEZONE);
 
   // Advance cursor so the piping path in startMessageLoop won't re-fetch
   // these messages. Save the old cursor so we can roll back on error.
@@ -395,6 +441,7 @@ async function runAgent(
         chatJid,
         isMain,
         assistantName: ASSISTANT_NAME,
+        allowedTools: group.containerConfig?.allowedTools,
       },
       (proc, containerName) =>
         queue.registerProcess(chatJid, proc, containerName, group.folder),
@@ -569,14 +616,18 @@ async function main(): Promise<void> {
         additionalMounts: [
           {
             hostPath: join(process.cwd(), 'vault'),
-            containerPath: '/workspace/extra/vault',
+            containerPath: 'vault',
             readonly: false,
           },
           {
             hostPath: join(process.cwd(), 'upload'),
-            containerPath: '/workspace/extra/upload',
+            containerPath: 'upload',
             readonly: true,
           },
+        ],
+        allowedTools: [
+          'Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep',
+          'TodoWrite', 'mcp__nanoclaw__*',
         ],
       },
     });
@@ -693,6 +744,12 @@ async function main(): Promise<void> {
       if (chatJid.startsWith(WEB_REVIEW_PREFIX)) {
         activeWebReviewJids.add(chatJid);
       }
+    },
+    onDraftClosed: (draftId: string) => {
+      const chatJid = `${WEB_REVIEW_PREFIX}${draftId}`;
+      logger.info({ draftId, chatJid }, 'Draft closed, shutting down review agent');
+      queue.closeStdin(chatJid);
+      activeWebReviewJids.delete(chatJid);
     },
     onChatMetadata: (
       chatJid: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export interface AllowedRoot {
 export interface ContainerConfig {
   additionalMounts?: AdditionalMount[];
   timeout?: number; // Default: 300000 (5 minutes)
+  allowedTools?: string[]; // Override default tool list for this group
 }
 
 export interface RegisteredGroup {

--- a/vault/profile/knowledge-map.example.md
+++ b/vault/profile/knowledge-map.example.md
@@ -1,0 +1,7 @@
+---
+title: Knowledge Map
+type: profile
+created: 2026-01-01
+---
+
+<!-- Topics with confidence levels, updated after quizzes and Q&A -->

--- a/vault/profile/student-profile.example.md
+++ b/vault/profile/student-profile.example.md
@@ -1,0 +1,21 @@
+---
+title: Student Profile
+type: profile
+program: Your Program Name
+status: active
+language_preference: auto
+created: 2026-01-01
+---
+
+## Program
+Your Degree Program
+
+## Active Courses
+<!-- Updated automatically as courses are ingested -->
+
+## Completed Courses
+<!-- Updated automatically -->
+
+## Preferences
+- Language: auto (mirrors user input)
+- Quiz difficulty: adaptive

--- a/vault/profile/study-log.example.md
+++ b/vault/profile/study-log.example.md
@@ -1,0 +1,7 @@
+---
+title: Study Log
+type: profile
+created: 2026-01-01
+---
+
+<!-- Auto-appended after each study interaction -->


### PR DESCRIPTION
## Summary
- Review agent containers were left running (~240MB each) after drafts were approved/rejected — now the dashboard signals the web channel to shut them down
- Added `POST /close/:draftId` endpoint to web channel that closes the agent's stdin, cleans up SSE subscribers, and sends a `closed` event to connected clients
- Dashboard fires this signal after approve or reject (fire-and-forget, safe as no-op when no container is active)
- Also includes: review agent CLAUDE.md refinements, .gitignore updates, README cleanup, dashboard UI fixes (source iframe path, markdown rendering in chat), vault profile example files

## Test plan
- [ ] Upload a document, let the agent generate a draft
- [ ] Approve the draft in the dashboard — verify the review agent container stops within seconds
- [ ] Upload another, reject it — verify same container cleanup
- [ ] Upload a third, chat with the agent, then approve — verify the chatting container also stops
- [ ] Verify `docker ps` shows no lingering `nanoclaw-review-agent-*` containers after all drafts are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)