### PR TITLE
feat: redesign upload page with multi-file, status tracking, and retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+.worktrees/

--- a/docs/superpowers/plans/2026-04-01-upload-page-redesign.md
+++ b/docs/superpowers/plans/2026-04-01-upload-page-redesign.md
@@ -1,0 +1,2028 @@
+# Upload Page Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the dashboard upload page into a full ingestion management interface with multi-file upload, real-time status polling, rate-limit recovery, retry controls, and vault output preview.
+
+**Architecture:** Shared SQLite DB reader for dashboard API routes, two React hooks (`useFileUpload`, `useIngestionJobs`) composing a thin page component, pipeline changes for `rate_limited` status and dynamic concurrency. All progress tracking via HTTP polling at 3-second intervals.
+
+**Tech Stack:** Next.js 16, React 19, better-sqlite3, Tailwind CSS 4, Vitest
+
+**Spec:** `docs/superpowers/specs/2026-04-01-upload-page-redesign.md`
+
+**Important:** This Next.js version returns `params` as a **Promise** — always `await params` in route handlers. Check `dashboard/node_modules/next/dist/docs/` for API reference if unsure about any Next.js API.
+
+---
+
+## File Structure
+
+### New files
+| File | Responsibility |
+|------|---------------|
+| `src/shared/db-reader.ts` | Read-only + limited-write SQLite access for dashboard; opens `store/messages.db` with `readonly` for queries, separate writer for mutations |
+| `dashboard/src/app/api/ingestion/jobs/route.ts` | `GET` — list last 20 jobs with optional `?status=` filter |
+| `dashboard/src/app/api/ingestion/jobs/[id]/route.ts` | `GET` — single job detail with promoted vault paths |
+| `dashboard/src/app/api/ingestion/retry/[id]/route.ts` | `POST` — stage-aware retry for failed jobs |
+| `dashboard/src/app/api/ingestion/settings/route.ts` | `GET` + `PATCH` — pipeline concurrency setting |
+| `dashboard/src/hooks/useFileUpload.ts` | Multi-file staging, validation, batch upload, duplicate detection |
+| `dashboard/src/hooks/useIngestionJobs.ts` | Job status polling with tab-visibility pause, retry action |
+| `dashboard/src/app/upload/components/DropZone.tsx` | Drop zone with staging list UI |
+| `dashboard/src/app/upload/components/JobList.tsx` | Grouped collapsible job list (In Progress / Completed / Failed) |
+| `dashboard/src/app/upload/components/JobRow.tsx` | Single job row with status badge, progress bar, actions |
+
+### Modified files
+| File | Changes |
+|------|---------|
+| `src/db.ts` | Add `retry_after` + `retry_count` column migrations, `settings` table, new query helpers |
+| `src/ingestion/pipeline.ts` | Add `drainRateLimited()`, dynamic concurrency getter, `JobRow` interface update |
+| `src/ingestion/index.ts` | Rate-limit detection in `handleGeneration`, store promoted paths in DB |
+| `src/ingestion/job-recovery.ts` | Also mark `rate_limited` jobs as failed on restart |
+| `dashboard/src/app/api/upload/route.ts` | Multi-file support, filename collision avoidance, 100 MB limit |
+| `dashboard/src/app/upload/page.tsx` | Full rewrite composing hooks + components |
+| `dashboard/package.json` | Add `better-sqlite3` + `@types/better-sqlite3` |
+
+---
+
+## Task 1: DB Schema — Add `retry_after`, `retry_count`, and `settings` table
+
+**Files:**
+- Modify: `src/db.ts:167-174` (after existing ingestion migrations)
+- Test: `src/db.test.ts`
+
+- [ ] **Step 1: Write failing test for new columns and settings table**
+
+```typescript
+// In src/db.test.ts — add at end of file
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  initDb,
+  createIngestionJob,
+  updateIngestionJob,
+  getIngestionJobs,
+  getSetting,
+  setSetting,
+} from './db.js';
+
+describe('ingestion job retry columns', () => {
+  beforeEach(() => {
+    initDb(':memory:');
+  });
+
+  it('stores and retrieves retry_after and retry_count', () => {
+    createIngestionJob('job-1', '/tmp/test.pdf', 'test.pdf');
+    updateIngestionJob('job-1', {
+      status: 'rate_limited',
+      error: 'rate limit exceeded',
+      retry_after: '2026-04-01T12:00:00Z',
+      retry_count: 1,
+    });
+    const jobs = getIngestionJobs('rate_limited') as Array<{
+      id: string;
+      retry_after: string;
+      retry_count: number;
+    }>;
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].retry_after).toBe('2026-04-01T12:00:00Z');
+    expect(jobs[0].retry_count).toBe(1);
+  });
+});
+
+describe('settings table', () => {
+  beforeEach(() => {
+    initDb(':memory:');
+  });
+
+  it('returns default when setting does not exist', () => {
+    expect(getSetting('maxGenerationConcurrent', '1')).toBe('1');
+  });
+
+  it('stores and retrieves a setting', () => {
+    setSetting('maxGenerationConcurrent', '3');
+    expect(getSetting('maxGenerationConcurrent', '1')).toBe('3');
+  });
+
+  it('overwrites existing setting', () => {
+    setSetting('maxGenerationConcurrent', '3');
+    setSetting('maxGenerationConcurrent', '5');
+    expect(getSetting('maxGenerationConcurrent', '1')).toBe('5');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/db.test.ts --reporter=verbose`
+Expected: FAIL — `getSetting` and `setSetting` are not exported, `retry_after`/`retry_count` not recognized.
+
+- [ ] **Step 3: Add migrations and new functions to db.ts**
+
+In `src/db.ts`, after the `content_hash` migration block (line ~174), add:
+
+```typescript
+  // Add retry_after and retry_count columns for rate-limit recovery
+  try {
+    database.exec(`ALTER TABLE ingestion_jobs ADD COLUMN retry_after TEXT`);
+  } catch {
+    /* column already exists */
+  }
+  try {
+    database.exec(
+      `ALTER TABLE ingestion_jobs ADD COLUMN retry_count INTEGER DEFAULT 0`,
+    );
+  } catch {
+    /* column already exists */
+  }
+
+  // Add promoted_paths column to store vault paths after promotion
+  try {
+    database.exec(
+      `ALTER TABLE ingestion_jobs ADD COLUMN promoted_paths TEXT`,
+    );
+  } catch {
+    /* column already exists */
+  }
+
+  // Settings table (key-value)
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      updated_at TEXT DEFAULT (datetime('now'))
+    );
+  `);
+```
+
+Update `updateIngestionJob` to accept the new fields. In `src/db.ts`, change the `updates` parameter type (line ~776):
+
+```typescript
+export function updateIngestionJob(
+  id: string,
+  updates: {
+    status?: string;
+    extraction_path?: string | null;
+    error?: string | null;
+    content_hash?: string;
+    retry_after?: string | null;
+    retry_count?: number;
+    promoted_paths?: string | null;
+  },
+): void {
+  const setClauses: string[] = ["updated_at = datetime('now')"];
+  const values: unknown[] = [];
+
+  if (updates.status !== undefined) {
+    setClauses.push('status = ?');
+    values.push(updates.status);
+    if (updates.status === 'completed') {
+      setClauses.push("completed_at = datetime('now')");
+    }
+  }
+  if (updates.extraction_path !== undefined) {
+    setClauses.push('extraction_path = ?');
+    values.push(updates.extraction_path);
+  }
+  if (updates.error !== undefined) {
+    setClauses.push('error = ?');
+    values.push(updates.error);
+  }
+  if (updates.content_hash !== undefined) {
+    setClauses.push('content_hash = ?');
+    values.push(updates.content_hash);
+  }
+  if (updates.retry_after !== undefined) {
+    setClauses.push('retry_after = ?');
+    values.push(updates.retry_after);
+  }
+  if (updates.retry_count !== undefined) {
+    setClauses.push('retry_count = ?');
+    values.push(updates.retry_count);
+  }
+  if (updates.promoted_paths !== undefined) {
+    setClauses.push('promoted_paths = ?');
+    values.push(updates.promoted_paths);
+  }
+
+  values.push(id);
+  getDb()
+    .prepare(`UPDATE ingestion_jobs SET ${setClauses.join(', ')} WHERE id = ?`)
+    .run(...values);
+}
+```
+
+Add settings functions after the ingestion job section:
+
+```typescript
+// --- Settings ---
+
+export function getSetting(key: string, defaultValue: string): string {
+  const row = getDb()
+    .prepare('SELECT value FROM settings WHERE key = ?')
+    .get(key) as { value: string } | undefined;
+  return row?.value ?? defaultValue;
+}
+
+export function setSetting(key: string, value: string): void {
+  getDb()
+    .prepare(
+      `INSERT INTO settings (key, value, updated_at) VALUES (?, ?, datetime('now'))
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+    )
+    .run(key, value);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/db.test.ts --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/db.ts src/db.test.ts
+git commit -m "feat(db): add retry_after, retry_count, promoted_paths columns and settings table"
+```
+
+---
+
+## Task 2: Pipeline — Rate-limit detection and `drainRateLimited`
+
+**Files:**
+- Modify: `src/ingestion/pipeline.ts`
+- Modify: `src/ingestion/index.ts:186-341`
+- Modify: `src/ingestion/job-recovery.ts`
+- Test: `src/ingestion/pipeline.test.ts`
+
+- [ ] **Step 1: Write failing test for rate-limit auto-retry in PipelineDrainer**
+
+```typescript
+// Add to src/ingestion/pipeline.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock db module before importing pipeline
+vi.mock('../db.js', () => ({
+  getJobsByStatus: vi.fn().mockReturnValue([]),
+  updateIngestionJob: vi.fn(),
+  getSetting: vi.fn().mockReturnValue('1'),
+}));
+
+import { PipelineDrainer } from './pipeline.js';
+import { getJobsByStatus, updateIngestionJob } from '../db.js';
+
+describe('drainRateLimited', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resets rate_limited jobs past retry_after to their pre-failure status', async () => {
+    const pastDate = new Date(Date.now() - 60_000).toISOString();
+    vi.mocked(getJobsByStatus).mockImplementation((status: string) => {
+      if (status === 'rate_limited') {
+        return [
+          {
+            id: 'job-1',
+            source_path: '/tmp/a.pdf',
+            source_filename: 'a.pdf',
+            status: 'rate_limited',
+            extraction_path: '/data/extractions/job-1',
+            retry_after: pastDate,
+            retry_count: 0,
+            error: 'generating:rate limit exceeded',
+            created_at: '2026-01-01',
+            updated_at: '2026-01-01',
+          },
+        ];
+      }
+      return [];
+    });
+
+    const drainer = new PipelineDrainer({
+      onExtract: vi.fn(),
+      onGenerate: vi.fn(),
+      onPromote: vi.fn(),
+      maxExtractionConcurrent: 1,
+      maxGenerationConcurrent: () => 1,
+      pollIntervalMs: 5000,
+    });
+
+    await drainer.tick();
+
+    expect(updateIngestionJob).toHaveBeenCalledWith('job-1', {
+      status: 'extracted',
+      error: null,
+      retry_after: null,
+      retry_count: 1,
+    });
+  });
+
+  it('skips rate_limited jobs whose retry_after is in the future', async () => {
+    const futureDate = new Date(Date.now() + 300_000).toISOString();
+    vi.mocked(getJobsByStatus).mockImplementation((status: string) => {
+      if (status === 'rate_limited') {
+        return [
+          {
+            id: 'job-2',
+            status: 'rate_limited',
+            retry_after: futureDate,
+            retry_count: 0,
+            error: 'generating:rate limit exceeded',
+          },
+        ];
+      }
+      return [];
+    });
+
+    const drainer = new PipelineDrainer({
+      onExtract: vi.fn(),
+      onGenerate: vi.fn(),
+      onPromote: vi.fn(),
+      maxExtractionConcurrent: 1,
+      maxGenerationConcurrent: () => 1,
+      pollIntervalMs: 5000,
+    });
+
+    await drainer.tick();
+
+    expect(updateIngestionJob).not.toHaveBeenCalledWith(
+      'job-2',
+      expect.objectContaining({ status: 'extracted' }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/ingestion/pipeline.test.ts --reporter=verbose`
+Expected: FAIL — `maxGenerationConcurrent` is not a function, `drainRateLimited` doesn't exist.
+
+- [ ] **Step 3: Update PipelineDrainer to support dynamic concurrency and rate-limit recovery**
+
+Replace `src/ingestion/pipeline.ts` entirely:
+
+```typescript
+import { getJobsByStatus, updateIngestionJob, getSetting } from '../db.js';
+
+export interface JobRow {
+  id: string;
+  source_path: string;
+  source_filename: string;
+  status: string;
+  extraction_path: string | null;
+  created_at: string;
+  updated_at: string;
+  retry_after?: string | null;
+  retry_count?: number;
+  error?: string | null;
+}
+
+export interface PipelineDrainerOpts {
+  onExtract: (job: JobRow) => Promise<void>;
+  onGenerate: (job: JobRow) => Promise<void>;
+  onPromote: (job: JobRow) => Promise<void>;
+  onComplete?: (job: JobRow) => Promise<void>;
+  maxExtractionConcurrent: number;
+  maxGenerationConcurrent: number | (() => number);
+  pollIntervalMs: number;
+}
+
+/** Map from the "error: stage:message" prefix to the status to reset to on retry. */
+const STAGE_RETRY_MAP: Record<string, string> = {
+  extracting: 'pending',
+  generating: 'extracted',
+  promoting: 'generated',
+};
+
+export class PipelineDrainer {
+  private opts: PipelineDrainerOpts;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private activeExtractions = 0;
+  private activeGenerations = 0;
+  private inFlight: Set<Promise<void>> = new Set();
+
+  constructor(opts: PipelineDrainerOpts) {
+    this.opts = opts;
+  }
+
+  private getMaxGenerationConcurrent(): number {
+    const val = this.opts.maxGenerationConcurrent;
+    return typeof val === 'function' ? val() : val;
+  }
+
+  drain(): void {
+    if (this.timer !== null) return;
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, this.opts.pollIntervalMs);
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    if (this.inFlight.size > 0) {
+      await Promise.allSettled([...this.inFlight]);
+    }
+  }
+
+  async tick(): Promise<void> {
+    this.drainRateLimited();
+    await this.drainExtractions();
+    await this.drainGenerations();
+    await this.drainPromotions();
+  }
+
+  drainRateLimited(): void {
+    const jobs = getJobsByStatus('rate_limited') as JobRow[];
+    const now = Date.now();
+
+    for (const job of jobs) {
+      if (!job.retry_after) continue;
+      if (new Date(job.retry_after).getTime() > now) continue;
+
+      // Determine which stage to reset to from the error prefix
+      const errorPrefix = job.error?.split(':')[0] ?? '';
+      const resetStatus = STAGE_RETRY_MAP[errorPrefix] ?? 'pending';
+
+      updateIngestionJob(job.id, {
+        status: resetStatus,
+        error: null,
+        retry_after: null,
+        retry_count: (job.retry_count ?? 0) + 1,
+      });
+    }
+  }
+
+  async drainExtractions(): Promise<void> {
+    const slots = this.opts.maxExtractionConcurrent - this.activeExtractions;
+    if (slots <= 0) return;
+
+    const pending = getJobsByStatus('pending') as JobRow[];
+    const batch = pending.slice(0, slots);
+
+    for (const job of batch) {
+      updateIngestionJob(job.id, { status: 'extracting' });
+      this.activeExtractions++;
+      const p = this.opts
+        .onExtract(job)
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          updateIngestionJob(job.id, { status: 'failed', error: `extracting:${msg}` });
+        })
+        .finally(() => {
+          this.activeExtractions--;
+          this.inFlight.delete(p);
+        });
+      this.inFlight.add(p);
+    }
+  }
+
+  async drainGenerations(): Promise<void> {
+    const maxConcurrent = this.getMaxGenerationConcurrent();
+    const slots = maxConcurrent - this.activeGenerations;
+    if (slots <= 0) return;
+
+    const extracted = getJobsByStatus('extracted') as JobRow[];
+
+    for (const job of extracted) {
+      if (this.activeGenerations >= maxConcurrent) break;
+
+      updateIngestionJob(job.id, { status: 'generating' });
+      this.activeGenerations++;
+      const p = this.opts
+        .onGenerate(job)
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          updateIngestionJob(job.id, { status: 'failed', error: `generating:${msg}` });
+        })
+        .finally(() => {
+          this.activeGenerations--;
+          this.inFlight.delete(p);
+        });
+      this.inFlight.add(p);
+    }
+  }
+
+  async drainPromotions(): Promise<void> {
+    const generated = getJobsByStatus('generated') as JobRow[];
+    for (const job of generated) {
+      updateIngestionJob(job.id, { status: 'promoting' });
+      try {
+        await this.opts.onPromote(job);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        updateIngestionJob(job.id, { status: 'failed', error: `promoting:${msg}` });
+      }
+    }
+  }
+}
+```
+
+Key changes:
+- `maxGenerationConcurrent` accepts `number | (() => number)`
+- Error messages are now prefixed with the stage name (`extracting:`, `generating:`, `promoting:`) for stage-aware retry
+- `drainRateLimited()` runs at start of each tick, resets eligible jobs
+- `JobRow` includes `retry_after`, `retry_count`, `error`
+
+- [ ] **Step 4: Update IngestionPipeline constructor to use dynamic concurrency getter**
+
+In `src/ingestion/index.ts`, change line 68 in the constructor:
+
+```typescript
+// Before:
+maxGenerationConcurrent: opts.maxGenerationConcurrent ?? 1,
+
+// After:
+maxGenerationConcurrent: () => {
+  const val = getSetting('maxGenerationConcurrent', '1');
+  return Math.max(1, Math.min(5, parseInt(val, 10) || 1));
+},
+```
+
+Add the import at the top of `src/ingestion/index.ts`:
+
+```typescript
+import { getSetting } from '../db.js';
+```
+
+- [ ] **Step 5: Add rate-limit detection to handleGeneration**
+
+In `src/ingestion/index.ts`, in `handleGeneration` (around line 320-333), the error is currently thrown up to the drainer's catch handler. We need to intercept rate-limit errors before they throw. Wrap the error-throwing section:
+
+After the `Promise.allSettled` block (around line 315-333), replace with:
+
+```typescript
+    const [containerSettled, validationSettled] = await Promise.allSettled([
+      containerPromise,
+      validationPromise,
+    ]);
+
+    // Check for rate-limit errors before re-throwing
+    const errorToCheck =
+      containerSettled.status === 'rejected'
+        ? containerSettled.reason
+        : validationSettled.status === 'rejected'
+          ? validationSettled.reason
+          : containerSettled.status === 'fulfilled' &&
+              containerSettled.value.status === 'error'
+            ? new Error(containerSettled.value.error || 'Agent processing failed')
+            : null;
+
+    if (errorToCheck) {
+      const msg =
+        errorToCheck instanceof Error ? errorToCheck.message : String(errorToCheck);
+      if (isRateLimitError(msg)) {
+        const retryCount = (
+          getIngestionJobs() as Array<{ id: string; retry_count: number }>
+        ).find((j) => j.id === job.id)?.retry_count ?? 0;
+        const delayMs =
+          retryCount === 0 ? 5 * 60_000 : retryCount === 1 ? 15 * 60_000 : 60 * 60_000;
+        const retryAfter = new Date(Date.now() + delayMs).toISOString();
+        updateIngestionJob(job.id, {
+          status: 'rate_limited',
+          error: `generating:${msg}`,
+          retry_after: retryAfter,
+        });
+        logger.warn(
+          { jobId: job.id, retryAfter, retryCount },
+          `ingestion: Rate limited — will retry after ${retryAfter}`,
+        );
+        // Do NOT re-throw — the drainer catch would override to 'failed'
+        return;
+      }
+      throw errorToCheck;
+    }
+
+    updateIngestionJob(job.id, { status: 'generated' });
+
+    logger.info(
+      { jobId: job.id, relativePath },
+      `ingestion: Generated: ${relativePath}`,
+    );
+```
+
+Add the helper function above the class:
+
+```typescript
+const RATE_LIMIT_PATTERNS = [
+  /rate.?limit/i,
+  /session.?limit/i,
+  /overloaded/i,
+  /429/,
+  /529/,
+  /too many requests/i,
+  /capacity/i,
+];
+
+function isRateLimitError(msg: string): boolean {
+  return RATE_LIMIT_PATTERNS.some((re) => re.test(msg));
+}
+```
+
+- [ ] **Step 6: Store promoted paths in handlePromotion**
+
+In `src/ingestion/index.ts`, in `handlePromotion` (around line 405), change the final status update:
+
+```typescript
+// Before:
+updateIngestionJob(job.id, { status: 'completed' });
+
+// After:
+updateIngestionJob(job.id, {
+  status: 'completed',
+  promoted_paths: JSON.stringify(promotedPaths),
+});
+```
+
+- [ ] **Step 7: Update job-recovery.ts to include rate_limited**
+
+In `src/ingestion/job-recovery.ts`, change line 9:
+
+```typescript
+// Before:
+const inProgressStatuses = ['extracting', 'generating', 'promoting'];
+
+// After:
+const inProgressStatuses = ['extracting', 'generating', 'promoting', 'rate_limited'];
+```
+
+- [ ] **Step 8: Run all ingestion tests**
+
+Run: `npx vitest run src/ingestion/ --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/ingestion/pipeline.ts src/ingestion/index.ts src/ingestion/job-recovery.ts src/ingestion/pipeline.test.ts
+git commit -m "feat(ingestion): add rate_limited status, stage-aware retry, dynamic concurrency"
+```
+
+---
+
+## Task 3: Shared DB Reader for Dashboard
+
+**Files:**
+- Create: `src/shared/db-reader.ts`
+- Test: `src/shared/db-reader.test.ts`
+
+- [ ] **Step 1: Write failing test for the shared DB reader**
+
+```typescript
+// src/shared/db-reader.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { initDb, createIngestionJob, updateIngestionJob, setSetting } from '../db.js';
+import { getRecentJobs, getJobDetail, getSettings, retryJob, updateSettings } from './db-reader.js';
+
+describe('db-reader', () => {
+  beforeEach(() => {
+    initDb(':memory:');
+  });
+
+  describe('getRecentJobs', () => {
+    it('returns jobs ordered by created_at desc', () => {
+      createIngestionJob('a', '/tmp/a.pdf', 'a.pdf');
+      createIngestionJob('b', '/tmp/b.pdf', 'b.pdf');
+      const jobs = getRecentJobs();
+      expect(jobs).toHaveLength(2);
+      expect(jobs[0].id).toBe('b');
+    });
+
+    it('filters by status', () => {
+      createIngestionJob('a', '/tmp/a.pdf', 'a.pdf');
+      createIngestionJob('b', '/tmp/b.pdf', 'b.pdf');
+      updateIngestionJob('a', { status: 'completed' });
+      const jobs = getRecentJobs('completed');
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].id).toBe('a');
+    });
+
+    it('limits to 20 results', () => {
+      for (let i = 0; i < 25; i++) {
+        createIngestionJob(`j${i}`, `/tmp/${i}.pdf`, `${i}.pdf`);
+      }
+      expect(getRecentJobs()).toHaveLength(20);
+    });
+  });
+
+  describe('getJobDetail', () => {
+    it('returns null for non-existent job', () => {
+      expect(getJobDetail('nope')).toBeNull();
+    });
+
+    it('returns promoted paths for completed jobs', () => {
+      createIngestionJob('a', '/tmp/a.pdf', 'a.pdf');
+      updateIngestionJob('a', {
+        status: 'completed',
+        promoted_paths: JSON.stringify(['sources/a.md', 'concepts/b.md']),
+      });
+      const detail = getJobDetail('a');
+      expect(detail).not.toBeNull();
+      expect(detail!.promotedPaths).toEqual(['sources/a.md', 'concepts/b.md']);
+    });
+  });
+
+  describe('retryJob', () => {
+    it('resets a failed extracting job to pending', () => {
+      createIngestionJob('a', '/tmp/a.pdf', 'a.pdf');
+      updateIngestionJob('a', { status: 'failed', error: 'extracting:timeout' });
+      const result = retryJob('a');
+      expect(result.ok).toBe(true);
+      const jobs = getRecentJobs('pending');
+      expect(jobs).toHaveLength(1);
+    });
+
+    it('resets a failed generating job to extracted', () => {
+      createIngestionJob('a', '/tmp/a.pdf', 'a.pdf');
+      updateIngestionJob('a', { status: 'failed', error: 'generating:crash' });
+      const result = retryJob('a');
+      expect(result.ok).toBe(true);
+      const jobs = getRecentJobs('extracted');
+      expect(jobs).toHaveLength(1);
+    });
+
+    it('returns error for non-failed jobs', () => {
+      createIngestionJob('a', '/tmp/a.pdf', 'a.pdf');
+      const result = retryJob('a');
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('settings', () => {
+    it('reads and writes maxGenerationConcurrent', () => {
+      expect(getSettings()).toEqual({ maxGenerationConcurrent: 1 });
+      updateSettings({ maxGenerationConcurrent: 3 });
+      expect(getSettings()).toEqual({ maxGenerationConcurrent: 3 });
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/shared/db-reader.test.ts --reporter=verbose`
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 3: Implement the shared DB reader**
+
+```typescript
+// src/shared/db-reader.ts
+import {
+  getIngestionJobs,
+  updateIngestionJob,
+  getSetting,
+  setSetting,
+} from '../db.js';
+
+export interface JobSummary {
+  id: string;
+  filename: string;
+  status: string;
+  error: string | null;
+  retryAfter: string | null;
+  retryCount: number;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+export interface JobDetail extends JobSummary {
+  promotedPaths: string[] | null;
+}
+
+interface RawJob {
+  id: string;
+  source_filename: string;
+  status: string;
+  error: string | null;
+  retry_after: string | null;
+  retry_count: number;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+  promoted_paths: string | null;
+}
+
+function toJobSummary(row: RawJob): JobSummary {
+  return {
+    id: row.id,
+    filename: row.source_filename,
+    status: row.status,
+    error: row.error,
+    retryAfter: row.retry_after,
+    retryCount: row.retry_count ?? 0,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
+  };
+}
+
+export function getRecentJobs(status?: string): JobSummary[] {
+  const rows = getIngestionJobs(status) as RawJob[];
+  return rows.slice(0, 20).map(toJobSummary);
+}
+
+export function getJobDetail(id: string): JobDetail | null {
+  const rows = getIngestionJobs() as RawJob[];
+  const row = rows.find((r) => r.id === id);
+  if (!row) return null;
+
+  let promotedPaths: string[] | null = null;
+  if (row.promoted_paths) {
+    try {
+      promotedPaths = JSON.parse(row.promoted_paths);
+    } catch {
+      promotedPaths = null;
+    }
+  }
+
+  return { ...toJobSummary(row), promotedPaths };
+}
+
+const STAGE_RETRY_MAP: Record<string, string> = {
+  extracting: 'pending',
+  generating: 'extracted',
+  promoting: 'generated',
+};
+
+export function retryJob(
+  id: string,
+): { ok: true } | { ok: false; error: string } {
+  const rows = getIngestionJobs() as RawJob[];
+  const job = rows.find((r) => r.id === id);
+  if (!job) return { ok: false, error: 'Job not found' };
+  if (job.status !== 'failed') return { ok: false, error: 'Job is not failed' };
+
+  const errorPrefix = job.error?.split(':')[0] ?? '';
+  const resetStatus = STAGE_RETRY_MAP[errorPrefix] ?? 'pending';
+
+  updateIngestionJob(id, {
+    status: resetStatus,
+    error: null,
+    retry_after: null,
+  });
+
+  return { ok: true };
+}
+
+export function getSettings(): { maxGenerationConcurrent: number } {
+  const val = getSetting('maxGenerationConcurrent', '1');
+  return { maxGenerationConcurrent: Math.max(1, Math.min(5, parseInt(val, 10) || 1)) };
+}
+
+export function updateSettings(settings: {
+  maxGenerationConcurrent: number;
+}): void {
+  const clamped = Math.max(1, Math.min(5, settings.maxGenerationConcurrent));
+  setSetting('maxGenerationConcurrent', String(clamped));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/shared/db-reader.test.ts --reporter=verbose`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/db-reader.ts src/shared/db-reader.test.ts
+git commit -m "feat: add shared db-reader module for dashboard API routes"
+```
+
+---
+
+## Task 4: Dashboard API Routes — Jobs, Retry, Settings
+
+**Files:**
+- Create: `dashboard/src/app/api/ingestion/jobs/route.ts`
+- Create: `dashboard/src/app/api/ingestion/jobs/[id]/route.ts`
+- Create: `dashboard/src/app/api/ingestion/retry/[id]/route.ts`
+- Create: `dashboard/src/app/api/ingestion/settings/route.ts`
+- Modify: `dashboard/package.json`
+
+- [ ] **Step 1: Add better-sqlite3 dependency to dashboard**
+
+Run: `cd dashboard && npm install better-sqlite3 @types/better-sqlite3`
+
+`next.config.ts` already has `serverExternalPackages: ['better-sqlite3']` so no change needed there.
+
+- [ ] **Step 2: Ensure the main DB is initialized when dashboard API routes import shared module**
+
+The dashboard's API routes need the DB to be initialized. Since `src/db.ts` uses `initDb()` which is called by the main process on startup, the shared reader needs to handle initialization. Add an auto-init guard to `src/shared/db-reader.ts`:
+
+At the top of `src/shared/db-reader.ts`, add:
+
+```typescript
+import { initDb } from '../db.js';
+
+// Auto-initialize DB if not already done (for dashboard process)
+try {
+  initDb();
+} catch {
+  // Already initialized
+}
+```
+
+- [ ] **Step 3: Create GET /api/ingestion/jobs**
+
+```typescript
+// dashboard/src/app/api/ingestion/jobs/route.ts
+import { getRecentJobs } from '../../../../shared/db-reader.js';
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const status = url.searchParams.get('status') ?? undefined;
+  const jobs = getRecentJobs(status);
+  return Response.json({ jobs });
+}
+```
+
+Note: The import path goes from `dashboard/src/app/api/ingestion/jobs/` up to `src/shared/`. Since the dashboard's `tsconfig.json` has `"@/*": ["./src/*"]`, and `src/shared/` is in the parent project, we use a relative path. This may need adjustment — check at build time. If the relative import fails, add a path alias in `dashboard/tsconfig.json`:
+
+```json
+"paths": {
+  "@/*": ["./src/*"],
+  "@shared/*": ["../src/shared/*"]
+}
+```
+
+- [ ] **Step 4: Create GET /api/ingestion/jobs/[id]**
+
+```typescript
+// dashboard/src/app/api/ingestion/jobs/[id]/route.ts
+import { getJobDetail } from '../../../../../shared/db-reader.js';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const job = getJobDetail(id);
+  if (!job) {
+    return Response.json({ error: 'Job not found' }, { status: 404 });
+  }
+  return Response.json(job);
+}
+```
+
+- [ ] **Step 5: Create POST /api/ingestion/retry/[id]**
+
+```typescript
+// dashboard/src/app/api/ingestion/retry/[id]/route.ts
+import { existsSync } from 'fs';
+import { retryJob, getJobDetail } from '../../../../../shared/db-reader.js';
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  // Check job exists
+  const job = getJobDetail(id);
+  if (!job) {
+    return Response.json({ error: 'Job not found' }, { status: 404 });
+  }
+
+  // For retry, we need the source_path — get from raw DB
+  // The shared module doesn't expose source_path, so read it directly
+  const { getIngestionJobs } = await import('../../../../shared/db-reader.js');
+  // Actually, let's add a source path check. We need to import from db.ts:
+  const { getIngestionJobByPath } = await import('../../../../../db.js');
+
+  // Simplified: retryJob already checks if status is 'failed'
+  const result = retryJob(id);
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: 409 });
+  }
+  return Response.json({ ok: true });
+}
+```
+
+Wait — we need the source file check. Let me revise. Add `getJobSourcePath` to `db-reader.ts`:
+
+Add to `src/shared/db-reader.ts`:
+
+```typescript
+export function getJobSourcePath(id: string): string | null {
+  const rows = getIngestionJobs() as RawJob[];
+  const job = rows.find((r) => r.id === id);
+  return (job as unknown as { source_path: string })?.source_path ?? null;
+}
+```
+
+Update the RawJob type to include `source_path`:
+```typescript
+interface RawJob {
+  id: string;
+  source_path: string;
+  source_filename: string;
+  // ... rest unchanged
+}
+```
+
+Then the retry route:
+
+```typescript
+// dashboard/src/app/api/ingestion/retry/[id]/route.ts
+import { existsSync } from 'fs';
+import { retryJob, getJobSourcePath } from '../../../../../shared/db-reader.js';
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const sourcePath = getJobSourcePath(id);
+  if (!sourcePath) {
+    return Response.json({ error: 'Job not found' }, { status: 404 });
+  }
+
+  // Check source file still exists on disk for extraction retry
+  if (!existsSync(sourcePath)) {
+    return Response.json(
+      { error: 'Source file missing — re-upload required' },
+      { status: 409 },
+    );
+  }
+
+  const result = retryJob(id);
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: 409 });
+  }
+
+  return Response.json({ ok: true });
+}
+```
+
+- [ ] **Step 6: Create GET + PATCH /api/ingestion/settings**
+
+```typescript
+// dashboard/src/app/api/ingestion/settings/route.ts
+import { getSettings, updateSettings } from '../../../../shared/db-reader.js';
+
+export async function GET() {
+  return Response.json(getSettings());
+}
+
+export async function PATCH(request: Request) {
+  const body = await request.json();
+  const maxGenerationConcurrent = Number(body.maxGenerationConcurrent);
+  if (!Number.isFinite(maxGenerationConcurrent) || maxGenerationConcurrent < 1) {
+    return Response.json({ error: 'Invalid value' }, { status: 400 });
+  }
+  updateSettings({ maxGenerationConcurrent });
+  return Response.json(getSettings());
+}
+```
+
+- [ ] **Step 7: Build dashboard to verify routes compile**
+
+Run: `cd dashboard && npm run build`
+Expected: Build succeeds. If import paths fail, adjust the path alias strategy.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add dashboard/package.json dashboard/package-lock.json dashboard/src/app/api/ingestion/ src/shared/db-reader.ts
+git commit -m "feat(dashboard): add ingestion API routes for jobs, retry, settings"
+```
+
+---
+
+## Task 5: Update Upload API — Multi-file, Collision Avoidance, Size Limit
+
+**Files:**
+- Modify: `dashboard/src/app/api/upload/route.ts`
+
+- [ ] **Step 1: Rewrite the upload route**
+
+```typescript
+// dashboard/src/app/api/upload/route.ts
+import { join } from 'path';
+import { writeFile, mkdir } from 'fs/promises';
+import { randomBytes } from 'crypto';
+
+const UPLOAD_DIR = process.env.UPLOAD_DIR || join(process.cwd(), '..', 'upload');
+const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100 MB
+
+export async function POST(req: Request) {
+  try {
+    const formData = await req.formData();
+    const files = formData.getAll('file') as File[];
+
+    if (files.length === 0) {
+      return Response.json({ error: 'No files provided' }, { status: 400 });
+    }
+
+    await mkdir(UPLOAD_DIR, { recursive: true });
+
+    const results: Array<{ ok: boolean; filename: string; path?: string; error?: string }> = [];
+
+    for (const file of files) {
+      // Validate PDF
+      if (!file.name.toLowerCase().endsWith('.pdf')) {
+        results.push({ ok: false, filename: file.name, error: 'Only PDF files are supported' });
+        continue;
+      }
+
+      // Validate size
+      if (file.size > MAX_FILE_SIZE) {
+        results.push({ ok: false, filename: file.name, error: 'File exceeds 100 MB limit' });
+        continue;
+      }
+
+      const bytes = await file.arrayBuffer();
+      const buffer = Buffer.from(bytes);
+      const sanitized = file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
+      const ext = sanitized.endsWith('.pdf') ? '' : '.pdf';
+      const suffix = randomBytes(3).toString('hex');
+      const base = sanitized.replace(/\.pdf$/i, '');
+      const filename = `${base}_${suffix}.pdf${ext}`;
+      const destPath = join(UPLOAD_DIR, filename);
+
+      await writeFile(destPath, buffer);
+      results.push({ ok: true, filename, path: destPath });
+    }
+
+    return Response.json({ results });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd dashboard && npm run build`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/src/app/api/upload/route.ts
+git commit -m "feat(upload): multi-file support, collision avoidance, 100MB size limit"
+```
+
+---
+
+## Task 6: React Hook — `useIngestionJobs`
+
+**Files:**
+- Create: `dashboard/src/hooks/useIngestionJobs.ts`
+
+- [ ] **Step 1: Create the hook**
+
+```typescript
+// dashboard/src/hooks/useIngestionJobs.ts
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+export interface JobSummary {
+  id: string;
+  filename: string;
+  status: string;
+  error: string | null;
+  retryAfter: string | null;
+  retryCount: number;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+export function useIngestionJobs(pollInterval = 3000) {
+  const [jobs, setJobs] = useState<JobSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchJobs = useCallback(async () => {
+    if (document.hidden) return;
+    try {
+      const res = await fetch('/api/ingestion/jobs');
+      if (res.ok) {
+        const data = await res.json();
+        setJobs(data.jobs);
+      }
+    } catch {
+      // Network error — keep previous state
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchJobs();
+    timerRef.current = setInterval(() => void fetchJobs(), pollInterval);
+
+    const handleVisibility = () => {
+      if (!document.hidden) void fetchJobs();
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [fetchJobs, pollInterval]);
+
+  const retry = useCallback(
+    async (jobId: string) => {
+      const res = await fetch(`/api/ingestion/retry/${jobId}`, {
+        method: 'POST',
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Retry failed');
+      }
+      // Immediate re-poll
+      await fetchJobs();
+    },
+    [fetchJobs],
+  );
+
+  return { jobs, isLoading, retry };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add dashboard/src/hooks/useIngestionJobs.ts
+git commit -m "feat(dashboard): add useIngestionJobs polling hook"
+```
+
+---
+
+## Task 7: React Hook — `useFileUpload`
+
+**Files:**
+- Create: `dashboard/src/hooks/useFileUpload.ts`
+
+- [ ] **Step 1: Create the hook**
+
+```typescript
+// dashboard/src/hooks/useFileUpload.ts
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type { JobSummary } from './useIngestionJobs';
+
+export interface StagedFile {
+  name: string;
+  file: File;
+  status: 'staged' | 'uploading' | 'uploaded' | 'upload-failed' | 'duplicate';
+  error?: string;
+}
+
+const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100 MB
+
+export function useFileUpload(jobs: JobSummary[]) {
+  const [files, setFiles] = useState<StagedFile[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
+  const uploadedNamesRef = useRef<Map<string, number>>(new Map());
+
+  // Track uploaded files that haven't appeared as jobs yet
+  useEffect(() => {
+    if (uploadedNamesRef.current.size === 0) return;
+
+    const now = Date.now();
+    const updated = new Map(uploadedNamesRef.current);
+    const toMarkDuplicate: string[] = [];
+
+    for (const [name, timestamp] of updated) {
+      // Check if this file appeared as a job
+      const found = jobs.some(
+        (j) =>
+          j.filename === name &&
+          new Date(j.createdAt).getTime() > timestamp - 5000,
+      );
+      if (found) {
+        updated.delete(name);
+      } else if (now - timestamp > 15_000) {
+        toMarkDuplicate.push(name);
+        updated.delete(name);
+      }
+    }
+
+    uploadedNamesRef.current = updated;
+
+    if (toMarkDuplicate.length > 0) {
+      setFiles((prev) =>
+        prev.map((f) =>
+          toMarkDuplicate.includes(f.name)
+            ? { ...f, status: 'duplicate' as const, error: 'Already processed — duplicate content' }
+            : f,
+        ),
+      );
+      // Clear duplicate entries after a delay
+      setTimeout(() => {
+        setFiles((prev) => prev.filter((f) => f.status !== 'duplicate'));
+      }, 5000);
+    }
+  }, [jobs]);
+
+  const addFiles = useCallback((newFiles: File[]) => {
+    const staged: StagedFile[] = [];
+    for (const file of newFiles) {
+      if (!file.name.toLowerCase().endsWith('.pdf')) {
+        staged.push({
+          name: file.name,
+          file,
+          status: 'staged',
+          error: 'Only PDF files are supported',
+        });
+        continue;
+      }
+      if (file.size > MAX_FILE_SIZE) {
+        staged.push({
+          name: file.name,
+          file,
+          status: 'staged',
+          error: 'File exceeds 100 MB limit',
+        });
+        continue;
+      }
+      staged.push({ name: file.name, file, status: 'staged' });
+    }
+    setFiles((prev) => [...prev, ...staged]);
+  }, []);
+
+  const removeFile = useCallback((name: string) => {
+    setFiles((prev) => prev.filter((f) => f.name !== name));
+  }, []);
+
+  const uploadAll = useCallback(async () => {
+    const valid = files.filter((f) => f.status === 'staged' && !f.error);
+    if (valid.length === 0) return;
+
+    setIsUploading(true);
+    setFiles((prev) =>
+      prev.map((f) =>
+        f.status === 'staged' && !f.error ? { ...f, status: 'uploading' as const } : f,
+      ),
+    );
+
+    try {
+      const formData = new FormData();
+      for (const f of valid) {
+        formData.append('file', f.file);
+      }
+
+      const res = await fetch('/api/upload', { method: 'POST', body: formData });
+      const data = await res.json();
+
+      if (data.results) {
+        const resultMap = new Map<string, { ok: boolean; filename?: string; error?: string }>();
+        for (const r of data.results) {
+          // Map original name to result
+          resultMap.set(r.filename || r.error, r);
+        }
+
+        // Track uploaded filenames for duplicate detection
+        const now = Date.now();
+        for (const r of data.results) {
+          if (r.ok && r.filename) {
+            uploadedNamesRef.current.set(r.filename, now);
+          }
+        }
+
+        setFiles((prev) =>
+          prev.map((f) => {
+            if (f.status !== 'uploading') return f;
+            // Find matching result by checking if any result succeeded
+            const matchingResult = data.results.find(
+              (r: { ok: boolean; filename: string }) =>
+                r.ok && r.filename.startsWith(f.name.replace(/\.pdf$/i, '').replace(/[^a-zA-Z0-9._-]/g, '_')),
+            );
+            if (matchingResult) {
+              return { ...f, status: 'uploaded' as const };
+            }
+            const failedResult = data.results.find(
+              (r: { ok: boolean; error?: string; filename: string }) => !r.ok && r.filename === f.name,
+            );
+            if (failedResult) {
+              return { ...f, status: 'upload-failed' as const, error: failedResult.error };
+            }
+            return { ...f, status: 'uploaded' as const };
+          }),
+        );
+
+        // Clear uploaded files after a delay
+        setTimeout(() => {
+          setFiles((prev) => prev.filter((f) => f.status !== 'uploaded'));
+        }, 3000);
+      }
+    } catch (err) {
+      setFiles((prev) =>
+        prev.map((f) =>
+          f.status === 'uploading'
+            ? { ...f, status: 'upload-failed' as const, error: String(err) }
+            : f,
+        ),
+      );
+    } finally {
+      setIsUploading(false);
+    }
+  }, [files]);
+
+  const clearErrors = useCallback(() => {
+    setFiles((prev) => prev.filter((f) => f.status === 'staged' && !f.error));
+  }, []);
+
+  return { files, addFiles, removeFile, uploadAll, clearErrors, isUploading };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add dashboard/src/hooks/useFileUpload.ts
+git commit -m "feat(dashboard): add useFileUpload multi-file staging hook"
+```
+
+---
+
+## Task 8: Upload Page — UI Components
+
+**Files:**
+- Create: `dashboard/src/app/upload/components/DropZone.tsx`
+- Create: `dashboard/src/app/upload/components/JobList.tsx`
+- Create: `dashboard/src/app/upload/components/JobRow.tsx`
+
+- [ ] **Step 1: Create DropZone component**
+
+```tsx
+// dashboard/src/app/upload/components/DropZone.tsx
+'use client';
+
+import { useRef, DragEvent } from 'react';
+import type { StagedFile } from '../../../hooks/useFileUpload';
+
+interface DropZoneProps {
+  files: StagedFile[];
+  isUploading: boolean;
+  onAddFiles: (files: File[]) => void;
+  onRemoveFile: (name: string) => void;
+  onUploadAll: () => void;
+}
+
+export function DropZone({
+  files,
+  isUploading,
+  onAddFiles,
+  onRemoveFile,
+  onUploadAll,
+}: DropZoneProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dragCounter = useRef(0);
+  const [dragging, setDragging] = useState(false);
+
+  function handleDragEnter(e: DragEvent) {
+    e.preventDefault();
+    dragCounter.current++;
+    setDragging(true);
+  }
+  function handleDragLeave(e: DragEvent) {
+    e.preventDefault();
+    dragCounter.current--;
+    if (dragCounter.current === 0) setDragging(false);
+  }
+  function handleDragOver(e: DragEvent) {
+    e.preventDefault();
+  }
+  function handleDrop(e: DragEvent) {
+    e.preventDefault();
+    dragCounter.current = 0;
+    setDragging(false);
+    const dropped = Array.from(e.dataTransfer.files);
+    if (dropped.length > 0) onAddFiles(dropped);
+  }
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const selected = Array.from(e.target.files || []);
+    if (selected.length > 0) onAddFiles(selected);
+    e.target.value = '';
+  }
+
+  const staged = files.filter((f) => f.status === 'staged' && !f.error);
+  const hasValidFiles = staged.length > 0;
+
+  return (
+    <div
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+      onClick={() => inputRef.current?.click()}
+      className={`border-2 border-dashed rounded-lg p-6 text-center cursor-pointer transition-colors ${
+        dragging
+          ? 'border-blue-500 bg-blue-950/30'
+          : 'border-gray-700 hover:border-gray-500 bg-gray-900/50'
+      }`}
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".pdf"
+        multiple
+        className="hidden"
+        onChange={handleInputChange}
+      />
+
+      {files.length === 0 ? (
+        <div>
+          <p className="text-gray-400">Drop PDFs here or click to browse</p>
+          <p className="text-gray-600 text-sm mt-1">PDF only · Multiple files supported</p>
+        </div>
+      ) : (
+        <div className="space-y-2" onClick={(e) => e.stopPropagation()}>
+          {files.map((f) => (
+            <div
+              key={f.name}
+              className="flex items-center justify-between px-3 py-2 rounded bg-gray-800/50 text-sm"
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="truncate text-gray-200">{f.name}</span>
+                {f.error && (
+                  <span className="text-red-400 text-xs shrink-0">{f.error}</span>
+                )}
+                {f.status === 'uploading' && (
+                  <span className="text-blue-400 text-xs shrink-0">Uploading...</span>
+                )}
+                {f.status === 'uploaded' && (
+                  <span className="text-green-400 text-xs shrink-0">Uploaded</span>
+                )}
+                {f.status === 'duplicate' && (
+                  <span className="text-yellow-400 text-xs shrink-0">{f.error}</span>
+                )}
+              </div>
+              {f.status === 'staged' && (
+                <button
+                  onClick={() => onRemoveFile(f.name)}
+                  className="text-gray-500 hover:text-gray-300 ml-2 shrink-0"
+                >
+                  ✕
+                </button>
+              )}
+            </div>
+          ))}
+
+          {hasValidFiles && (
+            <button
+              onClick={onUploadAll}
+              disabled={isUploading}
+              className="mt-2 w-full px-4 py-2 rounded bg-blue-700 hover:bg-blue-600 text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {isUploading ? 'Uploading...' : `Upload ${staged.length} file${staged.length > 1 ? 's' : ''}`}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+Add the missing import at top:
+```tsx
+import { useRef, useState, DragEvent } from 'react';
+```
+
+- [ ] **Step 2: Create JobRow component**
+
+```tsx
+// dashboard/src/app/upload/components/JobRow.tsx
+'use client';
+
+import { useState } from 'react';
+import type { JobSummary } from '../../../hooks/useIngestionJobs';
+
+interface JobRowProps {
+  job: JobSummary;
+  onRetry: (id: string) => Promise<void>;
+}
+
+const STATUS_CONFIG: Record<
+  string,
+  { label: string; color: string; bgColor: string; progress: number }
+> = {
+  pending: { label: 'Pending', color: 'text-gray-400', bgColor: 'bg-gray-500', progress: 0 },
+  extracting: { label: 'Extracting', color: 'text-orange-400', bgColor: 'bg-orange-500', progress: 16 },
+  extracted: { label: 'Extracted', color: 'text-orange-400', bgColor: 'bg-orange-500', progress: 33 },
+  generating: { label: 'Generating notes', color: 'text-blue-400', bgColor: 'bg-blue-500', progress: 50 },
+  generated: { label: 'Generated', color: 'text-blue-400', bgColor: 'bg-blue-500', progress: 66 },
+  promoting: { label: 'Promoting to vault', color: 'text-indigo-400', bgColor: 'bg-indigo-500', progress: 83 },
+  completed: { label: 'Completed', color: 'text-green-400', bgColor: 'bg-green-500', progress: 100 },
+  failed: { label: 'Failed', color: 'text-red-400', bgColor: 'bg-red-500', progress: 0 },
+  rate_limited: { label: 'Rate limited', color: 'text-amber-400', bgColor: 'bg-amber-500', progress: 50 },
+};
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function retryCountdown(retryAfter: string): string {
+  const diff = new Date(retryAfter).getTime() - Date.now();
+  if (diff <= 0) return 'retrying soon';
+  const mins = Math.ceil(diff / 60_000);
+  return `retries in ~${mins}m`;
+}
+
+export function JobRow({ job, onRetry }: JobRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [notes, setNotes] = useState<{ promotedPaths: string[] | null } | null>(null);
+  const [retrying, setRetrying] = useState(false);
+  const config = STATUS_CONFIG[job.status] ?? STATUS_CONFIG.pending;
+  const isActive = !['completed', 'failed'].includes(job.status);
+
+  async function handleExpand() {
+    if (job.status !== 'completed') return;
+    if (expanded) {
+      setExpanded(false);
+      return;
+    }
+    if (!notes) {
+      const res = await fetch(`/api/ingestion/jobs/${job.id}`);
+      if (res.ok) {
+        const data = await res.json();
+        setNotes({ promotedPaths: data.promotedPaths });
+      }
+    }
+    setExpanded(true);
+  }
+
+  async function handleRetry() {
+    setRetrying(true);
+    try {
+      await onRetry(job.id);
+    } catch {
+      // Error handled by parent
+    } finally {
+      setRetrying(false);
+    }
+  }
+
+  return (
+    <div className="px-4 py-3 border-b border-gray-800 last:border-b-0">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            {job.status === 'completed' && (
+              <button
+                onClick={handleExpand}
+                className="text-gray-500 hover:text-gray-300 text-xs shrink-0"
+              >
+                {expanded ? '▾' : '▸'}
+              </button>
+            )}
+            <span className="text-sm text-gray-200 truncate">{job.filename}</span>
+          </div>
+
+          {/* Error message */}
+          {job.status === 'failed' && job.error && (
+            <p className="text-xs text-red-400 mt-1 truncate">
+              {job.error.includes(':') ? job.error.split(':').slice(1).join(':') : job.error}
+            </p>
+          )}
+
+          {/* Rate-limit countdown */}
+          {job.status === 'rate_limited' && job.retryAfter && (
+            <p className="text-xs text-amber-400 mt-1">
+              Waiting for session reset — {retryCountdown(job.retryAfter)}
+            </p>
+          )}
+
+          {/* Progress bar for active jobs */}
+          {isActive && config.progress > 0 && (
+            <div className="mt-1.5 h-1 rounded-full bg-gray-800 overflow-hidden">
+              <div
+                className={`h-full rounded-full ${config.bgColor} transition-all duration-500`}
+                style={{ width: `${config.progress}%` }}
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3 shrink-0">
+          <span className={`text-xs ${config.color}`}>{config.label}</span>
+          <span
+            className="text-xs text-gray-600"
+            title={new Date(job.updatedAt).toLocaleString()}
+          >
+            {relativeTime(job.updatedAt)}
+          </span>
+
+          {job.status === 'failed' && (
+            <button
+              onClick={handleRetry}
+              disabled={retrying}
+              className="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-300 border border-gray-700 disabled:opacity-50"
+            >
+              {retrying ? '...' : 'Retry'}
+            </button>
+          )}
+          {job.status === 'rate_limited' && (
+            <button
+              onClick={handleRetry}
+              disabled={retrying}
+              className="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-amber-300 border border-gray-700 disabled:opacity-50"
+            >
+              {retrying ? '...' : 'Retry now'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Expanded: show promoted notes */}
+      {expanded && notes?.promotedPaths && (
+        <div className="mt-2 ml-6 space-y-1">
+          <p className="text-xs text-gray-500">
+            {notes.promotedPaths.length} note{notes.promotedPaths.length !== 1 ? 's' : ''} generated
+          </p>
+          {notes.promotedPaths.map((path) => (
+            <a
+              key={path}
+              href={`/vault?file=${encodeURIComponent(path)}`}
+              className="block text-xs text-blue-400 hover:text-blue-300 truncate"
+            >
+              {path}
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create JobList component**
+
+```tsx
+// dashboard/src/app/upload/components/JobList.tsx
+'use client';
+
+import { useState } from 'react';
+import type { JobSummary } from '../../../hooks/useIngestionJobs';
+import { JobRow } from './JobRow';
+
+interface JobListProps {
+  jobs: JobSummary[];
+  onRetry: (id: string) => Promise<void>;
+}
+
+const IN_PROGRESS_STATUSES = new Set([
+  'pending',
+  'extracting',
+  'extracted',
+  'generating',
+  'generated',
+  'promoting',
+  'rate_limited',
+]);
+
+export function JobList({ jobs, onRetry }: JobListProps) {
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({
+    inProgress: true,
+    completed: false,
+    failed: false,
+  });
+
+  const inProgress = jobs.filter((j) => IN_PROGRESS_STATUSES.has(j.status));
+  const completed = jobs.filter((j) => j.status === 'completed');
+  const failed = jobs.filter((j) => j.status === 'failed');
+
+  function toggleGroup(key: string) {
+    setExpandedGroups((prev) => ({ ...prev, [key]: !prev[key] }));
+  }
+
+  if (jobs.length === 0) {
+    return (
+      <p className="text-sm text-gray-600 text-center py-8">
+        No uploads yet. Drop a PDF above to get started.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* In Progress */}
+      {inProgress.length > 0 && (
+        <div className="rounded-lg border border-gray-800 overflow-hidden">
+          <button
+            onClick={() => toggleGroup('inProgress')}
+            className="w-full flex items-center justify-between px-4 py-2.5 bg-gray-900/50 hover:bg-gray-800/50 transition-colors"
+          >
+            <span className="text-sm font-medium text-gray-300">
+              {expandedGroups.inProgress ? '▾' : '▸'} In Progress ({inProgress.length})
+            </span>
+          </button>
+          {expandedGroups.inProgress && (
+            <div>
+              {inProgress.map((job) => (
+                <JobRow key={job.id} job={job} onRetry={onRetry} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Completed */}
+      {completed.length > 0 && (
+        <div className="rounded-lg border border-gray-800 overflow-hidden">
+          <button
+            onClick={() => toggleGroup('completed')}
+            className="w-full flex items-center justify-between px-4 py-2.5 bg-gray-900/50 hover:bg-gray-800/50 transition-colors"
+          >
+            <span className="text-sm font-medium text-gray-300">
+              {expandedGroups.completed ? '▾' : '▸'} Completed ({completed.length})
+            </span>
+          </button>
+          {expandedGroups.completed && (
+            <div>
+              {completed.map((job) => (
+                <JobRow key={job.id} job={job} onRetry={onRetry} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Failed */}
+      {failed.length > 0 && (
+        <div className="rounded-lg border border-gray-800 overflow-hidden">
+          <button
+            onClick={() => toggleGroup('failed')}
+            className="w-full flex items-center justify-between px-4 py-2.5 bg-gray-900/50 hover:bg-gray-800/50 transition-colors"
+          >
+            <span className="text-sm font-medium text-red-400">
+              {expandedGroups.failed ? '▾' : '▸'} Failed ({failed.length})
+            </span>
+          </button>
+          {expandedGroups.failed && (
+            <div>
+              {failed.map((job) => (
+                <JobRow key={job.id} job={job} onRetry={onRetry} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dashboard/src/app/upload/components/
+git commit -m "feat(dashboard): add DropZone, JobRow, JobList UI components"
+```
+
+---
+
+## Task 9: Upload Page — Compose Everything
+
+**Files:**
+- Modify: `dashboard/src/app/upload/page.tsx`
+
+- [ ] **Step 1: Rewrite the upload page**
+
+```tsx
+// dashboard/src/app/upload/page.tsx
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useIngestionJobs } from '../../hooks/useIngestionJobs';
+import { useFileUpload } from '../../hooks/useFileUpload';
+import { DropZone } from './components/DropZone';
+import { JobList } from './components/JobList';
+
+export default function UploadPage() {
+  const { jobs, isLoading, retry } = useIngestionJobs();
+  const { files, addFiles, removeFile, uploadAll, isUploading } = useFileUpload(jobs);
+  const [concurrency, setConcurrency] = useState(1);
+
+  useEffect(() => {
+    fetch('/api/ingestion/settings')
+      .then((r) => r.json())
+      .then((data) => setConcurrency(data.maxGenerationConcurrent))
+      .catch(() => {});
+  }, []);
+
+  const handleConcurrencyChange = useCallback(async (value: number) => {
+    setConcurrency(value);
+    await fetch('/api/ingestion/settings', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ maxGenerationConcurrent: value }),
+    });
+  }, []);
+
+  return (
+    <div className="max-w-2xl">
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-xl font-semibold">Upload</h2>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-gray-500">Parallel jobs:</span>
+          <div className="flex rounded-md overflow-hidden border border-gray-700">
+            {[1, 2, 3, 4, 5].map((n) => (
+              <button
+                key={n}
+                onClick={() => handleConcurrencyChange(n)}
+                className={`px-2.5 py-1 text-xs transition-colors ${
+                  concurrency === n
+                    ? 'bg-blue-700 text-white'
+                    : 'bg-gray-900 text-gray-400 hover:bg-gray-800'
+                }`}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <DropZone
+        files={files}
+        isUploading={isUploading}
+        onAddFiles={addFiles}
+        onRemoveFile={removeFile}
+        onUploadAll={uploadAll}
+      />
+
+      <div className="mt-6">
+        {isLoading ? (
+          <p className="text-sm text-gray-600 text-center py-4">Loading...</p>
+        ) : (
+          <JobList jobs={jobs} onRetry={retry} />
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd dashboard && npm run build`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/src/app/upload/page.tsx
+git commit -m "feat(dashboard): rewrite upload page with multi-file, status tracking, retry"
+```
+
+---
+
+## Task 10: Integration Testing and Polish
+
+- [ ] **Step 1: Run all tests across the project**
+
+Run: `npm test`
+Expected: All existing + new tests pass.
+
+- [ ] **Step 2: Run dashboard build**
+
+Run: `cd dashboard && npm run build`
+Expected: Clean build, no type errors.
+
+- [ ] **Step 3: Manual smoke test**
+
+Start the stack:
+```bash
+npm run dev &
+cd dashboard && npm run dev &
+```
+
+Verify:
+1. Open http://localhost:3100/upload
+2. Concurrency selector shows and persists changes
+3. Drop a PDF → appears in staging → click Upload → appears in "In Progress"
+4. Drop a non-PDF → inline error
+5. Drop a >100 MB file → inline error
+6. Job progresses through stages (extracting → generating → completed)
+7. Completed jobs show expand arrow → click shows vault links
+8. If pipeline is stopped, failed jobs show retry button
+
+- [ ] **Step 4: Fix any issues found during testing**
+
+Address type errors, import path issues, or visual bugs.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add -A
+git commit -m "fix: address integration issues from upload page testing"
+```

--- a/docs/superpowers/specs/2026-04-01-upload-page-redesign.md
+++ b/docs/superpowers/specs/2026-04-01-upload-page-redesign.md
@@ -10,6 +10,14 @@ The current upload page (`dashboard/src/app/upload/page.tsx`) supports single-fi
 
 New API routes expose ingestion data. Two custom React hooks handle upload management and job polling. The page component stays thin — layout and composition only.
 
+## Database Access
+
+The dashboard (Next.js) and main NanoClaw process (Node.js) share the same SQLite database (`store/messages.db`). SQLite WAL mode enables safe concurrent access — one writer with many readers.
+
+A shared read-only DB module (`src/shared/db-reader.ts`) encapsulates the query functions needed by the dashboard. It opens the database in read-only mode (`readonly: true`) with a `busy_timeout` of 5000ms. The dashboard imports this module for all GET endpoints. Write operations (retry, settings) use a separate writer connection with `busy_timeout` to handle brief contention with the main process.
+
+The shared module is a thin query layer — it imports the DB path from config and exports typed query functions. It does not duplicate schema definitions; those remain in `src/db.ts`. The dashboard's `next.config.ts` adds `better-sqlite3` to `serverExternalPackages`.
+
 ## API Layer
 
 ### New Routes
@@ -17,14 +25,14 @@ New API routes expose ingestion data. Two custom React hooks handle upload manag
 | Route | Method | Purpose |
 |-------|--------|---------|
 | `/api/ingestion/jobs` | GET | Last 20 jobs, ordered by `created_at` desc. Optional `?status=` filter. |
-| `/api/ingestion/jobs/[id]` | GET | Single job with manifest data (generated note filenames) for completed jobs. |
-| `/api/ingestion/retry/[id]` | POST | Reset `failed` job to `pending`, clear error. Returns 409 if source file missing from disk. |
+| `/api/ingestion/jobs/[id]` | GET | Single job with manifest data (generated note filenames) for completed jobs. Returns promoted vault paths. |
+| `/api/ingestion/retry/[id]` | POST | Reset `failed` job to `pending` or to last successful stage (see Retry Semantics). Returns 409 if source file missing. |
 | `/api/ingestion/settings` | GET | Current pipeline settings (maxGenerationConcurrent). |
 | `/api/ingestion/settings` | PATCH | Update pipeline settings. Takes effect on next drainer poll cycle (~5s). |
 
 ### Existing Route Changes
 
-`POST /api/upload` — accept multiple files in a single FormData request. Return an array of `{ ok, filename, path }` results.
+`POST /api/upload` — accept multiple files in a single FormData request. Append a short random suffix to sanitized filenames to prevent collisions in a batch (e.g., `lecture-09_a3f2.pdf`). Return an array of `{ ok, filename, path }` results. Enforce a 100 MB per-file size limit (server-side check; client shows error for files exceeding this).
 
 ### Response Shapes
 
@@ -37,9 +45,10 @@ interface JobsResponse {
 interface JobSummary {
   id: string;
   filename: string;
-  status: 'pending' | 'extracting' | 'extracted' | 'generating' | 'promoting' | 'completed' | 'failed' | 'rate_limited';
+  status: 'pending' | 'extracting' | 'extracted' | 'generating' | 'generated' | 'promoting' | 'completed' | 'failed' | 'rate_limited';
   error: string | null;
-  createdAt: string;   // ISO 8601
+  retryAfter: string | null;  // ISO 8601, only for rate_limited jobs
+  createdAt: string;           // ISO 8601
   updatedAt: string;
   completedAt: string | null;
 }
@@ -47,8 +56,8 @@ interface JobSummary {
 // GET /api/ingestion/jobs/[id]
 interface JobDetailResponse extends JobSummary {
   notes?: {
-    sourceNote: string;       // filename
-    conceptNotes: string[];   // filenames
+    sourceNote: string;       // promoted vault path (e.g., "sources/lecture-09.md")
+    conceptNotes: string[];   // promoted vault paths (e.g., ["concepts/big-o.md", ...])
   };
 }
 
@@ -62,22 +71,51 @@ interface SettingsResponse {
 
 ### New Status: `rate_limited`
 
-When a job fails due to a session/rate limit (detected by matching error strings: "rate limit", "session limit", "overloaded", or specific API error codes), the pipeline sets status to `rate_limited` instead of `failed`.
+When a job fails due to a session/rate limit, the pipeline sets status to `rate_limited` instead of `failed`.
 
-The `error` field stores the original error message. A separate `retry_after` TEXT column is added to `ingestion_jobs` to hold the ISO 8601 timestamp for the next retry attempt.
+**Detection:** The `onGenerate` callback in `src/ingestion/index.ts` catches errors and inspects the message for rate-limit signals ("rate limit", "session limit", "overloaded", HTTP 429, HTTP 529). If matched, it sets the job status to `rate_limited` directly and does **not** re-throw. The generic catch in `PipelineDrainer.drainGenerations()` only runs on re-thrown errors, so it won't override `rate_limited` with `failed`.
+
+The `error` field stores the original error message. A separate `retry_after` TEXT column holds the ISO 8601 retry timestamp. A `retry_count` INTEGER column (default 0) tracks how many rate-limit retries have occurred for backoff calculation.
 
 ### Auto-retry Logic
 
-On each drainer poll cycle, check for `rate_limited` jobs where `retryAfter` has passed. Reset to `pending` for normal pipeline pickup.
+On each drainer poll cycle, check for `rate_limited` jobs where `retry_after` has passed. Reset to the stage before failure (typically `extracted`, so the job re-enters generation without re-running Docling). Increment `retry_count`.
 
 Backoff schedule when no explicit `retry-after` header is available:
-- 1st rate limit: retry after 5 minutes
-- 2nd rate limit: retry after 15 minutes
-- 3rd+ rate limit: retry after 60 minutes
+- 1st rate limit (`retry_count` = 0): retry after 5 minutes
+- 2nd rate limit (`retry_count` = 1): retry after 15 minutes
+- 3rd+ rate limit (`retry_count` >= 2): retry after 60 minutes
+
+### Retry Semantics
+
+Manual retry (via the retry endpoint) and auto-retry are stage-aware:
+
+| Failed during | Reset to | Effect |
+|---------------|----------|--------|
+| `extracting` | `pending` | Re-runs Docling extraction |
+| `generating` | `extracted` | Skips extraction, re-runs agent note generation |
+| `promoting` | `generated` | Skips extraction and generation, re-runs vault promotion |
+
+The retry endpoint records the previous `status` before resetting, so the pipeline resumes at the correct stage. The `PipelineDrainer` already picks up jobs by status (`pending` → extract, `extracted` → generate, `generated` → promote), so stage-aware retry works naturally.
 
 ### Concurrency Setting
 
-`maxGenerationConcurrent` is stored in a `settings` table in SQLite (key-value pairs). Read on each drainer poll cycle. Changes via the PATCH endpoint take effect within ~5 seconds. Default: 1.
+`maxGenerationConcurrent` is stored in a `settings` table in SQLite (key-value pairs). The `PipelineDrainer` constructor accepts a getter `() => number` instead of a fixed value, reading the current setting from the DB on each poll cycle. Default: 1.
+
+### New DB Schema
+
+```sql
+-- New columns on ingestion_jobs
+ALTER TABLE ingestion_jobs ADD COLUMN retry_after TEXT;
+ALTER TABLE ingestion_jobs ADD COLUMN retry_count INTEGER DEFAULT 0;
+
+-- New table for pipeline settings
+CREATE TABLE IF NOT EXISTS settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+```
 
 ## React Hooks
 
@@ -101,9 +139,9 @@ interface StagedFile {
 }
 ```
 
-- Validates PDF-only on `addFiles`. Rejects others with per-file error.
+- Validates on `addFiles`: PDF-only (extension check), max 100 MB per file. Rejects with per-file error.
 - Uploads all staged files in a single multi-file FormData POST.
-- After upload, the hook accepts a `jobs` array (passed in from `useIngestionJobs`) to check whether uploaded filenames appear as new jobs. If a file doesn't appear within ~10 seconds (3 poll cycles), marks it as `duplicate` with "Already processed — duplicate content" message.
+- After upload, the hook accepts a `jobs` array (passed in from `useIngestionJobs`) to check whether uploaded filenames appear as new jobs. If a file doesn't appear within ~15 seconds (5 poll cycles — accounts for write finalization + watcher + hash check), marks it as `duplicate` with "Already processed — duplicate content" message.
 
 ### `useIngestionJobs(pollInterval = 3000)`
 
@@ -129,7 +167,7 @@ Grouped & collapsible layout:
 
 1. **Header area** — page title, concurrency selector ("Parallel jobs: 1 2 3 4 5" segmented control)
 2. **Drop zone** — compact, always visible. Shows staging list when files are added, with per-file remove buttons and "Upload all" action.
-3. **In Progress group** — collapsible, open by default. Contains `pending`, `extracting`, `generating`, `promoting`, and `rate_limited` jobs.
+3. **In Progress group** — collapsible, open by default. Contains `pending`, `extracting`, `extracted`, `generating`, `generated`, `promoting`, and `rate_limited` jobs.
 4. **Completed group** — collapsible, collapsed by default. Contains `completed` jobs.
 5. **Failed group** — collapsible, collapsed by default. Contains `failed` jobs. Only visible when there are failed jobs.
 
@@ -138,49 +176,51 @@ Grouped & collapsible layout:
 | Element | Behavior |
 |---------|----------|
 | Filename | Always visible |
-| Status badge | Color-coded: pending (gray), extracting (orange), generating (blue), promoting (blue), completed (green), failed (red), rate_limited (amber) |
-| Progress bar | Segmented: pending=0%, extracting=25%, extracted=50%, generating=75%, completed=100% |
+| Status badge | Color-coded: pending (gray), extracting (orange), generating (blue), promoting (indigo), completed (green), failed (red), rate_limited (amber) |
+| Progress bar | Three visible stages: extracting (0–33%), generating (33–66%), promoting (66–100%). Transient statuses (`extracted`, `generated`) are treated as the start of the next stage — e.g., `extracted` shows as 33% (ready for generation). |
 | Timestamp | Relative ("2 min ago") with absolute time in tooltip |
 | Error message | Inline below filename on failed jobs |
-| Rate-limit info | Amber badge: "Waiting for session reset — retries in ~Xm" |
+| Rate-limit info | Amber badge: "Waiting for session reset — retries in ~Xm" with countdown based on `retryAfter` |
 | Retry button | Failed jobs only. Rate-limited jobs show "Retry now" override. |
 | Expand arrow | Completed jobs only |
 
 ### Expanded Completed Row
 
-Shows the manifest output:
-- Source note filename → links to `/vault?file=sources/{name}.md`
-- Concept note filenames → each links to `/vault?file=concepts/{name}.md`
+Shows the manifest output with promoted vault paths:
+- Source note → links to `/vault?file=sources/{name}.md`
+- Concept notes → each links to `/vault?file=concepts/{name}.md`
 - Count: "1 source note + 3 concept notes"
 
-Manifest data fetched on-demand from `GET /api/ingestion/jobs/[id]` when the user expands the row.
+The job detail endpoint (`GET /api/ingestion/jobs/[id]`) resolves promoted vault paths by scanning the vault for notes whose frontmatter `source_job` field matches the job ID. This is fetched on-demand when the user expands a row.
 
 ## File Validation
 
-- PDF only (`.pdf` extension check on client)
+- PDF only (`.pdf` extension check on client, confirmed server-side)
+- Max 100 MB per file (client-side check with server-side enforcement)
 - Non-PDF files rejected with inline error: "Only PDF files are supported"
+- Oversized files rejected with: "File exceeds 100 MB limit"
 - Matches backend file watcher which also only processes `.pdf`
 
 ## Duplicate Detection
 
 Handled by existing backend content-hash dedup in the file watcher. The watcher computes SHA256 of uploaded files and skips if an identical file already has a `completed` job.
 
-Frontend detects this indirectly: if a file was uploaded but no corresponding job appears within ~10 seconds, the staging entry shows "Already processed — duplicate content" before clearing.
+Frontend detects this indirectly: if a file was uploaded but no corresponding job appears within ~15 seconds, the staging entry shows "Already processed — duplicate content" before clearing.
 
 ## Data Flow
 
 ```
 User drops files
-  → Client validates (PDF only)
+  → Client validates (PDF only, <100 MB)
   → Staging list shown
   → User clicks "Upload all"
   → POST /api/upload (multi-file FormData)
-  → Files written to UPLOAD_DIR
+  → Files written to UPLOAD_DIR (with random suffix to avoid collisions)
   → File watcher detects new files (chokidar)
   → Dedup check (content hash)
   → Job created in ingestion_jobs table
   → Pipeline drainer picks up pending jobs
-  → extracting → generating → promoting → completed
+  → extracting → extracted → generating → generated → promoting → completed
   → Client polls GET /api/ingestion/jobs every 3s
   → UI updates in real-time
 ```
@@ -188,16 +228,18 @@ User drops files
 Rate-limit branch:
 ```
 generating fails with rate limit
-  → Status set to rate_limited (not failed)
-  → retryAfter timestamp stored
+  → onGenerate callback detects rate-limit error
+  → Status set to rate_limited (not re-thrown, so drainer catch doesn't override)
+  → retry_after timestamp stored, retry_count stays unchanged
   → Drainer checks rate_limited jobs each cycle
-  → When retryAfter passes, reset to pending
-  → Normal pipeline resumes
+  → When retry_after passes, reset to extracted, increment retry_count
+  → Normal pipeline resumes from generation stage
 ```
 
 ## Files to Create/Modify
 
 ### New files
+- `src/shared/db-reader.ts` — shared read-only DB query module for dashboard
 - `dashboard/src/app/api/ingestion/jobs/route.ts` — jobs list endpoint
 - `dashboard/src/app/api/ingestion/jobs/[id]/route.ts` — job detail endpoint
 - `dashboard/src/app/api/ingestion/retry/[id]/route.ts` — retry endpoint
@@ -207,6 +249,9 @@ generating fails with rate limit
 
 ### Modified files
 - `dashboard/src/app/upload/page.tsx` — full rewrite with new layout
-- `dashboard/src/app/api/upload/route.ts` — multi-file support
-- `src/ingestion/pipeline.ts` — rate_limited status, auto-retry logic, dynamic concurrency
-- `src/db.ts` — add `retry_after` column, `rate_limited` status handling, `settings` table, read/write helpers
+- `dashboard/src/app/api/upload/route.ts` — multi-file support, filename collision avoidance, size limit
+- `dashboard/next.config.ts` — add `better-sqlite3` to `serverExternalPackages`
+- `dashboard/package.json` — add `better-sqlite3` dependency
+- `src/ingestion/pipeline.ts` — rate_limited handling in drainGenerations, auto-retry logic in new drainRateLimited method, dynamic concurrency via getter
+- `src/ingestion/index.ts` — rate-limit detection in onGenerate callback
+- `src/db.ts` — add `retry_after` and `retry_count` columns, `settings` table, new query helpers (getSettings, updateSettings, getJobDetail with manifest resolution)

--- a/docs/superpowers/specs/2026-04-01-upload-page-redesign.md
+++ b/docs/superpowers/specs/2026-04-01-upload-page-redesign.md
@@ -1,0 +1,212 @@
+# Upload Page Redesign
+
+Redesign the dashboard upload page from a minimal single-file drop zone into a full ingestion management interface with multi-file upload, real-time status tracking, retry controls, and vault output preview.
+
+## Context
+
+The current upload page (`dashboard/src/app/upload/page.tsx`) supports single-file drag-and-drop with no history, status tracking, or feedback beyond "Uploaded: filename". The ingestion pipeline already tracks full job lifecycle in the `ingestion_jobs` SQLite table, but this data is not exposed to the dashboard.
+
+## Architecture: Approach B — Shared Hooks, Separated Concerns
+
+New API routes expose ingestion data. Two custom React hooks handle upload management and job polling. The page component stays thin — layout and composition only.
+
+## API Layer
+
+### New Routes
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/ingestion/jobs` | GET | Last 20 jobs, ordered by `created_at` desc. Optional `?status=` filter. |
+| `/api/ingestion/jobs/[id]` | GET | Single job with manifest data (generated note filenames) for completed jobs. |
+| `/api/ingestion/retry/[id]` | POST | Reset `failed` job to `pending`, clear error. Returns 409 if source file missing from disk. |
+| `/api/ingestion/settings` | GET | Current pipeline settings (maxGenerationConcurrent). |
+| `/api/ingestion/settings` | PATCH | Update pipeline settings. Takes effect on next drainer poll cycle (~5s). |
+
+### Existing Route Changes
+
+`POST /api/upload` — accept multiple files in a single FormData request. Return an array of `{ ok, filename, path }` results.
+
+### Response Shapes
+
+```typescript
+// GET /api/ingestion/jobs
+interface JobsResponse {
+  jobs: JobSummary[];
+}
+
+interface JobSummary {
+  id: string;
+  filename: string;
+  status: 'pending' | 'extracting' | 'extracted' | 'generating' | 'promoting' | 'completed' | 'failed' | 'rate_limited';
+  error: string | null;
+  createdAt: string;   // ISO 8601
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+// GET /api/ingestion/jobs/[id]
+interface JobDetailResponse extends JobSummary {
+  notes?: {
+    sourceNote: string;       // filename
+    conceptNotes: string[];   // filenames
+  };
+}
+
+// GET /api/ingestion/settings
+interface SettingsResponse {
+  maxGenerationConcurrent: number;
+}
+```
+
+## Pipeline Changes
+
+### New Status: `rate_limited`
+
+When a job fails due to a session/rate limit (detected by matching error strings: "rate limit", "session limit", "overloaded", or specific API error codes), the pipeline sets status to `rate_limited` instead of `failed`.
+
+The `error` field stores the original error message. A separate `retry_after` TEXT column is added to `ingestion_jobs` to hold the ISO 8601 timestamp for the next retry attempt.
+
+### Auto-retry Logic
+
+On each drainer poll cycle, check for `rate_limited` jobs where `retryAfter` has passed. Reset to `pending` for normal pipeline pickup.
+
+Backoff schedule when no explicit `retry-after` header is available:
+- 1st rate limit: retry after 5 minutes
+- 2nd rate limit: retry after 15 minutes
+- 3rd+ rate limit: retry after 60 minutes
+
+### Concurrency Setting
+
+`maxGenerationConcurrent` is stored in a `settings` table in SQLite (key-value pairs). Read on each drainer poll cycle. Changes via the PATCH endpoint take effect within ~5 seconds. Default: 1.
+
+## React Hooks
+
+### `useFileUpload()`
+
+Manages the staging → upload flow for multi-file drops.
+
+```typescript
+interface UseFileUploadReturn {
+  files: StagedFile[];         // files waiting to be uploaded
+  addFiles: (files: File[]) => void;  // validate and stage
+  removeFile: (name: string) => void; // remove from staging
+  uploadAll: () => Promise<void>;     // submit batch
+  isUploading: boolean;
+}
+
+interface StagedFile {
+  file: File;
+  status: 'staged' | 'uploading' | 'uploaded' | 'upload-failed' | 'duplicate';
+  error?: string;
+}
+```
+
+- Validates PDF-only on `addFiles`. Rejects others with per-file error.
+- Uploads all staged files in a single multi-file FormData POST.
+- After upload, the hook accepts a `jobs` array (passed in from `useIngestionJobs`) to check whether uploaded filenames appear as new jobs. If a file doesn't appear within ~10 seconds (3 poll cycles), marks it as `duplicate` with "Already processed — duplicate content" message.
+
+### `useIngestionJobs(pollInterval = 3000)`
+
+Polls job status from the API.
+
+```typescript
+interface UseIngestionJobsReturn {
+  jobs: JobSummary[];
+  isLoading: boolean;
+  retry: (jobId: string) => Promise<void>;
+}
+```
+
+- Polls `GET /api/ingestion/jobs` on interval.
+- Pauses polling when `document.hidden` is true (tab backgrounded).
+- `retry()` calls `POST /api/ingestion/retry/:id`, then forces immediate re-poll.
+
+## UI Layout
+
+### Structure
+
+Grouped & collapsible layout:
+
+1. **Header area** — page title, concurrency selector ("Parallel jobs: 1 2 3 4 5" segmented control)
+2. **Drop zone** — compact, always visible. Shows staging list when files are added, with per-file remove buttons and "Upload all" action.
+3. **In Progress group** — collapsible, open by default. Contains `pending`, `extracting`, `generating`, `promoting`, and `rate_limited` jobs.
+4. **Completed group** — collapsible, collapsed by default. Contains `completed` jobs.
+5. **Failed group** — collapsible, collapsed by default. Contains `failed` jobs. Only visible when there are failed jobs.
+
+### Job Row
+
+| Element | Behavior |
+|---------|----------|
+| Filename | Always visible |
+| Status badge | Color-coded: pending (gray), extracting (orange), generating (blue), promoting (blue), completed (green), failed (red), rate_limited (amber) |
+| Progress bar | Segmented: pending=0%, extracting=25%, extracted=50%, generating=75%, completed=100% |
+| Timestamp | Relative ("2 min ago") with absolute time in tooltip |
+| Error message | Inline below filename on failed jobs |
+| Rate-limit info | Amber badge: "Waiting for session reset — retries in ~Xm" |
+| Retry button | Failed jobs only. Rate-limited jobs show "Retry now" override. |
+| Expand arrow | Completed jobs only |
+
+### Expanded Completed Row
+
+Shows the manifest output:
+- Source note filename → links to `/vault?file=sources/{name}.md`
+- Concept note filenames → each links to `/vault?file=concepts/{name}.md`
+- Count: "1 source note + 3 concept notes"
+
+Manifest data fetched on-demand from `GET /api/ingestion/jobs/[id]` when the user expands the row.
+
+## File Validation
+
+- PDF only (`.pdf` extension check on client)
+- Non-PDF files rejected with inline error: "Only PDF files are supported"
+- Matches backend file watcher which also only processes `.pdf`
+
+## Duplicate Detection
+
+Handled by existing backend content-hash dedup in the file watcher. The watcher computes SHA256 of uploaded files and skips if an identical file already has a `completed` job.
+
+Frontend detects this indirectly: if a file was uploaded but no corresponding job appears within ~10 seconds, the staging entry shows "Already processed — duplicate content" before clearing.
+
+## Data Flow
+
+```
+User drops files
+  → Client validates (PDF only)
+  → Staging list shown
+  → User clicks "Upload all"
+  → POST /api/upload (multi-file FormData)
+  → Files written to UPLOAD_DIR
+  → File watcher detects new files (chokidar)
+  → Dedup check (content hash)
+  → Job created in ingestion_jobs table
+  → Pipeline drainer picks up pending jobs
+  → extracting → generating → promoting → completed
+  → Client polls GET /api/ingestion/jobs every 3s
+  → UI updates in real-time
+```
+
+Rate-limit branch:
+```
+generating fails with rate limit
+  → Status set to rate_limited (not failed)
+  → retryAfter timestamp stored
+  → Drainer checks rate_limited jobs each cycle
+  → When retryAfter passes, reset to pending
+  → Normal pipeline resumes
+```
+
+## Files to Create/Modify
+
+### New files
+- `dashboard/src/app/api/ingestion/jobs/route.ts` — jobs list endpoint
+- `dashboard/src/app/api/ingestion/jobs/[id]/route.ts` — job detail endpoint
+- `dashboard/src/app/api/ingestion/retry/[id]/route.ts` — retry endpoint
+- `dashboard/src/app/api/ingestion/settings/route.ts` — settings endpoint
+- `dashboard/src/hooks/useFileUpload.ts` — upload staging hook
+- `dashboard/src/hooks/useIngestionJobs.ts` — job polling hook
+
+### Modified files
+- `dashboard/src/app/upload/page.tsx` — full rewrite with new layout
+- `dashboard/src/app/api/upload/route.ts` — multi-file support
+- `src/ingestion/pipeline.ts` — rate_limited status, auto-retry logic, dynamic concurrency
+- `src/db.ts` — add `retry_after` column, `rate_limited` status handling, `settings` table, read/write helpers

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,7 +38,9 @@ export const SENDER_ALLOWLIST_PATH = path.join(
   'nanoclaw',
   'sender-allowlist.json',
 );
-export const STORE_DIR = path.resolve(PROJECT_ROOT, 'store');
+export const STORE_DIR = process.env.STORE_DIR
+  ? path.resolve(process.env.STORE_DIR)
+  : path.resolve(PROJECT_ROOT, 'store');
 export const GROUPS_DIR = path.resolve(PROJECT_ROOT, 'groups');
 export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
 

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -15,6 +15,13 @@ import {
   updateTask,
 } from './db.js';
 import { getTrackedDoc, upsertTrackedDoc, deleteTrackedDoc } from './db.js';
+import {
+  createIngestionJob,
+  updateIngestionJob,
+  getIngestionJobs,
+  getSetting,
+  setSetting,
+} from './db.js';
 
 beforeEach(() => {
   _initTestDatabase();
@@ -514,5 +521,70 @@ describe('rag_index_tracker', () => {
 
   it('deleteTrackedDoc is safe for nonexistent path', () => {
     expect(() => deleteTrackedDoc('nope.md')).not.toThrow();
+  });
+});
+
+// --- updateIngestionJob: retry_after, retry_count, promoted_paths ---
+
+describe('updateIngestionJob retry/promoted fields', () => {
+  it('stores and retrieves retry_after via updateIngestionJob', () => {
+    createIngestionJob('job-r1', '/upload/file.pdf', 'file.pdf');
+    updateIngestionJob('job-r1', { retry_after: '2026-04-01T12:00:00.000Z' });
+    const jobs = getIngestionJobs() as Array<Record<string, unknown>>;
+    const job = jobs.find((j) => j['id'] === 'job-r1');
+    expect(job).toBeDefined();
+    expect(job!['retry_after']).toBe('2026-04-01T12:00:00.000Z');
+  });
+
+  it('stores and retrieves retry_count via updateIngestionJob', () => {
+    createIngestionJob('job-r2', '/upload/file.pdf', 'file.pdf');
+    updateIngestionJob('job-r2', { retry_count: 3 });
+    const jobs = getIngestionJobs() as Array<Record<string, unknown>>;
+    const job = jobs.find((j) => j['id'] === 'job-r2');
+    expect(job!['retry_count']).toBe(3);
+  });
+
+  it('stores and retrieves promoted_paths via updateIngestionJob', () => {
+    createIngestionJob('job-r3', '/upload/file.pdf', 'file.pdf');
+    const paths = JSON.stringify(['vault/concepts/foo.md', 'vault/sources/bar.md']);
+    updateIngestionJob('job-r3', { promoted_paths: paths });
+    const jobs = getIngestionJobs() as Array<Record<string, unknown>>;
+    const job = jobs.find((j) => j['id'] === 'job-r3');
+    expect(job!['promoted_paths']).toBe(paths);
+  });
+
+  it('clears retry_after by setting null', () => {
+    createIngestionJob('job-r4', '/upload/file.pdf', 'file.pdf');
+    updateIngestionJob('job-r4', { retry_after: '2026-04-01T12:00:00.000Z' });
+    updateIngestionJob('job-r4', { retry_after: null });
+    const jobs = getIngestionJobs() as Array<Record<string, unknown>>;
+    const job = jobs.find((j) => j['id'] === 'job-r4');
+    expect(job!['retry_after']).toBeNull();
+  });
+});
+
+// --- getSetting / setSetting ---
+
+describe('getSetting and setSetting', () => {
+  it('getSetting returns defaultValue when key does not exist', () => {
+    expect(getSetting('nonexistent.key', 'default-val')).toBe('default-val');
+  });
+
+  it('setSetting stores a value and getSetting retrieves it', () => {
+    setSetting('ingestion.max_retries', '5');
+    expect(getSetting('ingestion.max_retries', '0')).toBe('5');
+  });
+
+  it('setSetting overwrites an existing value', () => {
+    setSetting('ingestion.mode', 'auto');
+    setSetting('ingestion.mode', 'manual');
+    expect(getSetting('ingestion.mode', 'auto')).toBe('manual');
+  });
+
+  it('setSetting handles multiple independent keys', () => {
+    setSetting('key.a', 'alpha');
+    setSetting('key.b', 'beta');
+    expect(getSetting('key.a', '')).toBe('alpha');
+    expect(getSetting('key.b', '')).toBe('beta');
   });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -172,6 +172,30 @@ function createSchema(database: Database.Database): void {
   } catch {
     /* column/index already exists */
   }
+  try {
+    database.exec(`ALTER TABLE ingestion_jobs ADD COLUMN retry_after TEXT`);
+  } catch {
+    /* column already exists */
+  }
+  try {
+    database.exec(
+      `ALTER TABLE ingestion_jobs ADD COLUMN retry_count INTEGER DEFAULT 0`,
+    );
+  } catch {
+    /* column already exists */
+  }
+  try {
+    database.exec(`ALTER TABLE ingestion_jobs ADD COLUMN promoted_paths TEXT`);
+  } catch {
+    /* column already exists */
+  }
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS settings (
+      key        TEXT PRIMARY KEY,
+      value      TEXT NOT NULL,
+      updated_at TEXT DEFAULT (datetime('now'))
+    )
+  `);
 
   // Add channel and is_group columns if they don't exist (migration for existing DBs)
   try {
@@ -778,6 +802,9 @@ export function updateIngestionJob(
     extraction_path?: string | null;
     error?: string | null;
     content_hash?: string;
+    retry_after?: string | null;
+    retry_count?: number;
+    promoted_paths?: string | null;
   },
 ): void {
   const setClauses: string[] = ["updated_at = datetime('now')"];
@@ -802,6 +829,18 @@ export function updateIngestionJob(
     setClauses.push('content_hash = ?');
     values.push(updates.content_hash);
   }
+  if (updates.retry_after !== undefined) {
+    setClauses.push('retry_after = ?');
+    values.push(updates.retry_after);
+  }
+  if (updates.retry_count !== undefined) {
+    setClauses.push('retry_count = ?');
+    values.push(updates.retry_count);
+  }
+  if (updates.promoted_paths !== undefined) {
+    setClauses.push('promoted_paths = ?');
+    values.push(updates.promoted_paths);
+  }
 
   values.push(id);
   getDb()
@@ -815,6 +854,25 @@ export function getRecentlyCompletedJobs(limit: number = 10): unknown[] {
       `SELECT * FROM ingestion_jobs WHERE status = 'completed' ORDER BY completed_at DESC LIMIT ?`,
     )
     .all(limit);
+}
+
+// --- Settings ---
+
+export function getSetting(key: string, defaultValue: string): string {
+  const row = getDb()
+    .prepare('SELECT value FROM settings WHERE key = ?')
+    .get(key) as { value: string } | undefined;
+  return row !== undefined ? row.value : defaultValue;
+}
+
+export function setSetting(key: string, value: string): void {
+  getDb()
+    .prepare(
+      `INSERT INTO settings (key, value, updated_at)
+       VALUES (?, ?, datetime('now'))
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+    )
+    .run(key, value);
 }
 
 // --- RAG index tracker ---

--- a/src/db.ts
+++ b/src/db.ts
@@ -777,6 +777,10 @@ export function createIngestionJob(
     .run(id, sourcePath, sourceFilename, contentHash ?? null);
 }
 
+export function getIngestionJobById(id: string): unknown | undefined {
+  return getDb().prepare('SELECT * FROM ingestion_jobs WHERE id = ?').get(id);
+}
+
 export function getIngestionJobs(status?: string): unknown[] {
   if (status !== undefined) {
     return db

--- a/src/db.ts
+++ b/src/db.ts
@@ -181,6 +181,9 @@ function createSchema(database: Database.Database): void {
     database.exec(
       `ALTER TABLE ingestion_jobs ADD COLUMN retry_count INTEGER DEFAULT 0`,
     );
+    database.exec(
+      `UPDATE ingestion_jobs SET retry_count = 0 WHERE retry_count IS NULL`,
+    );
   } catch {
     /* column already exists */
   }

--- a/src/ingestion/index.ts
+++ b/src/ingestion/index.ts
@@ -21,6 +21,8 @@ import {
   getIngestionJobByPath,
   getCompletedJobByHash,
   updateIngestionJob,
+  getSetting,
+  getIngestionJobs,
 } from '../db.js';
 import { RegisteredGroup } from '../types.js';
 import { logger } from '../logger.js';
@@ -30,6 +32,14 @@ import {
   SENTINEL_TIMEOUT,
   PROCESSED_DIR,
 } from '../config.js';
+
+const RATE_LIMIT_PATTERNS = [
+  /rate.?limit/i, /session.?limit/i, /overloaded/i,
+  /429/, /529/, /too many requests/i, /capacity/i,
+];
+function isRateLimitError(msg: string): boolean {
+  return RATE_LIMIT_PATTERNS.some((re) => re.test(msg));
+}
 
 export interface IngestionPipelineOpts {
   uploadDir: string;
@@ -64,7 +74,10 @@ export class IngestionPipeline {
       onGenerate: (job) => this.handleGeneration(job),
       onPromote: (job) => this.handlePromotion(job),
       maxExtractionConcurrent: MAX_EXTRACTION_CONCURRENT,
-      maxGenerationConcurrent: opts.maxGenerationConcurrent ?? 1,
+      maxGenerationConcurrent: () => {
+        const val = getSetting('maxGenerationConcurrent', '1');
+        return Math.max(1, Math.min(5, parseInt(val, 10) || 1));
+      },
       pollIntervalMs: 5000,
     });
   }
@@ -316,19 +329,47 @@ export class IngestionPipeline {
       validationPromise,
     ]);
 
-    // If the container errored, that takes priority.
+    // Collect the error (if any) from either promise.
+    let error: Error | undefined;
     if (containerSettled.status === 'rejected') {
-      throw containerSettled.reason;
+      error = containerSettled.reason instanceof Error
+        ? containerSettled.reason
+        : new Error(String(containerSettled.reason));
+    } else if (validationSettled.status === 'rejected') {
+      error = validationSettled.reason instanceof Error
+        ? validationSettled.reason
+        : new Error(String(validationSettled.reason));
+    } else {
+      const result = containerSettled.value;
+      if (result.status === 'error') {
+        error = new Error(result.error || 'Agent processing failed');
+      }
     }
 
-    // If validation errored (and the container didn't), surface that.
-    if (validationSettled.status === 'rejected') {
-      throw validationSettled.reason;
-    }
+    if (error) {
+      const msg = error.message;
+      if (isRateLimitError(msg)) {
+        // Look up current retry_count from DB
+        const allJobs = getIngestionJobs('generating') as JobRow[];
+        const current = allJobs.find((j) => j.id === job.id);
+        const retryCount = current?.retry_count ?? 0;
+        const delays = [5 * 60_000, 15 * 60_000, 60 * 60_000]; // 5min, 15min, 60min
+        const delay = delays[Math.min(retryCount, delays.length - 1)];
+        const retryAfter = new Date(Date.now() + delay).toISOString();
 
-    const result = containerSettled.value;
-    if (result.status === 'error') {
-      throw new Error(result.error || 'Agent processing failed');
+        updateIngestionJob(job.id, {
+          status: 'rate_limited',
+          error: `generating:${msg}`,
+          retry_after: retryAfter,
+          retry_count: retryCount + 1,
+        });
+        logger.warn(
+          { jobId: job.id, retryAfter, retryCount: retryCount + 1 },
+          `ingestion: Rate limited, will retry after ${retryAfter}`,
+        );
+        return; // Do NOT re-throw — prevent drainer catch from overriding to 'failed'
+      }
+      throw error;
     }
 
     updateIngestionJob(job.id, { status: 'generated' });
@@ -400,7 +441,10 @@ export class IngestionPipeline {
     await this.extractor.cleanup(job.id);
     await this.pruneEmptyDirs(dirname(job.source_path));
 
-    updateIngestionJob(job.id, { status: 'completed' });
+    updateIngestionJob(job.id, {
+      status: 'completed',
+      promoted_paths: JSON.stringify(promotedPaths),
+    });
 
     logger.info(
       { jobId: job.id, relativePath, notes: promotedPaths.length },

--- a/src/ingestion/index.ts
+++ b/src/ingestion/index.ts
@@ -34,8 +34,13 @@ import {
 } from '../config.js';
 
 const RATE_LIMIT_PATTERNS = [
-  /rate.?limit/i, /session.?limit/i, /overloaded/i,
-  /429/, /529/, /too many requests/i, /capacity/i,
+  /rate.?limit/i,
+  /session.?limit/i,
+  /overloaded/i,
+  /429/,
+  /529/,
+  /too many requests/i,
+  /capacity/i,
 ];
 function isRateLimitError(msg: string): boolean {
   return RATE_LIMIT_PATTERNS.some((re) => re.test(msg));
@@ -332,13 +337,15 @@ export class IngestionPipeline {
     // Collect the error (if any) from either promise.
     let error: Error | undefined;
     if (containerSettled.status === 'rejected') {
-      error = containerSettled.reason instanceof Error
-        ? containerSettled.reason
-        : new Error(String(containerSettled.reason));
+      error =
+        containerSettled.reason instanceof Error
+          ? containerSettled.reason
+          : new Error(String(containerSettled.reason));
     } else if (validationSettled.status === 'rejected') {
-      error = validationSettled.reason instanceof Error
-        ? validationSettled.reason
-        : new Error(String(validationSettled.reason));
+      error =
+        validationSettled.reason instanceof Error
+          ? validationSettled.reason
+          : new Error(String(validationSettled.reason));
     } else {
       const result = containerSettled.value;
       if (result.status === 'error') {
@@ -361,7 +368,6 @@ export class IngestionPipeline {
           status: 'rate_limited',
           error: `generating:${msg}`,
           retry_after: retryAfter,
-          retry_count: retryCount + 1,
         });
         logger.warn(
           { jobId: job.id, retryAfter, retryCount: retryCount + 1 },

--- a/src/ingestion/job-recovery.ts
+++ b/src/ingestion/job-recovery.ts
@@ -6,7 +6,7 @@ import { logger } from '../logger.js';
  * No auto-retry — failures surface in the dashboard for manual re-upload.
  */
 export function markInterruptedJobsFailed(): number {
-  const inProgressStatuses = ['extracting', 'generating', 'promoting'];
+  const inProgressStatuses = ['extracting', 'generating', 'promoting', 'rate_limited'];
   let count = 0;
 
   for (const status of inProgressStatuses) {

--- a/src/ingestion/pipeline.test.ts
+++ b/src/ingestion/pipeline.test.ts
@@ -4,8 +4,9 @@ import {
   createIngestionJob,
   getJobsByStatus,
   updateIngestionJob,
+  setSetting,
 } from '../db.js';
-import { PipelineDrainer } from './pipeline.js';
+import { PipelineDrainer, JobRow } from './pipeline.js';
 
 beforeEach(() => {
   _initTestDatabase();
@@ -90,5 +91,239 @@ describe('PipelineDrainer', () => {
     expect(promoted).toContain('job-3');
     const jobs = getJobsByStatus('promoting') as Array<{ id: string }>;
     expect(jobs.some((j) => j.id === 'job-3')).toBe(true);
+  });
+
+  describe('drainRateLimited', () => {
+    it('resets past-due rate_limited jobs to correct status based on error prefix', async () => {
+      const pastDate = new Date(Date.now() - 60_000).toISOString();
+
+      createIngestionJob('rl-1', '/uploads/rl-1.pdf', 'rl-1.pdf');
+      updateIngestionJob('rl-1', {
+        status: 'rate_limited',
+        error: 'extracting:rate limit exceeded',
+        retry_after: pastDate,
+        retry_count: 0,
+      });
+
+      createIngestionJob('rl-2', '/uploads/rl-2.pdf', 'rl-2.pdf');
+      updateIngestionJob('rl-2', {
+        status: 'rate_limited',
+        error: 'generating:429 too many requests',
+        retry_after: pastDate,
+        retry_count: 1,
+      });
+
+      createIngestionJob('rl-3', '/uploads/rl-3.pdf', 'rl-3.pdf');
+      updateIngestionJob('rl-3', {
+        status: 'rate_limited',
+        error: 'promoting:overloaded',
+        retry_after: pastDate,
+        retry_count: 2,
+      });
+
+      const drainer = new PipelineDrainer({
+        onExtract: async () => {},
+        onGenerate: async () => {},
+        onPromote: async () => {},
+        maxExtractionConcurrent: 2,
+        maxGenerationConcurrent: 2,
+        pollIntervalMs: 100,
+      });
+
+      drainer.drainRateLimited();
+
+      // rl-1 should be reset to 'pending' (extracting → pending)
+      const pending = getJobsByStatus('pending') as JobRow[];
+      expect(pending.some((j) => j.id === 'rl-1')).toBe(true);
+      const rl1 = pending.find((j) => j.id === 'rl-1')!;
+      expect(rl1.retry_count).toBe(1);
+      expect(rl1.error).toBeNull();
+
+      // rl-2 should be reset to 'extracted' (generating → extracted)
+      const extracted = getJobsByStatus('extracted') as JobRow[];
+      expect(extracted.some((j) => j.id === 'rl-2')).toBe(true);
+      const rl2 = extracted.find((j) => j.id === 'rl-2')!;
+      expect(rl2.retry_count).toBe(2);
+
+      // rl-3 should be reset to 'generated' (promoting → generated)
+      const generated = getJobsByStatus('generated') as JobRow[];
+      expect(generated.some((j) => j.id === 'rl-3')).toBe(true);
+      const rl3 = generated.find((j) => j.id === 'rl-3')!;
+      expect(rl3.retry_count).toBe(3);
+    });
+
+    it('skips jobs whose retry_after is in the future', () => {
+      const futureDate = new Date(Date.now() + 600_000).toISOString();
+
+      createIngestionJob('rl-future', '/uploads/rl-future.pdf', 'rl-future.pdf');
+      updateIngestionJob('rl-future', {
+        status: 'rate_limited',
+        error: 'generating:rate limit',
+        retry_after: futureDate,
+        retry_count: 0,
+      });
+
+      const drainer = new PipelineDrainer({
+        onExtract: async () => {},
+        onGenerate: async () => {},
+        onPromote: async () => {},
+        maxExtractionConcurrent: 2,
+        maxGenerationConcurrent: 2,
+        pollIntervalMs: 100,
+      });
+
+      drainer.drainRateLimited();
+
+      // Should still be rate_limited
+      const rateLimited = getJobsByStatus('rate_limited') as JobRow[];
+      expect(rateLimited.some((j) => j.id === 'rl-future')).toBe(true);
+    });
+  });
+
+  describe('stage-prefixed errors', () => {
+    it('prefixes extraction errors with extracting:', async () => {
+      createIngestionJob('ext-err', '/uploads/ext-err.pdf', 'ext-err.pdf');
+
+      const drainer = new PipelineDrainer({
+        onExtract: async () => {
+          throw new Error('disk full');
+        },
+        onGenerate: async () => {},
+        onPromote: async () => {},
+        maxExtractionConcurrent: 2,
+        maxGenerationConcurrent: 2,
+        pollIntervalMs: 100,
+      });
+
+      drainer.drain();
+      await vi.advanceTimersByTimeAsync(150);
+      await drainer.stop();
+
+      const failed = getJobsByStatus('failed') as JobRow[];
+      const job = failed.find((j) => j.id === 'ext-err');
+      expect(job).toBeDefined();
+      expect(job!.error).toBe('extracting:disk full');
+    });
+
+    it('prefixes generation errors with generating:', async () => {
+      createIngestionJob('gen-err', '/uploads/gen-err.pdf', 'gen-err.pdf');
+      updateIngestionJob('gen-err', { status: 'extracted' });
+
+      const drainer = new PipelineDrainer({
+        onExtract: async () => {},
+        onGenerate: async () => {
+          throw new Error('timeout');
+        },
+        onPromote: async () => {},
+        maxExtractionConcurrent: 2,
+        maxGenerationConcurrent: 2,
+        pollIntervalMs: 100,
+      });
+
+      drainer.drain();
+      await vi.advanceTimersByTimeAsync(150);
+      await drainer.stop();
+
+      const failed = getJobsByStatus('failed') as JobRow[];
+      const job = failed.find((j) => j.id === 'gen-err');
+      expect(job).toBeDefined();
+      expect(job!.error).toBe('generating:timeout');
+    });
+
+    it('prefixes promotion errors with promoting:', async () => {
+      createIngestionJob('prom-err', '/uploads/prom-err.pdf', 'prom-err.pdf');
+      updateIngestionJob('prom-err', { status: 'generated' });
+
+      const drainer = new PipelineDrainer({
+        onExtract: async () => {},
+        onGenerate: async () => {},
+        onPromote: async () => {
+          throw new Error('vault locked');
+        },
+        maxExtractionConcurrent: 2,
+        maxGenerationConcurrent: 2,
+        pollIntervalMs: 100,
+      });
+
+      drainer.drain();
+      await vi.advanceTimersByTimeAsync(150);
+      await drainer.stop();
+
+      const failed = getJobsByStatus('failed') as JobRow[];
+      const job = failed.find((j) => j.id === 'prom-err');
+      expect(job).toBeDefined();
+      expect(job!.error).toBe('promoting:vault locked');
+    });
+  });
+
+  describe('dynamic concurrency', () => {
+    it('calls getter function for maxGenerationConcurrent', async () => {
+      createIngestionJob('dyn-1', '/uploads/dyn-1.pdf', 'dyn-1.pdf');
+      updateIngestionJob('dyn-1', { status: 'extracted' });
+      createIngestionJob('dyn-2', '/uploads/dyn-2.pdf', 'dyn-2.pdf');
+      updateIngestionJob('dyn-2', { status: 'extracted' });
+      createIngestionJob('dyn-3', '/uploads/dyn-3.pdf', 'dyn-3.pdf');
+      updateIngestionJob('dyn-3', { status: 'extracted' });
+
+      const getter = vi.fn().mockReturnValue(2);
+      const generated: string[] = [];
+      const drainer = new PipelineDrainer({
+        onExtract: async () => {},
+        onGenerate: async (job) => {
+          generated.push(job.id);
+        },
+        onPromote: async () => {},
+        maxExtractionConcurrent: 2,
+        maxGenerationConcurrent: getter,
+        pollIntervalMs: 100,
+      });
+
+      drainer.drain();
+      await vi.advanceTimersByTimeAsync(150);
+      await drainer.stop();
+
+      expect(getter).toHaveBeenCalled();
+      // Should start at most 2 jobs (the getter returns 2)
+      const generating = getJobsByStatus('generating') as JobRow[];
+      expect(generating.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe('tick ordering', () => {
+    it('calls drainRateLimited before other drain methods', async () => {
+      // Set up a rate_limited job with generating error prefix
+      // so it resets to 'extracted', which drainGenerations will then pick up
+      const pastDate = new Date(Date.now() - 60_000).toISOString();
+      createIngestionJob('tick-rl', '/uploads/tick-rl.pdf', 'tick-rl.pdf');
+      updateIngestionJob('tick-rl', {
+        status: 'rate_limited',
+        error: 'generating:rate limit',
+        retry_after: pastDate,
+        retry_count: 0,
+        extraction_path: '/tmp/ext',
+      });
+
+      const generatedIds: string[] = [];
+      const drainer = new PipelineDrainer({
+        onExtract: async () => {},
+        onGenerate: async (job) => {
+          generatedIds.push(job.id);
+        },
+        onPromote: async () => {},
+        maxExtractionConcurrent: 2,
+        maxGenerationConcurrent: 2,
+        pollIntervalMs: 100,
+      });
+
+      await drainer.tick();
+
+      // drainRateLimited ran first, resetting to 'extracted',
+      // then drainGenerations picked it up
+      const rateLimited = getJobsByStatus('rate_limited') as JobRow[];
+      expect(rateLimited).toHaveLength(0);
+
+      // The job should have been picked up by onGenerate
+      expect(generatedIds).toContain('tick-rl');
+    });
   });
 });

--- a/src/ingestion/pipeline.ts
+++ b/src/ingestion/pipeline.ts
@@ -8,6 +8,9 @@ export interface JobRow {
   extraction_path: string | null;
   created_at: string;
   updated_at: string;
+  retry_after?: string | null;
+  retry_count?: number;
+  error?: string | null;
 }
 
 export interface PipelineDrainerOpts {
@@ -16,7 +19,7 @@ export interface PipelineDrainerOpts {
   onPromote: (job: JobRow) => Promise<void>;
   onComplete?: (job: JobRow) => Promise<void>;
   maxExtractionConcurrent: number;
-  maxGenerationConcurrent: number;
+  maxGenerationConcurrent: number | (() => number);
   pollIntervalMs: number;
 }
 
@@ -29,6 +32,11 @@ export class PipelineDrainer {
 
   constructor(opts: PipelineDrainerOpts) {
     this.opts = opts;
+  }
+
+  private getMaxGenerationConcurrent(): number {
+    const val = this.opts.maxGenerationConcurrent;
+    return typeof val === 'function' ? val() : val;
   }
 
   drain(): void {
@@ -49,9 +57,44 @@ export class PipelineDrainer {
   }
 
   async tick(): Promise<void> {
+    this.drainRateLimited();
     await this.drainExtractions();
     await this.drainGenerations();
     await this.drainPromotions();
+  }
+
+  private static readonly STAGE_RESET_MAP: Record<string, string> = {
+    extracting: 'pending',
+    generating: 'extracted',
+    promoting: 'generated',
+  };
+
+  drainRateLimited(): void {
+    const jobs = getJobsByStatus('rate_limited') as JobRow[];
+    const now = Date.now();
+
+    for (const job of jobs) {
+      if (job.retry_after) {
+        const retryAt = new Date(job.retry_after).getTime();
+        if (retryAt > now) continue;
+      }
+
+      // Determine reset status from the error prefix (e.g. "generating:rate limit exceeded")
+      let resetStatus = 'pending'; // fallback
+      if (job.error) {
+        const stage = job.error.split(':')[0];
+        if (PipelineDrainer.STAGE_RESET_MAP[stage]) {
+          resetStatus = PipelineDrainer.STAGE_RESET_MAP[stage];
+        }
+      }
+
+      updateIngestionJob(job.id, {
+        status: resetStatus,
+        error: null,
+        retry_after: null,
+        retry_count: (job.retry_count ?? 0) + 1,
+      });
+    }
   }
 
   async drainExtractions(): Promise<void> {
@@ -68,7 +111,7 @@ export class PipelineDrainer {
         .onExtract(job)
         .catch((err: unknown) => {
           const msg = err instanceof Error ? err.message : String(err);
-          updateIngestionJob(job.id, { status: 'failed', error: msg });
+          updateIngestionJob(job.id, { status: 'failed', error: `extracting:${msg}` });
         })
         .finally(() => {
           this.activeExtractions--;
@@ -79,13 +122,14 @@ export class PipelineDrainer {
   }
 
   async drainGenerations(): Promise<void> {
-    const slots = this.opts.maxGenerationConcurrent - this.activeGenerations;
+    const maxGen = this.getMaxGenerationConcurrent();
+    const slots = maxGen - this.activeGenerations;
     if (slots <= 0) return;
 
     const extracted = getJobsByStatus('extracted') as JobRow[];
 
     for (const job of extracted) {
-      if (this.activeGenerations >= this.opts.maxGenerationConcurrent) break;
+      if (this.activeGenerations >= maxGen) break;
 
       updateIngestionJob(job.id, { status: 'generating' });
       this.activeGenerations++;
@@ -93,7 +137,7 @@ export class PipelineDrainer {
         .onGenerate(job)
         .catch((err: unknown) => {
           const msg = err instanceof Error ? err.message : String(err);
-          updateIngestionJob(job.id, { status: 'failed', error: msg });
+          updateIngestionJob(job.id, { status: 'failed', error: `generating:${msg}` });
         })
         .finally(() => {
           this.activeGenerations--;
@@ -111,7 +155,7 @@ export class PipelineDrainer {
         await this.opts.onPromote(job);
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
-        updateIngestionJob(job.id, { status: 'failed', error: msg });
+        updateIngestionJob(job.id, { status: 'failed', error: `promoting:${msg}` });
       }
     }
   }

--- a/src/shared/db-reader.test.ts
+++ b/src/shared/db-reader.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  _initTestDatabase,
+  createIngestionJob,
+  updateIngestionJob,
+} from '../db.js';
+import {
+  getRecentJobs,
+  getJobDetail,
+  getJobSourcePath,
+  retryJob,
+  getSettings,
+  updateSettings,
+} from './db-reader.js';
+
+beforeEach(() => {
+  _initTestDatabase();
+});
+
+// --- getRecentJobs ---
+
+describe('getRecentJobs', () => {
+  it('returns jobs ordered by created_at desc', () => {
+    createIngestionJob('job-a', '/upload/a.pdf', 'a.pdf');
+    createIngestionJob('job-b', '/upload/b.pdf', 'b.pdf');
+    createIngestionJob('job-c', '/upload/c.pdf', 'c.pdf');
+
+    const jobs = getRecentJobs();
+    expect(jobs.length).toBeGreaterThanOrEqual(3);
+    // All three jobs should be present (order by created_at DESC)
+    const ids = jobs.map((j) => j.id);
+    expect(ids).toContain('job-a');
+    expect(ids).toContain('job-b');
+    expect(ids).toContain('job-c');
+    // Verify DESC ordering: no job's createdAt should be before the next job's
+    for (let i = 0; i < jobs.length - 1; i++) {
+      expect(jobs[i].createdAt >= jobs[i + 1].createdAt).toBe(true);
+    }
+  });
+
+  it('filters by status', () => {
+    createIngestionJob('pend-1', '/upload/p1.pdf', 'p1.pdf');
+    createIngestionJob('pend-2', '/upload/p2.pdf', 'p2.pdf');
+    createIngestionJob('comp-1', '/upload/c1.pdf', 'c1.pdf');
+    updateIngestionJob('comp-1', { status: 'completed' });
+
+    const pending = getRecentJobs('pending');
+    expect(pending).toHaveLength(2);
+    expect(pending.every((j) => j.status === 'pending')).toBe(true);
+
+    const completed = getRecentJobs('completed');
+    expect(completed).toHaveLength(1);
+    expect(completed[0].id).toBe('comp-1');
+  });
+
+  it('limits results to 20', () => {
+    for (let i = 1; i <= 25; i++) {
+      createIngestionJob(`limit-job-${i}`, `/upload/f${i}.pdf`, `f${i}.pdf`);
+    }
+
+    const jobs = getRecentJobs();
+    expect(jobs).toHaveLength(20);
+  });
+});
+
+// --- getJobDetail ---
+
+describe('getJobDetail', () => {
+  it('returns null for a non-existent job', () => {
+    const detail = getJobDetail('no-such-id');
+    expect(detail).toBeNull();
+  });
+
+  it('returns promoted paths parsed from JSON for completed jobs', () => {
+    createIngestionJob('detail-1', '/upload/d1.pdf', 'd1.pdf');
+    updateIngestionJob('detail-1', {
+      status: 'completed',
+      promoted_paths: JSON.stringify(['vault/sources/d1.md', 'vault/concepts/topic.md']),
+    });
+
+    const detail = getJobDetail('detail-1');
+    expect(detail).not.toBeNull();
+    expect(detail!.promotedPaths).toEqual([
+      'vault/sources/d1.md',
+      'vault/concepts/topic.md',
+    ]);
+    expect(detail!.status).toBe('completed');
+  });
+
+  it('returns promotedPaths as null when promoted_paths is not set', () => {
+    createIngestionJob('detail-2', '/upload/d2.pdf', 'd2.pdf');
+    const detail = getJobDetail('detail-2');
+    expect(detail).not.toBeNull();
+    expect(detail!.promotedPaths).toBeNull();
+  });
+
+  it('maps all camelCase fields correctly', () => {
+    createIngestionJob('detail-3', '/upload/d3.pdf', 'd3.pdf');
+    const detail = getJobDetail('detail-3');
+    expect(detail).not.toBeNull();
+    expect(detail!.filename).toBe('d3.pdf');
+    expect(detail!.status).toBe('pending');
+    expect(detail!.error).toBeNull();
+    expect(detail!.retryAfter).toBeNull();
+    expect(typeof detail!.retryCount).toBe('number');
+    expect(typeof detail!.createdAt).toBe('string');
+    expect(typeof detail!.updatedAt).toBe('string');
+    expect(detail!.completedAt).toBeNull();
+  });
+});
+
+// --- retryJob ---
+
+describe('retryJob', () => {
+  it('resets a failed extracting job to pending', () => {
+    createIngestionJob('retry-1', '/upload/r1.pdf', 'r1.pdf');
+    updateIngestionJob('retry-1', {
+      status: 'failed',
+      error: 'extracting: Docling timed out',
+    });
+
+    const result = retryJob('retry-1');
+    expect(result).toEqual({ ok: true });
+
+    const detail = getJobDetail('retry-1');
+    expect(detail!.status).toBe('pending');
+    expect(detail!.error).toBeNull();
+    expect(detail!.retryAfter).toBeNull();
+  });
+
+  it('resets a failed generating job to extracted', () => {
+    createIngestionJob('retry-2', '/upload/r2.pdf', 'r2.pdf');
+    updateIngestionJob('retry-2', {
+      status: 'failed',
+      error: 'generating: Claude API error',
+    });
+
+    const result = retryJob('retry-2');
+    expect(result).toEqual({ ok: true });
+
+    const detail = getJobDetail('retry-2');
+    expect(detail!.status).toBe('extracted');
+  });
+
+  it('resets a failed promoting job to generated', () => {
+    createIngestionJob('retry-3', '/upload/r3.pdf', 'r3.pdf');
+    updateIngestionJob('retry-3', {
+      status: 'failed',
+      error: 'promoting: vault write failed',
+    });
+
+    const result = retryJob('retry-3');
+    expect(result).toEqual({ ok: true });
+
+    const detail = getJobDetail('retry-3');
+    expect(detail!.status).toBe('generated');
+  });
+
+  it('resets a failed job with unknown prefix to pending', () => {
+    createIngestionJob('retry-4', '/upload/r4.pdf', 'r4.pdf');
+    updateIngestionJob('retry-4', {
+      status: 'failed',
+      error: 'unknown error occurred',
+    });
+
+    const result = retryJob('retry-4');
+    expect(result).toEqual({ ok: true });
+
+    const detail = getJobDetail('retry-4');
+    expect(detail!.status).toBe('pending');
+  });
+
+  it('returns error for a non-failed job', () => {
+    createIngestionJob('retry-5', '/upload/r5.pdf', 'r5.pdf');
+    // status is 'pending' by default
+
+    const result = retryJob('retry-5');
+    expect(result.ok).toBe(false);
+    expect((result as { ok: false; error: string }).error).toMatch(/not in failed/i);
+  });
+
+  it('returns error for a non-existent job', () => {
+    const result = retryJob('no-such-job');
+    expect(result.ok).toBe(false);
+    expect((result as { ok: false; error: string }).error).toMatch(/not found/i);
+  });
+});
+
+// --- getSettings ---
+
+describe('getSettings', () => {
+  it('returns default maxGenerationConcurrent of 1 when no setting exists', () => {
+    const settings = getSettings();
+    expect(settings.maxGenerationConcurrent).toBe(1);
+  });
+});
+
+// --- updateSettings ---
+
+describe('updateSettings', () => {
+  it('stores and retrieves the maxGenerationConcurrent value', () => {
+    updateSettings({ maxGenerationConcurrent: 3 });
+    const settings = getSettings();
+    expect(settings.maxGenerationConcurrent).toBe(3);
+  });
+
+  it('clamps value to minimum of 1', () => {
+    updateSettings({ maxGenerationConcurrent: 0 });
+    expect(getSettings().maxGenerationConcurrent).toBe(1);
+  });
+
+  it('clamps value to maximum of 5', () => {
+    updateSettings({ maxGenerationConcurrent: 10 });
+    expect(getSettings().maxGenerationConcurrent).toBe(5);
+  });
+});

--- a/src/shared/db-reader.test.ts
+++ b/src/shared/db-reader.test.ts
@@ -76,7 +76,10 @@ describe('getJobDetail', () => {
     createIngestionJob('detail-1', '/upload/d1.pdf', 'd1.pdf');
     updateIngestionJob('detail-1', {
       status: 'completed',
-      promoted_paths: JSON.stringify(['vault/sources/d1.md', 'vault/concepts/topic.md']),
+      promoted_paths: JSON.stringify([
+        'vault/sources/d1.md',
+        'vault/concepts/topic.md',
+      ]),
     });
 
     const detail = getJobDetail('detail-1');
@@ -177,13 +180,17 @@ describe('retryJob', () => {
 
     const result = retryJob('retry-5');
     expect(result.ok).toBe(false);
-    expect((result as { ok: false; error: string }).error).toMatch(/not in failed/i);
+    expect((result as { ok: false; error: string }).error).toMatch(
+      /not in a retryable state/i,
+    );
   });
 
   it('returns error for a non-existent job', () => {
     const result = retryJob('no-such-job');
     expect(result.ok).toBe(false);
-    expect((result as { ok: false; error: string }).error).toMatch(/not found/i);
+    expect((result as { ok: false; error: string }).error).toMatch(
+      /not found/i,
+    );
   });
 });
 

--- a/src/shared/db-reader.ts
+++ b/src/shared/db-reader.ts
@@ -1,4 +1,5 @@
 import {
+  getIngestionJobById,
   getIngestionJobs,
   getSetting,
   setSetting,
@@ -51,8 +52,7 @@ export function getRecentJobs(status?: string): JobSummary[] {
  * Parses the promoted_paths JSON string into a string array.
  */
 export function getJobDetail(id: string): JobDetail | null {
-  const rows = getIngestionJobs() as DbRow[];
-  const row = rows.find((r) => r.id === id);
+  const row = getIngestionJobById(id) as DbRow | undefined;
   if (!row) return null;
 
   const summary = rowToSummary(row);
@@ -72,8 +72,7 @@ export function getJobDetail(id: string): JobDetail | null {
  * Returns the source_path for a job (used by retry endpoint to check file exists).
  */
 export function getJobSourcePath(id: string): string | null {
-  const rows = getIngestionJobs() as DbRow[];
-  const row = rows.find((r) => r.id === id);
+  const row = getIngestionJobById(id) as DbRow | undefined;
   return row ? (row.source_path as string) : null;
 }
 
@@ -90,15 +89,17 @@ const STAGE_MAP: Record<string, string> = {
 export function retryJob(
   id: string,
 ): { ok: true } | { ok: false; error: string } {
-  const rows = getIngestionJobs() as DbRow[];
-  const row = rows.find((r) => r.id === id);
+  const row = getIngestionJobById(id) as DbRow | undefined;
 
   if (!row) {
     return { ok: false, error: 'Job not found' };
   }
 
-  if (row.status !== 'failed') {
-    return { ok: false, error: `Job is not in failed state (status: ${row.status})` };
+  if (row.status !== 'failed' && row.status !== 'rate_limited') {
+    return {
+      ok: false,
+      error: `Job is not in a retryable state (status: ${row.status})`,
+    };
   }
 
   const errorStr = (row.error as string | null) ?? '';

--- a/src/shared/db-reader.ts
+++ b/src/shared/db-reader.ts
@@ -1,0 +1,136 @@
+import {
+  getIngestionJobs,
+  getSetting,
+  setSetting,
+  updateIngestionJob,
+} from '../db.js';
+
+export interface JobSummary {
+  id: string;
+  filename: string;
+  status: string;
+  error: string | null;
+  retryAfter: string | null;
+  retryCount: number;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+export interface JobDetail extends JobSummary {
+  promotedPaths: string[] | null;
+}
+
+type DbRow = Record<string, unknown>;
+
+function rowToSummary(row: DbRow): JobSummary {
+  return {
+    id: row.id as string,
+    filename: row.source_filename as string,
+    status: row.status as string,
+    error: (row.error as string | null) ?? null,
+    retryAfter: (row.retry_after as string | null) ?? null,
+    retryCount: (row.retry_count as number) ?? 0,
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
+    completedAt: (row.completed_at as string | null) ?? null,
+  };
+}
+
+/**
+ * Returns up to 20 recent ingestion jobs, optionally filtered by status.
+ * Results are ordered by created_at DESC (as returned by getIngestionJobs).
+ */
+export function getRecentJobs(status?: string): JobSummary[] {
+  const rows = getIngestionJobs(status) as DbRow[];
+  return rows.slice(0, 20).map(rowToSummary);
+}
+
+/**
+ * Returns full job detail for a single job, or null if not found.
+ * Parses the promoted_paths JSON string into a string array.
+ */
+export function getJobDetail(id: string): JobDetail | null {
+  const rows = getIngestionJobs() as DbRow[];
+  const row = rows.find((r) => r.id === id);
+  if (!row) return null;
+
+  const summary = rowToSummary(row);
+  let promotedPaths: string[] | null = null;
+  if (row.promoted_paths && typeof row.promoted_paths === 'string') {
+    try {
+      promotedPaths = JSON.parse(row.promoted_paths) as string[];
+    } catch {
+      promotedPaths = null;
+    }
+  }
+
+  return { ...summary, promotedPaths };
+}
+
+/**
+ * Returns the source_path for a job (used by retry endpoint to check file exists).
+ */
+export function getJobSourcePath(id: string): string | null {
+  const rows = getIngestionJobs() as DbRow[];
+  const row = rows.find((r) => r.id === id);
+  return row ? (row.source_path as string) : null;
+}
+
+const STAGE_MAP: Record<string, string> = {
+  extracting: 'pending',
+  generating: 'extracted',
+  promoting: 'generated',
+};
+
+/**
+ * Resets a failed job back to an appropriate status based on which stage it
+ * failed at (determined by the error message prefix).
+ */
+export function retryJob(
+  id: string,
+): { ok: true } | { ok: false; error: string } {
+  const rows = getIngestionJobs() as DbRow[];
+  const row = rows.find((r) => r.id === id);
+
+  if (!row) {
+    return { ok: false, error: 'Job not found' };
+  }
+
+  if (row.status !== 'failed') {
+    return { ok: false, error: `Job is not in failed state (status: ${row.status})` };
+  }
+
+  const errorStr = (row.error as string | null) ?? '';
+  const prefix = errorStr.split(':')[0].toLowerCase().trim();
+  const resetStatus = STAGE_MAP[prefix] ?? 'pending';
+
+  updateIngestionJob(id, {
+    status: resetStatus,
+    error: null,
+    retry_after: null,
+  });
+
+  return { ok: true };
+}
+
+/**
+ * Returns settings for the dashboard. Reads maxGenerationConcurrent,
+ * clamped to 1-5.
+ */
+export function getSettings(): { maxGenerationConcurrent: number } {
+  const raw = getSetting('maxGenerationConcurrent', '1');
+  const parsed = parseInt(raw, 10);
+  const clamped = Math.min(5, Math.max(1, isNaN(parsed) ? 1 : parsed));
+  return { maxGenerationConcurrent: clamped };
+}
+
+/**
+ * Stores settings. Clamps maxGenerationConcurrent to 1-5.
+ */
+export function updateSettings(settings: {
+  maxGenerationConcurrent: number;
+}): void {
+  const clamped = Math.min(5, Math.max(1, settings.maxGenerationConcurrent));
+  setSetting('maxGenerationConcurrent', String(clamped));
+}


### PR DESCRIPTION
## Summary

- **Multi-file upload** with drag-and-drop, PDF validation, 100MB size limit, and collision-safe filenames
- **Real-time job tracking** via 3-second polling — shows pipeline stages (extracting → generating → promoting → completed) with progress bars
- **Rate-limit recovery** — new `rate_limited` status with automatic backoff retry (5m → 15m → 60m), distinct from permanent failures
- **Stage-aware retry** — failed jobs restart from the last successful stage, not from scratch
- **Vault output preview** — completed jobs expand to show generated notes with links to the vault browser
- **Concurrency control** — configurable parallel generation jobs (1–5) via settings stored in SQLite
- **Shared DB layer** — dashboard accesses ingestion data via `better-sqlite3` with WAL mode for safe concurrent access

## Architecture

- `src/db.ts` — new columns (`retry_after`, `retry_count`, `promoted_paths`) + `settings` table
- `src/ingestion/pipeline.ts` — `drainRateLimited()`, dynamic concurrency, stage-prefixed errors
- `src/shared/db-reader.ts` — typed query layer + `dashboard/src/lib/ingestion-db.ts` (self-contained copy for Turbopack compatibility)
- 4 new API routes: `/api/ingestion/jobs`, `/api/ingestion/jobs/[id]`, `/api/ingestion/retry/[id]`, `/api/ingestion/settings`
- 2 React hooks: `useIngestionJobs` (polling), `useFileUpload` (staging + duplicate detection)
- 3 UI components: `DropZone`, `JobList`, `JobRow` — grouped collapsible layout

## Test plan

- [x] 562 tests passing (70 new), 46 test files
- [x] Dashboard builds cleanly with all routes
- [ ] Manual smoke test: upload PDF, observe pipeline stages, verify vault links
- [ ] Rate-limit recovery: trigger rate limit, verify auto-retry after backoff
- [ ] Retry: fail a job, click retry, verify stage-aware reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)