### PR TITLE
feat: Telegram attachment passthrough

### DIFF
--- a/docs/superpowers/specs/2026-04-02-extraction-cleanup-and-oversized-documents-design.md
+++ b/docs/superpowers/specs/2026-04-02-extraction-cleanup-and-oversized-documents-design.md
@@ -24,15 +24,29 @@ New file: `src/ingestion/extraction-cleaner.ts`
 
 A pure function `cleanExtraction(markdown: string): string` that takes Docling markdown and returns a cleaned version. Stateless and deterministic.
 
-**Cleanup rules, applied in order:**
+#### Block definition
 
-1. **Collapse noise blocks** — consecutive `<!-- page:N label:text -->` blocks on the same page where the text content (excluding the marker itself) is under 50 chars get merged into a single block. The merged block keeps one page marker and joins the text fragments with spaces. This handles Docling's table-cell-as-text-block explosion.
+Docling output is structured as a sequence of **blocks**. Each block consists of a `<!-- page:N label:TYPE -->` comment marker on its own line, followed by one or more lines of text content, terminated by a blank line (or end of file). Blocks are separated by blank lines. Example:
 
-2. **Strip references tail** — find a `## References` (or `## Bibliography`, `## Works Cited`) section header that appears at or after 60% through the document. Strip everything from that header onward. The position threshold prevents false positives on papers with an early "References" subsection.
+```markdown
+<!-- page:3 label:text -->
+Some content here
 
-3. **Strip supplementary tail** — same pattern for `## Appendix`, `## Supplementary`, `## Supporting Information` at or after 70% through the document.
+<!-- page:3 label:section_header -->
+## Next Section
+```
 
-4. **Deduplicate adjacent identical blocks** — if the same text content appears in consecutive blocks on the same page, keep only the first.
+The cleanup rules operate on these blocks as atomic units.
+
+#### Cleanup rules, applied in order:
+
+1. **Deduplicate adjacent identical blocks** — if the same text content appears in consecutive blocks on the same page, keep only the first. Runs first so subsequent rules operate on fewer blocks.
+
+2. **Collapse noise blocks** — consecutive `label:text` blocks on the same page where the text content (excluding the marker line) is under 50 chars get merged into a single block. The merged block keeps one page marker and joins the text fragments with spaces. This handles Docling's table-cell-as-text-block explosion.
+
+3. **Strip references tail** — find a `## References` (or `## Bibliography`, `## Works Cited`) section header that appears at or after 60% through the document. Strip everything from that header onward. The 60% threshold is a conservative starting point — if false negatives are observed with documents where references start earlier, this can be tuned down. The position check prevents false positives on papers with an early "References" subsection within the body.
+
+4. **Strip supplementary tail** — same pattern for `## Appendix`, `## Supplementary`, `## Supporting Information` at or after 70% through the document.
 
 **What it does NOT do:**
 
@@ -45,22 +59,27 @@ A pure function `cleanExtraction(markdown: string): string` that takes Docling m
 
 `Extractor.extract()` calls `cleanExtraction()` after Docling finishes. The cleaned output is written to `content.clean.md` alongside the original `content.md` (preserved for debugging).
 
+The `ExtractionResult` interface gains a `cleanContentPath: string` field pointing to the cleaned file.
+
+The extractor logs the cleanup ratio (original size vs cleaned size) after each cleanup run for visibility into how effective the rules are across document types.
+
+**Crash recovery:** `Extractor.hasArtifacts()` currently checks for `content.md` and `metadata.json`. It must also check for `content.clean.md`. If the process crashed after Docling wrote `content.md` but before cleanup ran, `hasArtifacts()` returns false and extraction re-runs (including cleanup). This ensures cleanup is never skipped.
+
 `AgentProcessor.process()` currently receives the extraction directory path and reads `content.md` from it. This changes to read `content.clean.md` first, falling back to `content.md` if the clean file doesn't exist (backward compatibility with pre-existing extractions). No interface changes needed — just the filename it looks for.
 
 ### 3. Token Budget Gate
 
-Located in `handleGeneration()` in `src/ingestion/index.ts`, before building the vault manifest or spawning the agent.
+Located at the top of `handleGeneration()` in `src/ingestion/index.ts`, before building the vault manifest or spawning the agent.
 
-**Token estimation:** `Math.ceil(contentChars / 4)` — simple char-count heuristic, no tokenizer dependency.
+**Token estimation:** `Math.ceil(contentChars / 4)` — simple char-count heuristic, no tokenizer dependency. This tends to slightly overestimate for English academic text (real ratio is ~3.5-3.8 chars/token), making the gate conservative. For Norwegian text with compound words the ratio may differ, but erring on the side of caution is the safer direction. This is a known approximation — do not "fix" it with a tighter ratio without understanding the trade-off.
 
 **Budget:** 80,000 tokens for document content alone. This leaves headroom for the CLAUDE.md system prompt, vault manifest, job parameters, and multi-turn agent conversation within the 200K context window.
 
 **When over budget:**
 
-- Set job status to `oversized`
-- Store token estimate in the job's error field for visibility
-- Send a Telegram notification to the user's main chat with the document name and token count
-- Do not retry automatically — the user decides what to do
+- Set job status to `oversized` and return normally (do NOT throw). This matches the existing rate-limit pattern in `handleGeneration` where the handler returns without throwing to prevent the drainer's `.catch()` from overwriting the status to `failed`.
+- Store token estimate in the job's error field for visibility (e.g. `"oversized:~120K tokens after cleanup"`)
+- Send a Telegram notification to the user's main chat
 
 **When under budget:** Proceed to agent generation as normal.
 
@@ -73,6 +92,10 @@ pending → extracting → extracted → generating → generated → promoting 
 
 `oversized` is a new terminal-ish status. The `PipelineDrainer` ignores it (does not auto-retry). The user can retry or dismiss via the dashboard.
 
+**`enqueue()` dedup handling:** The `enqueue()` method in `src/ingestion/index.ts` checks for existing jobs by source path. It must handle the new statuses:
+- `dismissed` — treat like `completed` (allow re-enqueue of the same file)
+- `oversized` — treat as already queued (skip, do not create a duplicate job)
+
 ### 5. Dashboard Job Management
 
 For jobs in `failed`, `oversized`, or `rate_limited` status, the dashboard provides two actions:
@@ -84,6 +107,12 @@ For jobs in `failed`, `oversized`, or `rate_limited` status, the dashboard provi
 
 `upload/dismissed/` is a new directory. The file watcher ignores it (same as `upload/processed/`).
 
+**Dashboard status config:** Add entries for `oversized` and `dismissed` to the `STATUS_CONFIG` map in `JobRow.tsx`:
+- `oversized`: label "Oversized", distinct color (e.g. purple), non-active
+- `dismissed`: label "Dismissed", muted color, non-active
+
+Update the `isActive` check (currently `!['completed', 'failed'].includes(status)`) to also exclude `oversized` and `dismissed`, so they don't show progress bars.
+
 ### 6. Database Changes
 
 - Add `oversized` and `dismissed` as recognized job statuses
@@ -91,7 +120,7 @@ For jobs in `failed`, `oversized`, or `rate_limited` status, the dashboard provi
 
 ### 7. Notification
 
-Uses existing Telegram channel infrastructure. The ingestion pipeline sends a message to the user's main registered chat when a job is parked as `oversized`.
+The ingestion pipeline sends a Telegram notification when a job is parked as `oversized`. The pipeline uses the router's `sendMessage()` function (from `src/router.ts`) to deliver the message to the user's main registered Telegram chat. The ingestion pipeline constructor receives a `notify` callback that the orchestrator wires to the router — keeping the ingestion module decoupled from channel specifics.
 
 Message format: `"Document '{filename}' is too large for single-pass processing (~{tokens}K tokens after cleanup). Retry or dismiss it from the dashboard."`
 
@@ -101,23 +130,31 @@ Message format: `"Document '{filename}' is too large for single-pass processing 
 
 Each cleanup rule tested individually:
 
-- Noise block collapsing: same-page short blocks merge; different-page blocks don't; blocks over 50 chars are preserved
+- Deduplication: identical adjacent blocks on same page collapsed; different pages preserved; different content preserved
+- Noise block collapsing: same-page short blocks merge; different-page blocks don't; blocks over 50 chars preserved
 - References stripping: various heading formats (`## References`, `## Bibliography`, `## Works Cited`); position threshold (early occurrence preserved, late occurrence stripped)
 - Supplementary stripping: `## Appendix`, `## Supplementary`, `## Supporting Information`; position threshold
-- Adjacent duplicate removal
 - Passthrough: clean documents come through unchanged
 - Composition: all rules applied together on realistic sample
+- Cleanup ratio logging: verify log output includes original and cleaned sizes
 
 ### Extractor integration
 
 - Verify `extract()` writes `content.clean.md` alongside `content.md`
 - Verify `cleanContentPath` is set in `ExtractionResult`
+- Verify `hasArtifacts()` returns false when `content.clean.md` is missing (triggers re-extraction with cleanup)
 
 ### Budget gate
 
-- Verify oversized jobs are parked with `oversized` status
+- Verify oversized jobs are parked with `oversized` status and handler returns normally (no throw)
 - Verify under-budget jobs proceed normally
-- Verify notification is triggered for oversized jobs
+- Verify notification callback is invoked for oversized jobs
+
+### Dashboard
+
+- Verify retry action resets job to `extracted`
+- Verify dismiss action sets `dismissed`, moves source file to `upload/dismissed/`
+- Verify `oversized` and `dismissed` are rendered as non-active terminal states
 
 ### Existing tests
 
@@ -127,3 +164,4 @@ Promoter, sentinel, validation, and pipeline tests should need no changes — th
 
 - **Section-based chunking** for textbook-length documents: split at major headings, process each chunk as a separate agent session, merge manifests. Deferred until textbook uploads become a real use case.
 - **Inline dashboard actions** on the Telegram notification (reply "skip" / "retry") — deferred, notification-only for now.
+- **Threshold tuning** — the 60%/70% position thresholds for references/supplementary stripping may need adjustment as more document types are processed. Monitor cleanup ratio logs.

--- a/docs/superpowers/specs/2026-04-02-extraction-cleanup-and-oversized-documents-design.md
+++ b/docs/superpowers/specs/2026-04-02-extraction-cleanup-and-oversized-documents-design.md
@@ -1,0 +1,129 @@
+# Extraction Cleanup and Oversized Document Handling
+
+**Date:** 2026-04-02
+**Status:** Approved
+
+## Problem
+
+Docling extracts large PDFs into noisy markdown that inflates token counts beyond what the agent can process in a single session. A 206-page academic paper produced 559KB of extracted content (~140K tokens), of which ~42% was structural noise (single-word table cell blocks, references, supplementary material). The agent hit rate limits and timed out.
+
+This affects all documents to varying degrees — even shorter papers benefit from trimmed extractions that save tokens.
+
+## Design
+
+### Overview
+
+1. A cleanup pass runs on every Docling extraction, trimming structural noise
+2. A token budget gate checks the cleaned content before spawning the agent
+3. Oversized documents are parked and the user is notified via Telegram
+4. Failed/oversized jobs can be dismissed from the dashboard
+
+### 1. Extraction Cleanup — `cleanExtraction()`
+
+New file: `src/ingestion/extraction-cleaner.ts`
+
+A pure function `cleanExtraction(markdown: string): string` that takes Docling markdown and returns a cleaned version. Stateless and deterministic.
+
+**Cleanup rules, applied in order:**
+
+1. **Collapse noise blocks** — consecutive `<!-- page:N label:text -->` blocks on the same page where the text content (excluding the marker itself) is under 50 chars get merged into a single block. The merged block keeps one page marker and joins the text fragments with spaces. This handles Docling's table-cell-as-text-block explosion.
+
+2. **Strip references tail** — find a `## References` (or `## Bibliography`, `## Works Cited`) section header that appears at or after 60% through the document. Strip everything from that header onward. The position threshold prevents false positives on papers with an early "References" subsection.
+
+3. **Strip supplementary tail** — same pattern for `## Appendix`, `## Supplementary`, `## Supporting Information` at or after 70% through the document.
+
+4. **Deduplicate adjacent identical blocks** — if the same text content appears in consecutive blocks on the same page, keep only the first.
+
+**What it does NOT do:**
+
+- Does not touch tables (valuable structured content)
+- Does not remove section headers (used for citation references)
+- Does not modify content within blocks — only removes or merges whole blocks
+- Does not guess about content semantics — operates solely on Docling's structural markers
+
+### 2. Integration with Extraction
+
+`Extractor.extract()` calls `cleanExtraction()` after Docling finishes. The cleaned output is written to `content.clean.md` alongside the original `content.md` (preserved for debugging).
+
+`AgentProcessor.process()` currently receives the extraction directory path and reads `content.md` from it. This changes to read `content.clean.md` first, falling back to `content.md` if the clean file doesn't exist (backward compatibility with pre-existing extractions). No interface changes needed — just the filename it looks for.
+
+### 3. Token Budget Gate
+
+Located in `handleGeneration()` in `src/ingestion/index.ts`, before building the vault manifest or spawning the agent.
+
+**Token estimation:** `Math.ceil(contentChars / 4)` — simple char-count heuristic, no tokenizer dependency.
+
+**Budget:** 80,000 tokens for document content alone. This leaves headroom for the CLAUDE.md system prompt, vault manifest, job parameters, and multi-turn agent conversation within the 200K context window.
+
+**When over budget:**
+
+- Set job status to `oversized`
+- Store token estimate in the job's error field for visibility
+- Send a Telegram notification to the user's main chat with the document name and token count
+- Do not retry automatically — the user decides what to do
+
+**When under budget:** Proceed to agent generation as normal.
+
+### 4. Pipeline Status Flow
+
+```
+pending → extracting → extracted → generating → generated → promoting → completed
+                                  ↘ oversized (parked, user notified)
+```
+
+`oversized` is a new terminal-ish status. The `PipelineDrainer` ignores it (does not auto-retry). The user can retry or dismiss via the dashboard.
+
+### 5. Dashboard Job Management
+
+For jobs in `failed`, `oversized`, or `rate_limited` status, the dashboard provides two actions:
+
+- **Retry** — resets job to `extracted` so the pipeline picks it up again
+- **Dismiss** — sets job to `dismissed` status, moves the source file to `upload/dismissed/{jobId}-{filename}`, cleans up extraction artifacts
+
+`dismissed` is a terminal status like `completed`. The drainer ignores it.
+
+`upload/dismissed/` is a new directory. The file watcher ignores it (same as `upload/processed/`).
+
+### 6. Database Changes
+
+- Add `oversized` and `dismissed` as recognized job statuses
+- No new columns needed — token estimate stored in existing `error` field
+
+### 7. Notification
+
+Uses existing Telegram channel infrastructure. The ingestion pipeline sends a message to the user's main registered chat when a job is parked as `oversized`.
+
+Message format: `"Document '{filename}' is too large for single-pass processing (~{tokens}K tokens after cleanup). Retry or dismiss it from the dashboard."`
+
+## Testing
+
+### `extraction-cleaner.test.ts`
+
+Each cleanup rule tested individually:
+
+- Noise block collapsing: same-page short blocks merge; different-page blocks don't; blocks over 50 chars are preserved
+- References stripping: various heading formats (`## References`, `## Bibliography`, `## Works Cited`); position threshold (early occurrence preserved, late occurrence stripped)
+- Supplementary stripping: `## Appendix`, `## Supplementary`, `## Supporting Information`; position threshold
+- Adjacent duplicate removal
+- Passthrough: clean documents come through unchanged
+- Composition: all rules applied together on realistic sample
+
+### Extractor integration
+
+- Verify `extract()` writes `content.clean.md` alongside `content.md`
+- Verify `cleanContentPath` is set in `ExtractionResult`
+
+### Budget gate
+
+- Verify oversized jobs are parked with `oversized` status
+- Verify under-budget jobs proceed normally
+- Verify notification is triggered for oversized jobs
+
+### Existing tests
+
+Promoter, sentinel, validation, and pipeline tests should need no changes — the flow is unchanged for normal-sized documents.
+
+## Future Work
+
+- **Section-based chunking** for textbook-length documents: split at major headings, process each chunk as a separate agent session, merge manifests. Deferred until textbook uploads become a real use case.
+- **Inline dashboard actions** on the Telegram notification (reply "skip" / "retry") — deferred, notification-only for now.

--- a/docs/superpowers/specs/2026-04-02-telegram-attachment-passthrough-design.md
+++ b/docs/superpowers/specs/2026-04-02-telegram-attachment-passthrough-design.md
@@ -9,23 +9,25 @@ When a user sends a file (PDF, image, etc.) as a Telegram attachment, the agent 
 
 ## Solution
 
-Download Telegram file attachments on the host, encode a machine-readable marker in the message content, and copy files into the container's mounted group folder before the agent turn. Clean up after.
+Download Telegram file attachments on the host, encode a machine-readable marker in the message content, and stage files into the container's mounted group folder before the agent prompt is built. Files persist for the duration of the container session and are cleaned up at teardown.
 
 ## Design
 
 ### Marker Format
 
-When a Telegram message has a file attachment, the handler downloads it and appends an `(attachment:...)` marker to the message content:
+When a Telegram message has a file attachment, the handler downloads it and appends an `(__attachment__:...)` marker to the message content:
 
-- Document: `[Document: report.pdf](attachment:/abs/path/data/attachments/tg:-123/456-report.pdf)`
-- Photo: `[Photo](attachment:/abs/path/data/attachments/tg:-123/456-photo.jpg)`
-- Photo with caption: `[Photo] Check this out(attachment:/abs/path/data/attachments/tg:-123/456-photo.jpg)`
+- Document: `[Document: report.pdf](__attachment__:/abs/path/data/attachments/main/456-report.pdf)`
+- Photo: `[Photo](__attachment__:/abs/path/data/attachments/main/456-photo.jpg)`
+- Photo with caption: `[Photo] Check this out(__attachment__:/abs/path/data/attachments/main/456-photo.jpg)`
 
-The marker uses absolute host paths. It is stripped and rewritten before reaching the agent prompt.
+The marker uses absolute host paths keyed by group folder (not raw JID). The `(__attachment__:...)` prefix is deliberately unlikely to collide with user message text. It is stripped and rewritten before reaching the agent prompt.
 
 ### Attachment Storage
 
-Downloaded files are stored at `data/attachments/{chatJid}/{msgId}-{filename}`. This location survives between message receipt and agent invocation. Telegram's Bot API enforces a 20MB file limit, so no additional size cap is needed.
+Downloaded files are stored at `data/attachments/{groupFolder}/{msgId}-{filename}`. Using group folder (alphanumeric, validated by `GROUP_FOLDER_PATTERN`) instead of raw chatJid avoids colons and special characters in paths, consistent with how other `data/` subdirectories (sessions, IPC) are organized.
+
+This location survives between message receipt and agent invocation. Telegram's Bot API enforces a 20MB file limit, so no additional size cap is needed.
 
 Supported types: PDF, images (jpg, png, heic, webp), plain text.
 
@@ -33,31 +35,45 @@ Supported types: PDF, images (jpg, png, heic, webp), plain text.
 
 Channel-agnostic module with three functions:
 
-**`prepareAttachments(messages, groupFolder)`** — Called before building the agent prompt. Scans all message contents for `(attachment:...)` markers. For each match:
+**`prepareAttachments(messages, groupFolder)`** — Called before building the agent prompt. Scans all message contents for `(__attachment__:...)` markers. For each match:
 
 1. Copies the file from `data/attachments/...` to `groups/{folder}/inputs/{filename}` (deduplicating filenames with numeric suffix if needed)
-2. Rewrites message content: `[Document: report.pdf](attachment:...)` becomes `[Document: report.pdf — available at /workspace/group/inputs/report.pdf]`
-3. Returns the list of consumed source paths for cleanup
+2. Rewrites message content: `[Document: report.pdf](__attachment__:...)` becomes `[Document: report.pdf — available at /workspace/group/inputs/report.pdf (1.4 MB)]`
+3. Returns the list of consumed source paths for cleanup later
 
-**`cleanupAttachments(groupFolder, sourcePaths)`** — Called after the agent turn completes. Removes `groups/{folder}/inputs/` directory and deletes consumed source files from `data/attachments/`.
+File size is included in the rewritten marker to help the agent make better tool-use decisions (e.g., paging large PDFs rather than reading 20MB at once).
 
-**`ATTACHMENT_MARKER_RE`** — Exported regex: `\(attachment:([^)]+)\)` for testing.
+**`cleanupAttachments(groupFolder, sourcePaths)`** — Called at container teardown (not after each agent turn). Removes `groups/{folder}/inputs/` directory and deletes consumed source files from `data/attachments/`.
+
+**`ATTACHMENT_MARKER_RE`** — Exported regex: `\(__attachment__:([^)]+)\)` for testing.
 
 The `inputs/` directory lives inside the group folder, which is already mounted at `/workspace/group` (writable). No new mounts or security changes needed. The agent uses the standard Read tool to access files at `/workspace/group/inputs/`.
 
 ### Telegram Handler Changes (`src/channels/telegram.ts`)
 
-Two handlers change: `message:document` and `message:photo`.
+The `message:document` and `message:photo` handlers get dedicated async implementations that download the file before storing the message. They do **not** use the shared `storeNonText` helper, which is synchronous and not suitable for async downloads. This matches the pattern already used by the `message:voice` handler.
 
-**Documents:** Download via `ctx.getFile()` (grammyjs/files already configured), save to `data/attachments/{chatJid}/{msgId}-{filename}`, store message with `(attachment:...)` marker.
+**Documents:**
+1. Check if group is registered (early return if not)
+2. Download via `ctx.getFile()` (grammyjs/files already configured)
+3. Save to `data/attachments/{groupFolder}/{msgId}-{filename}`
+4. Call `onMessage` with content `[Document: {filename}](__attachment__:{path})`
+5. On download failure: fall back to `[Document: {filename}]` (no marker), same as today
 
-**Photos:** Pick the largest resolution (last element in `ctx.message.photo`), download, name as `{msgId}-photo.jpg`.
+**Photos:**
+1. Pick the largest resolution (last element in `ctx.message.photo`)
+2. Download and name as `{msgId}-photo.jpg`
+3. Call `onMessage` with content `[Photo](__attachment__:{path})`
 
-Both fall back to current placeholder-only behavior on download failure. No new dependencies — `hydrateFiles` and `DATA_DIR` are already available.
+Both handlers also pass `thread_id` through to `onMessage`, fixing a pre-existing bug where non-text message handlers dropped the thread context.
 
-### Integration Point (`src/index.ts`)
+The group folder for attachment storage is resolved by looking up the chatJid in `registeredGroups()`. No new dependencies — `hydrateFiles` and `DATA_DIR` are already available.
 
-The attachment lifecycle hooks into `processMessages()`:
+### Integration Points (`src/index.ts`)
+
+Attachments must be prepared in **two** code paths:
+
+**1. Initial turn (`processGroupMessages`):**
 
 ```
 // Before building the prompt:
@@ -65,32 +81,43 @@ const attachmentPaths = prepareAttachments(missedMessages, group.folder);
 
 // Build prompt as usual (messages now have rewritten content)
 const prompt = reviewContext + formatMessages(missedMessages, TIMEZONE);
-
-// ... run agent ...
-
-// After agent turn completes (finally block):
-cleanupAttachments(group.folder, attachmentPaths);
 ```
 
-`prepareAttachments` mutates the `content` field of in-memory message objects. DB records are untouched — they keep original markers, which is fine since messages are formatted into prompts once per turn.
+**2. Piped follow-up messages (`startMessageLoop`):**
+
+When messages are piped to an already-running container via `queue.sendMessage()`, `prepareAttachments` must also be called before `formatMessages`:
+
+```
+// Before formatting for piping:
+const pipedPaths = prepareAttachments(messagesToSend, group.folder);
+attachmentPaths.push(...pipedPaths);
+
+const formatted = formatMessages(messagesToSend, TIMEZONE);
+queue.sendMessage(chatJid, formatted);
+```
+
+**Cleanup:** Runs at container teardown, not after each turn. When the container process exits (the `close` handler in `runContainerAgent`), cleanup removes `groups/{folder}/inputs/` and deletes consumed source files. This ensures files remain accessible across piped follow-up messages within the same container session.
+
+`prepareAttachments` mutates the `content` field of in-memory message objects. DB records are untouched — they keep original markers.
 
 ### Edge Cases
 
 - **Duplicate filenames:** Second file gets `report-2.pdf` suffix in inputs dir
 - **Download failure:** Falls back to placeholder-only (no marker), same as today
 - **Missing source at prep time:** Log warning, strip marker, continue without that file
-- **HEIC images:** No conversion. Claude reads HEIC natively via Read tool. Stored as-is.
-- **Stale attachments:** Purge `data/attachments/` on NanoClaw startup to clean orphans
+- **HEIC images:** No conversion. Stored as-is. Must verify during implementation that Claude's Read tool supports HEIC inside Docker containers (host support is confirmed, container support may depend on image libraries).
+- **Stale attachments:** On NanoClaw startup, delete files in `data/attachments/` older than 24 hours. This avoids purging attachments from messages that arrived just before a crash but haven't been processed yet. Age-based cleanup handles the common case (orphans from crashes days ago) without the race condition of a blanket purge.
 
 ### Testing
 
-- **Unit tests for `src/attachments.ts`:** Marker parsing, file copying, content rewriting, dedup logic, cleanup, missing-file handling
-- **Telegram handler tests:** Update existing tests for download + marker behavior in document and photo handlers
-- **Integration:** Marker in content → file in inputs dir → rewritten prompt → cleanup after turn
+- **Unit tests for `src/attachments.ts`:** Marker parsing, file copying, content rewriting, dedup logic, cleanup, missing-file handling, file size formatting
+- **Telegram handler tests:** Update existing tests for download + marker behavior in document and photo handlers; verify thread_id passthrough
+- **Integration:** Marker in content → file in inputs dir → rewritten prompt → cleanup at container teardown
+- **Piping path:** Verify attachments in follow-up messages (piped to running container) are also staged and rewritten correctly
 
 ## Non-Goals
 
-- Image conversion (HEIC→JPG etc.) — not needed, Claude handles HEIC
+- Image conversion (HEIC→JPG etc.) — not needed if container supports HEIC
 - Support for video or audio attachments — out of scope
 - Multi-channel support in this iteration — Telegram only, but the utility module is channel-agnostic by design
 - DB schema changes — markers live in the content string

--- a/docs/superpowers/specs/2026-04-02-telegram-attachment-passthrough-design.md
+++ b/docs/superpowers/specs/2026-04-02-telegram-attachment-passthrough-design.md
@@ -1,0 +1,96 @@
+# Telegram Attachment Passthrough
+
+**Date:** 2026-04-02
+**Status:** Draft
+
+## Problem
+
+When a user sends a file (PDF, image, etc.) as a Telegram attachment, the agent in its container only sees a text placeholder like `[Document: filename.pdf]`. The file is never downloaded or made accessible to the agent. The agent cannot read or process the attached file.
+
+## Solution
+
+Download Telegram file attachments on the host, encode a machine-readable marker in the message content, and copy files into the container's mounted group folder before the agent turn. Clean up after.
+
+## Design
+
+### Marker Format
+
+When a Telegram message has a file attachment, the handler downloads it and appends an `(attachment:...)` marker to the message content:
+
+- Document: `[Document: report.pdf](attachment:/abs/path/data/attachments/tg:-123/456-report.pdf)`
+- Photo: `[Photo](attachment:/abs/path/data/attachments/tg:-123/456-photo.jpg)`
+- Photo with caption: `[Photo] Check this out(attachment:/abs/path/data/attachments/tg:-123/456-photo.jpg)`
+
+The marker uses absolute host paths. It is stripped and rewritten before reaching the agent prompt.
+
+### Attachment Storage
+
+Downloaded files are stored at `data/attachments/{chatJid}/{msgId}-{filename}`. This location survives between message receipt and agent invocation. Telegram's Bot API enforces a 20MB file limit, so no additional size cap is needed.
+
+Supported types: PDF, images (jpg, png, heic, webp), plain text.
+
+### Attachment Utility Module (`src/attachments.ts`)
+
+Channel-agnostic module with three functions:
+
+**`prepareAttachments(messages, groupFolder)`** — Called before building the agent prompt. Scans all message contents for `(attachment:...)` markers. For each match:
+
+1. Copies the file from `data/attachments/...` to `groups/{folder}/inputs/{filename}` (deduplicating filenames with numeric suffix if needed)
+2. Rewrites message content: `[Document: report.pdf](attachment:...)` becomes `[Document: report.pdf — available at /workspace/group/inputs/report.pdf]`
+3. Returns the list of consumed source paths for cleanup
+
+**`cleanupAttachments(groupFolder, sourcePaths)`** — Called after the agent turn completes. Removes `groups/{folder}/inputs/` directory and deletes consumed source files from `data/attachments/`.
+
+**`ATTACHMENT_MARKER_RE`** — Exported regex: `\(attachment:([^)]+)\)` for testing.
+
+The `inputs/` directory lives inside the group folder, which is already mounted at `/workspace/group` (writable). No new mounts or security changes needed. The agent uses the standard Read tool to access files at `/workspace/group/inputs/`.
+
+### Telegram Handler Changes (`src/channels/telegram.ts`)
+
+Two handlers change: `message:document` and `message:photo`.
+
+**Documents:** Download via `ctx.getFile()` (grammyjs/files already configured), save to `data/attachments/{chatJid}/{msgId}-{filename}`, store message with `(attachment:...)` marker.
+
+**Photos:** Pick the largest resolution (last element in `ctx.message.photo`), download, name as `{msgId}-photo.jpg`.
+
+Both fall back to current placeholder-only behavior on download failure. No new dependencies — `hydrateFiles` and `DATA_DIR` are already available.
+
+### Integration Point (`src/index.ts`)
+
+The attachment lifecycle hooks into `processMessages()`:
+
+```
+// Before building the prompt:
+const attachmentPaths = prepareAttachments(missedMessages, group.folder);
+
+// Build prompt as usual (messages now have rewritten content)
+const prompt = reviewContext + formatMessages(missedMessages, TIMEZONE);
+
+// ... run agent ...
+
+// After agent turn completes (finally block):
+cleanupAttachments(group.folder, attachmentPaths);
+```
+
+`prepareAttachments` mutates the `content` field of in-memory message objects. DB records are untouched — they keep original markers, which is fine since messages are formatted into prompts once per turn.
+
+### Edge Cases
+
+- **Duplicate filenames:** Second file gets `report-2.pdf` suffix in inputs dir
+- **Download failure:** Falls back to placeholder-only (no marker), same as today
+- **Missing source at prep time:** Log warning, strip marker, continue without that file
+- **HEIC images:** No conversion. Claude reads HEIC natively via Read tool. Stored as-is.
+- **Stale attachments:** Purge `data/attachments/` on NanoClaw startup to clean orphans
+
+### Testing
+
+- **Unit tests for `src/attachments.ts`:** Marker parsing, file copying, content rewriting, dedup logic, cleanup, missing-file handling
+- **Telegram handler tests:** Update existing tests for download + marker behavior in document and photo handlers
+- **Integration:** Marker in content → file in inputs dir → rewritten prompt → cleanup after turn
+
+## Non-Goals
+
+- Image conversion (HEIC→JPG etc.) — not needed, Claude handles HEIC
+- Support for video or audio attachments — out of scope
+- Multi-channel support in this iteration — Telegram only, but the utility module is channel-agnostic by design
+- DB schema changes — markers live in the content string


### PR DESCRIPTION
## Summary

- Download Telegram document and photo attachments to `data/attachments/{groupFolder}/`, embedding machine-readable `(__attachment__:...)` markers in message content
- Add channel-agnostic `src/attachments.ts` utility module that stages files into `groups/{folder}/inputs/` (already mounted at `/workspace/group` in containers), rewrites message content with container-visible paths and file sizes, and cleans up on teardown
- Integrate `prepareAttachments` in both initial-turn (`processGroupMessages`) and piped follow-up (`startMessageLoop`) code paths
- Purge stale attachments (>24h) at startup for crash recovery
- Fix `thread_id` not being passed through for non-text message handlers (pre-existing bug)
- Sanitize user-provided filenames to prevent path traversal

## Test plan

- [x] 13 unit tests for `src/attachments.ts` (marker regex, file staging, dedup, cleanup, missing-file handling, file size formatting)
- [x] 8 new tests for Telegram handlers (document/photo download success + failure, caption preservation, thread_id passthrough)
- [x] Full test suite passes (653/654 — 1 pre-existing timeout in claw-skill.test.ts)
- [x] TypeScript build compiles clean
- [ ] Manual smoke test: send a PDF/photo to a registered Telegram group and verify agent can read it at /workspace/group/inputs/

**Design spec:** docs/superpowers/specs/2026-04-02-telegram-attachment-passthrough-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)