### PR TITLE
fix: draft cleanup, IPC path robustness, and docs accuracy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ dist/
 store/
 data/
 logs/
+ipc/
 
 # ------ Groups ------
 # Only track base structure and specific CLAUDE.md files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ This is a fork of NanoClaw customized as a personal university teaching assistan
 - `scripts/docling-extract.py` — Python document extraction script
 - `store/messages.db` — SQLite database (messages, tasks, ingestion jobs, RAG tracker)
 - `data/` — IPC files, extraction artifacts
-- `onecli/` — OneCLI credential gateway Docker Compose config
+- `onecli/` — OneCLI credential gateway config (containers already built; for new installs, run `/init-onecli`)
 
 ### Testing
 
@@ -114,18 +114,18 @@ universityClaw runs as a stack of 4 services. All must be running for full funct
 | Service | What it does | How to start | How to stop | Port |
 |---------|-------------|--------------|-------------|------|
 | **NanoClaw** | Main orchestrator (Node.js) | `npm run dev` | Ctrl+C or `kill <pid>` | — |
-| **LightRAG** | RAG server (Python) | `python3 -m lightrag.api.lightrag_server` | `kill <pid>` | 9621 |
-| **OneCLI** | Credential proxy (Docker) | `docker compose -f onecli/docker-compose.yml up -d` | `docker compose -f onecli/docker-compose.yml down` | 10254 |
+| **LightRAG** | RAG server (Python, venv) | `.venv/bin/python3 -m lightrag.api.lightrag_server --port 9621 --working-dir ./data/lightrag` | `pkill -f lightrag` | 9621 |
+| **OneCLI** | Credential proxy (Docker) | `docker restart onecli-app-1 onecli-postgres-1` | `docker stop onecli-app-1 onecli-postgres-1` | 10254 |
 | **Dashboard** | Web UI (Next.js) | `cd dashboard && npm run dev` | Ctrl+C or `kill <pid>` | 3100 |
 
 ### Start Everything
 
 ```bash
-# 1. OneCLI (credential proxy — Docker)
-docker compose -f onecli/docker-compose.yml up -d
+# 1. OneCLI (credential proxy — restart existing containers)
+docker restart onecli-app-1 onecli-postgres-1
 
-# 2. LightRAG (RAG server — background)
-python3 -m lightrag.api.lightrag_server &
+# 2. LightRAG (RAG server — uses .venv, reads config from .env)
+.venv/bin/python3 -m lightrag.api.lightrag_server --port 9621 --working-dir ./data/lightrag &
 
 # 3. Dashboard (web UI — background)
 cd dashboard && npm run dev &
@@ -144,7 +144,7 @@ pkill -f "tsx src/index.ts"
 pkill -f "next dev.*dashboard"
 
 # Stop OneCLI containers
-docker compose -f onecli/docker-compose.yml down
+docker stop onecli-app-1 onecli-postgres-1
 ```
 
 ### Verify Status
@@ -172,6 +172,10 @@ Key env vars (set in `.env` or shell). All have sensible defaults:
 | `MAX_CONCURRENT_CONTAINERS` | `5` | Parallel container limit |
 | `EXTRACTION_TIMEOUT` | `600000` (10min) | Docling per-document timeout |
 | `DASHBOARD_PORT` | `3100` | Dashboard web UI port |
+| `LLM_BINDING` | `ollama` | LightRAG LLM provider (entity extraction) |
+| `LLM_MODEL` | `qwen2.5:3b` | LightRAG LLM model |
+| `EMBEDDING_BINDING` | `ollama` | LightRAG embedding provider |
+| `EMBEDDING_MODEL` | `bge-m3:latest` | LightRAG embedding model |
 | `TZ` | auto-detected | Timezone for scheduling |
 
 ## Container Build Cache

--- a/src/index.ts
+++ b/src/index.ts
@@ -650,6 +650,7 @@ async function main(): Promise<void> {
     uploadDir: UPLOAD_DIR,
     vaultDir: VAULT_DIR,
     reviewAgentGroup: registeredGroups[REVIEW_AGENT_JID],
+    maxGenerationConcurrent: 2,
   });
   await pipeline.start();
 

--- a/src/ingestion/file-watcher.test.ts
+++ b/src/ingestion/file-watcher.test.ts
@@ -46,7 +46,14 @@ describe('FileWatcher', () => {
   });
 
   it('ignores non-PDF file types', async () => {
-    const files = ['file.docx', 'file.pptx', 'file.txt', 'file.md', 'file.png', 'file.csv'];
+    const files = [
+      'file.docx',
+      'file.pptx',
+      'file.txt',
+      'file.md',
+      'file.png',
+      'file.csv',
+    ];
     for (const name of files) {
       await writeFile(join(tmpDir, name), 'content');
     }

--- a/src/ingestion/index.ts
+++ b/src/ingestion/index.ts
@@ -82,7 +82,8 @@ export class IngestionPipeline {
       onPromote: (job) => this.handlePromotion(job),
       maxExtractionConcurrent: MAX_EXTRACTION_CONCURRENT,
       maxGenerationConcurrent: () => {
-        const val = getSetting('maxGenerationConcurrent', '1');
+        const fallback = String(opts.maxGenerationConcurrent ?? 1);
+        const val = getSetting('maxGenerationConcurrent', fallback);
         return Math.max(1, Math.min(5, parseInt(val, 10) || 1));
       },
       pollIntervalMs: 5000,

--- a/src/ingestion/index.ts
+++ b/src/ingestion/index.ts
@@ -14,6 +14,7 @@ import {
   sendIpcClose,
   sendIpcMessage,
   cleanupSentinel,
+  cleanupDraftBundle,
 } from './sentinel.js';
 import { validateDrafts, formatValidationMessage } from './draft-validator.js';
 import {
@@ -27,6 +28,7 @@ import {
 import { RegisteredGroup } from '../types.js';
 import { logger } from '../logger.js';
 import {
+  DATA_DIR,
   MAX_EXTRACTION_CONCURRENT,
   EXTRACTIONS_DIR,
   SENTINEL_TIMEOUT,
@@ -228,7 +230,6 @@ export class IngestionPipeline {
       throw new Error(`No extraction path for job ${job.id}`);
     }
 
-    const dataDir = process.cwd();
     const sentinelPath = join(draftsDir, `${job.id}-complete`);
 
     // Shared abort controller — either side can signal the other to stop.
@@ -256,7 +257,7 @@ export class IngestionPipeline {
             { jobId: job.id },
             'Sentinel timeout — sending IPC close',
           );
-          sendIpcClose(job.id, dataDir);
+          sendIpcClose(job.id, DATA_DIR);
           throw new Error('Agent did not complete within sentinel timeout');
         }
 
@@ -273,12 +274,12 @@ export class IngestionPipeline {
           // Tell the agent validation passed, then close the session
           sendIpcMessage(
             job.id,
-            dataDir,
+            DATA_DIR,
             'Output validation passed. Your work is complete. Shutting down.',
           );
           // Small delay so the agent receives the message before _close
           await new Promise((r) => setTimeout(r, 500));
-          sendIpcClose(job.id, dataDir);
+          sendIpcClose(job.id, DATA_DIR);
           return;
         }
 
@@ -295,11 +296,11 @@ export class IngestionPipeline {
           );
           sendIpcMessage(
             job.id,
-            dataDir,
+            DATA_DIR,
             `Validation failed after ${maxAttempts} attempts. Shutting down.\n\n${formatValidationMessage(validation)}`,
           );
           await new Promise((r) => setTimeout(r, 500));
-          sendIpcClose(job.id, dataDir);
+          sendIpcClose(job.id, DATA_DIR);
           // Signal the container to stop waiting
           ac.abort();
           throw new Error(
@@ -315,7 +316,7 @@ export class IngestionPipeline {
         }
 
         // Send corrections to agent via IPC — agent fixes and writes new sentinel
-        sendIpcMessage(job.id, dataDir, formatValidationMessage(validation));
+        sendIpcMessage(job.id, DATA_DIR, formatValidationMessage(validation));
       }
     };
 
@@ -442,8 +443,9 @@ export class IngestionPipeline {
       logger.warn({ jobId: job.id }, 'Failed to move source to processed/');
     }
 
-    // Cleanup
+    // Cleanup — sentinel, manifest, any remaining draft files, extraction artifacts
     cleanupSentinel(draftsDir, job.id);
+    cleanupDraftBundle(draftsDir, job.id);
     await this.extractor.cleanup(job.id);
     await this.pruneEmptyDirs(dirname(job.source_path));
 

--- a/src/ingestion/sentinel.ts
+++ b/src/ingestion/sentinel.ts
@@ -1,4 +1,10 @@
-import { existsSync, writeFileSync, unlinkSync, mkdirSync } from 'fs';
+import {
+  existsSync,
+  writeFileSync,
+  unlinkSync,
+  mkdirSync,
+  readdirSync,
+} from 'fs';
 import { join } from 'path';
 import { logger } from '../logger.js';
 
@@ -72,6 +78,31 @@ export function cleanupSentinel(draftsDir: string, jobId: string): void {
       unlinkSync(f);
     } catch {
       // Already deleted or never existed
+    }
+  }
+}
+
+/**
+ * Removes all remaining files belonging to a draft bundle ({jobId}-*).
+ * Called after promotion to clean up any leftover draft .md files.
+ * promoteNote() moves promoted drafts via renameSync, but files may remain
+ * if the manifest had concept_notes: [] or promotion partially failed.
+ */
+export function cleanupDraftBundle(draftsDir: string, jobId: string): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(draftsDir);
+  } catch {
+    return;
+  }
+  const prefix = `${jobId}-`;
+  for (const entry of entries) {
+    if (!entry.startsWith(prefix)) continue;
+    try {
+      unlinkSync(join(draftsDir, entry));
+      logger.info({ jobId, file: entry }, 'Cleaned up leftover draft file');
+    } catch {
+      // Already deleted
     }
   }
 }

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -148,49 +148,49 @@ export function startIpcWatcher(deps: IpcDeps): void {
                           'Voice file is not a .wav, skipping conversion',
                         );
                       } else {
-                      const oggPath = wavPath.replace(/\.wav$/, '.ogg');
+                        const oggPath = wavPath.replace(/\.wav$/, '.ogg');
 
-                      try {
-                        // Convert WAV to OGG Opus for Telegram voice bubbles
-                        await execFileAsync(
-                          'ffmpeg',
-                          [
-                            '-y',
-                            '-i',
-                            wavPath,
-                            '-c:a',
-                            'libopus',
-                            '-b:a',
-                            '48k',
-                            '-vbr',
-                            'on',
-                            '-application',
-                            'voip',
+                        try {
+                          // Convert WAV to OGG Opus for Telegram voice bubbles
+                          await execFileAsync(
+                            'ffmpeg',
+                            [
+                              '-y',
+                              '-i',
+                              wavPath,
+                              '-c:a',
+                              'libopus',
+                              '-b:a',
+                              '48k',
+                              '-vbr',
+                              'on',
+                              '-application',
+                              'voip',
+                              oggPath,
+                            ],
+                            { timeout: 30_000 },
+                          );
+
+                          await deps.sendVoice(
+                            data.chatJid,
                             oggPath,
-                          ],
-                          { timeout: 30_000 },
-                        );
+                            (data.caption as string) || undefined,
+                          );
+                          logger.info(
+                            { chatJid: data.chatJid, sourceGroup },
+                            'IPC voice message sent',
+                          );
 
-                        await deps.sendVoice(
-                          data.chatJid,
-                          oggPath,
-                          (data.caption as string) || undefined,
-                        );
-                        logger.info(
-                          { chatJid: data.chatJid, sourceGroup },
-                          'IPC voice message sent',
-                        );
-
-                        // Clean up audio files — safe because grammY's sendVoice
-                        // fully uploads the file before the promise resolves
-                        fs.unlink(wavPath, () => {});
-                        fs.unlink(oggPath, () => {});
-                      } catch (err) {
-                        logger.error(
-                          { file: wavPath, sourceGroup, err },
-                          'Failed to convert/send voice message',
-                        );
-                      }
+                          // Clean up audio files — safe because grammY's sendVoice
+                          // fully uploads the file before the promise resolves
+                          fs.unlink(wavPath, () => {});
+                          fs.unlink(oggPath, () => {});
+                        } catch (err) {
+                          logger.error(
+                            { file: wavPath, sourceGroup, err },
+                            'Failed to convert/send voice message',
+                          );
+                        }
                       }
                     }
                   }

--- a/src/rag/indexer.ts
+++ b/src/rag/indexer.ts
@@ -7,7 +7,14 @@ import type { RagClient } from './rag-client.js';
 import { parseFrontmatter } from '../vault/frontmatter.js';
 import { computeDocId } from './doc-id.js';
 
-/** Paths relative to vaultDir that should be indexed. */
+/**
+ * Paths relative to vaultDir that should be indexed into LightRAG.
+ * Only sources/, concepts/, and profile/archive/ are indexed.
+ * profile/ top-level docs (student profile, knowledge map, study log) are
+ * working documents read in full by the agent — not suitable for RAG retrieval.
+ * Explicitly excluded: drafts/ (working area for ingestion pipeline),
+ * attachments/ (binary figures), and any other top-level directories.
+ */
 const ALLOWED_PATHS = ['concepts', 'sources', 'profile/archive'];
 
 export class RagIndexer {

--- a/src/voice-validation.test.ts
+++ b/src/voice-validation.test.ts
@@ -32,7 +32,17 @@ describe('TTS validation', () => {
 
   describe('validateTtsLanguage', () => {
     it('accepts all supported languages', () => {
-      for (const lang of ['en', 'de', 'it', 'fr', 'es', 'pt', 'nl', 'ar', 'hi']) {
+      for (const lang of [
+        'en',
+        'de',
+        'it',
+        'fr',
+        'es',
+        'pt',
+        'nl',
+        'ar',
+        'hi',
+      ]) {
         expect(validateTtsLanguage(lang)).toBeNull();
       }
     });


### PR DESCRIPTION
## Summary
- Add `cleanupDraftBundle()` to remove leftover draft files after note promotion, fixing stale file accumulation in `vault/drafts/`
- Replace `process.cwd()` with `DATA_DIR` constant for IPC paths in the ingestion pipeline (more robust)
- Cap concurrent note generation at 2 (`maxGenerationConcurrent`)
- Fix indentation in `src/ipc.ts` voice conversion block
- Update CLAUDE.md service commands to match actual setup (venv paths, container names, LightRAG env vars)
- Add `ipc/` to `.gitignore` (runtime artifact, not source code)

## Test plan
- [ ] `npm test` passes
- [ ] Ingestion pipeline processes a file end-to-end without leftover drafts
- [ ] IPC paths resolve correctly with `DATA_DIR`

🤖 Generated with [Claude Code](https://claude.com/claude-code)