### PR TITLE
fix(tts): raise character limit and timeout for long-form audio

### DIFF
--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -347,7 +347,7 @@ server.tool(
   'synthesize_speech',
   'Convert text to speech audio. Returns a file path to the generated WAV audio. Call send_voice with the returned path to deliver it as a Telegram voice message. Everything is pre-configured — just call this tool.',
   {
-    text: z.string().describe('Text to synthesize (max 50000 characters). Mistral handles long text via server-side interleaving.'),
+    text: z.string().max(50000).describe('Text to synthesize (max 50000 characters). Mistral handles long text via server-side interleaving.'),
   },
   async (args) => {
     if (!args.text || args.text.trim().length === 0) {

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -338,7 +338,7 @@ Use available_groups.json to find the JID for a group. The folder name must be c
 );
 
 const AUDIO_DIR = '/workspace/group/audio';
-const TTS_MAX_TEXT_LENGTH = 5000;
+const TTS_MAX_TEXT_LENGTH = 50000;
 const MISTRAL_TTS_URL = 'https://api.mistral.ai/v1/audio/speech';
 // Default voice: "Paul - Neutral" (en_us, male, casual)
 const MISTRAL_DEFAULT_VOICE_ID = 'c69964a6-ab8b-4f8a-9465-ec0925096ec8';
@@ -347,7 +347,7 @@ server.tool(
   'synthesize_speech',
   'Convert text to speech audio. Returns a file path to the generated WAV audio. Call send_voice with the returned path to deliver it as a Telegram voice message. Everything is pre-configured — just call this tool.',
   {
-    text: z.string().describe('Text to synthesize (max 5000 characters)'),
+    text: z.string().describe('Text to synthesize (max 50000 characters). Mistral handles long text via server-side interleaving.'),
   },
   async (args) => {
     if (!args.text || args.text.trim().length === 0) {
@@ -391,7 +391,7 @@ server.tool(
           voice_id: MISTRAL_DEFAULT_VOICE_ID,
           response_format: 'wav',
         }),
-        signal: AbortSignal.timeout(60_000),
+        signal: AbortSignal.timeout(300_000),
       });
 
       if (!response.ok) {

--- a/src/db.ts
+++ b/src/db.ts
@@ -210,9 +210,7 @@ function createSchema(database: Database.Database): void {
     /* column exists */
   }
   try {
-    database.exec(
-      `ALTER TABLE ingestion_jobs ADD COLUMN zotero_metadata TEXT`,
-    );
+    database.exec(`ALTER TABLE ingestion_jobs ADD COLUMN zotero_metadata TEXT`);
   } catch {
     /* column exists */
   }

--- a/src/ingestion/agent-processor.test.ts
+++ b/src/ingestion/agent-processor.test.ts
@@ -107,11 +107,18 @@ describe('AgentProcessor.buildPrompt', () => {
       itemType: 'journalArticle',
     });
 
-    const prompt = processor.buildPrompt('content', 'file.pdf', 'job-1', [], undefined, {
-      source_type: 'zotero',
-      zotero_key: 'ABCD1234',
-      zotero_metadata: metadata,
-    });
+    const prompt = processor.buildPrompt(
+      'content',
+      'file.pdf',
+      'job-1',
+      [],
+      undefined,
+      {
+        source_type: 'zotero',
+        zotero_key: 'ABCD1234',
+        zotero_metadata: metadata,
+      },
+    );
 
     expect(prompt).toContain('## Source Document Metadata (from Zotero)');
     expect(prompt).toContain('Doe, J.');

--- a/src/ingestion/agent-processor.ts
+++ b/src/ingestion/agent-processor.ts
@@ -57,7 +57,8 @@ export class AgentProcessor {
         if (meta.title) lines.push(`- Title: ${meta.title}`);
         if (creators) lines.push(`- Authors: ${creators}`);
         if (meta.date) lines.push(`- Date: ${meta.date}`);
-        if (meta.publicationTitle) lines.push(`- Publication: ${meta.publicationTitle}`);
+        if (meta.publicationTitle)
+          lines.push(`- Publication: ${meta.publicationTitle}`);
         if (meta.DOI) lines.push(`- DOI: ${meta.DOI}`);
         if (tags) lines.push(`- Tags: ${tags}`);
         if (meta.abstractNote) lines.push(`- Abstract: ${meta.abstractNote}`);

--- a/src/ingestion/types.ts
+++ b/src/ingestion/types.ts
@@ -16,7 +16,12 @@ export interface ZoteroItem {
   data: ZoteroItemData;
   meta: { numChildren?: number };
   links?: {
-    attachment?: { href: string; type: string; attachmentType?: string; attachmentSize?: number };
+    attachment?: {
+      href: string;
+      type: string;
+      attachmentType?: string;
+      attachmentSize?: number;
+    };
   };
 }
 

--- a/src/ingestion/zotero-client.test.ts
+++ b/src/ingestion/zotero-client.test.ts
@@ -35,7 +35,9 @@ describe('ZoteroLocalClient', () => {
 
     const result = await client.getItems();
     expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/api/users/0/items?itemType=-attachment+-note&format=json'),
+      expect.stringContaining(
+        '/api/users/0/items?itemType=-attachment+-note&format=json',
+      ),
       expect.any(Object),
     );
     expect(result.version).toBe(200);
@@ -85,7 +87,9 @@ describe('ZoteroLocalClient', () => {
   });
 
   it('throws on network error', async () => {
-    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(
+      new Error('ECONNREFUSED'),
+    );
 
     await expect(client.getItems()).rejects.toThrow('ECONNREFUSED');
   });
@@ -124,16 +128,20 @@ describe('ZoteroWebClient', () => {
     vi.spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(
         new Response(
-          JSON.stringify({ key: 'ABC12345', version: 100, data: { tags: [{ tag: 'existing' }] } }),
+          JSON.stringify({
+            key: 'ABC12345',
+            version: 100,
+            data: { tags: [{ tag: 'existing' }] },
+          }),
         ),
       )
-      .mockResolvedValueOnce(
-        new Response(null, { status: 204 }),
-      );
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
 
     await client.addTag('ABC12345', 'vault:ingested');
     const patchCall = vi.mocked(fetch).mock.calls[1];
-    expect(patchCall[0]).toBe('https://api.zotero.org/users/12345/items/ABC12345');
+    expect(patchCall[0]).toBe(
+      'https://api.zotero.org/users/12345/items/ABC12345',
+    );
     const body = JSON.parse(patchCall[1]!.body as string);
     expect(body.tags).toEqual([{ tag: 'existing' }, { tag: 'vault:ingested' }]);
   });
@@ -141,7 +149,11 @@ describe('ZoteroWebClient', () => {
   it('addTag skips if tag already present', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(
-        JSON.stringify({ key: 'ABC12345', version: 100, data: { tags: [{ tag: 'vault:ingested' }] } }),
+        JSON.stringify({
+          key: 'ABC12345',
+          version: 100,
+          data: { tags: [{ tag: 'vault:ingested' }] },
+        }),
       ),
     );
 

--- a/src/ingestion/zotero-db.test.ts
+++ b/src/ingestion/zotero-db.test.ts
@@ -25,7 +25,9 @@ describe('Zotero DB functions', () => {
     const job = getIngestionJobById('job-1') as Record<string, unknown>;
     expect(job.source_type).toBe('zotero');
     expect(job.zotero_key).toBe('ABCD1234');
-    expect(JSON.parse(job.zotero_metadata as string)).toEqual({ title: 'Test Paper' });
+    expect(JSON.parse(job.zotero_metadata as string)).toEqual({
+      title: 'Test Paper',
+    });
   });
 
   it('createIngestionJob defaults source_type to upload', () => {

--- a/src/ingestion/zotero-watcher.test.ts
+++ b/src/ingestion/zotero-watcher.test.ts
@@ -28,7 +28,11 @@ describe('ZoteroWatcher', () => {
     getCollections: ReturnType<typeof vi.fn>;
     getFileUrl: ReturnType<typeof vi.fn>;
   };
-  let enqueuedItems: { filePath: string; zoteroKey: string; metadata: unknown }[];
+  let enqueuedItems: {
+    filePath: string;
+    zoteroKey: string;
+    metadata: unknown;
+  }[];
 
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -56,7 +60,18 @@ describe('ZoteroWatcher', () => {
   it('first run stores version without processing items', async () => {
     vi.mocked(getZoteroSyncVersion).mockReturnValue(null);
     mockClient.getItems.mockResolvedValue({
-      items: [{ key: 'ABC', data: { title: 'Paper', collections: [], creators: [], date: '', tags: [] } }],
+      items: [
+        {
+          key: 'ABC',
+          data: {
+            title: 'Paper',
+            collections: [],
+            creators: [],
+            date: '',
+            tags: [],
+          },
+        },
+      ],
       version: 200,
     });
 
@@ -78,7 +93,9 @@ describe('ZoteroWatcher', () => {
             title: 'New Paper',
             itemType: 'journalArticle',
             collections: [],
-            creators: [{ firstName: 'John', lastName: 'Doe', creatorType: 'author' }],
+            creators: [
+              { firstName: 'John', lastName: 'Doe', creatorType: 'author' },
+            ],
             date: '2025-01-01',
             tags: [{ tag: 'AI' }],
             abstractNote: 'Abstract text',
@@ -101,22 +118,40 @@ describe('ZoteroWatcher', () => {
       },
     ]);
 
-    mockClient.getFileUrl.mockResolvedValue('/Users/test/Zotero/storage/ATT1/paper.pdf');
+    mockClient.getFileUrl.mockResolvedValue(
+      '/Users/test/Zotero/storage/ATT1/paper.pdf',
+    );
 
     await watcher.poll();
 
     expect(enqueuedItems).toHaveLength(1);
-    expect(enqueuedItems[0].filePath).toBe('/Users/test/Zotero/storage/ATT1/paper.pdf');
+    expect(enqueuedItems[0].filePath).toBe(
+      '/Users/test/Zotero/storage/ATT1/paper.pdf',
+    );
     expect(enqueuedItems[0].zoteroKey).toBe('NEW1');
     expect(setZoteroSyncVersion).toHaveBeenCalledWith(150);
   });
 
   it('skips items already ingested (dedup by zotero_key)', async () => {
     vi.mocked(getZoteroSyncVersion).mockReturnValue(100);
-    vi.mocked(getIngestionJobByZoteroKey).mockReturnValue({ id: 'existing', status: 'completed' });
+    vi.mocked(getIngestionJobByZoteroKey).mockReturnValue({
+      id: 'existing',
+      status: 'completed',
+    });
 
     mockClient.getItems.mockResolvedValue({
-      items: [{ key: 'OLD1', data: { title: 'Old', collections: [], creators: [], date: '', tags: [] } }],
+      items: [
+        {
+          key: 'OLD1',
+          data: {
+            title: 'Old',
+            collections: [],
+            creators: [],
+            date: '',
+            tags: [],
+          },
+        },
+      ],
       version: 150,
     });
 
@@ -130,7 +165,19 @@ describe('ZoteroWatcher', () => {
     vi.mocked(getIngestionJobByZoteroKey).mockReturnValue(undefined);
 
     mockClient.getItems.mockResolvedValue({
-      items: [{ key: 'NOPDF', data: { title: 'Webpage', collections: [], creators: [], date: '', tags: [] }, meta: { numChildren: 0 } }],
+      items: [
+        {
+          key: 'NOPDF',
+          data: {
+            title: 'Webpage',
+            collections: [],
+            creators: [],
+            date: '',
+            tags: [],
+          },
+          meta: { numChildren: 0 },
+        },
+      ],
       version: 150,
     });
 
@@ -159,7 +206,17 @@ describe('ZoteroWatcher', () => {
 
     mockClient.getItems.mockResolvedValue({
       items: [
-        { key: 'EXCL_ITEM', data: { title: 'Excluded', collections: ['EXCL1'], creators: [], date: '', tags: [] }, meta: { numChildren: 1 } },
+        {
+          key: 'EXCL_ITEM',
+          data: {
+            title: 'Excluded',
+            collections: ['EXCL1'],
+            creators: [],
+            date: '',
+            tags: [],
+          },
+          meta: { numChildren: 1 },
+        },
       ],
       version: 150,
     });
@@ -167,11 +224,17 @@ describe('ZoteroWatcher', () => {
     mockClient.getChildren.mockResolvedValue([
       {
         key: 'ATT_EXCL',
-        data: { itemType: 'attachment', contentType: 'application/pdf', filename: 'paper.pdf' },
+        data: {
+          itemType: 'attachment',
+          contentType: 'application/pdf',
+          filename: 'paper.pdf',
+        },
         links: { enclosure: { length: 500000 } },
       },
     ]);
-    mockClient.getFileUrl.mockResolvedValue('/Users/test/Zotero/storage/ATT_EXCL/paper.pdf');
+    mockClient.getFileUrl.mockResolvedValue(
+      '/Users/test/Zotero/storage/ATT_EXCL/paper.pdf',
+    );
 
     // Must call start() so resolveExcludeCollection runs before polling
     await watcherWithExclude.start();
@@ -187,19 +250,39 @@ describe('ZoteroWatcher', () => {
     vi.mocked(getIngestionJobByZoteroKey).mockReturnValue(undefined);
 
     mockClient.getItems.mockResolvedValue({
-      items: [{ key: 'MULTI', data: { title: 'Multi', collections: [], creators: [], date: '', tags: [] }, meta: { numChildren: 2 } }],
+      items: [
+        {
+          key: 'MULTI',
+          data: {
+            title: 'Multi',
+            collections: [],
+            creators: [],
+            date: '',
+            tags: [],
+          },
+          meta: { numChildren: 2 },
+        },
+      ],
       version: 150,
     });
 
     mockClient.getChildren.mockResolvedValue([
       {
         key: 'SMALL',
-        data: { itemType: 'attachment', contentType: 'application/pdf', filename: 'supplement.pdf' },
+        data: {
+          itemType: 'attachment',
+          contentType: 'application/pdf',
+          filename: 'supplement.pdf',
+        },
         links: { enclosure: { length: 100000 } },
       },
       {
         key: 'BIG',
-        data: { itemType: 'attachment', contentType: 'application/pdf', filename: 'full-text.pdf' },
+        data: {
+          itemType: 'attachment',
+          contentType: 'application/pdf',
+          filename: 'full-text.pdf',
+        },
         links: { enclosure: { length: 5000000 } },
       },
     ]);

--- a/src/ingestion/zotero-watcher.ts
+++ b/src/ingestion/zotero-watcher.ts
@@ -10,7 +10,11 @@ import { logger } from '../logger.js';
 export interface ZoteroWatcherOpts {
   client: ZoteroLocalClient;
   excludeCollection: string;
-  onItem: (filePath: string, zoteroKey: string, metadata: ZoteroMetadata) => void;
+  onItem: (
+    filePath: string,
+    zoteroKey: string,
+    metadata: ZoteroMetadata,
+  ) => void;
   pollIntervalMs?: number;
 }
 
@@ -108,7 +112,11 @@ export class ZoteroWatcher {
         title: string;
         itemType: string;
         collections: string[];
-        creators: { firstName: string; lastName: string; creatorType: string }[];
+        creators: {
+          firstName: string;
+          lastName: string;
+          creatorType: string;
+        }[];
         date: string;
         DOI?: string;
         url?: string;
@@ -149,7 +157,8 @@ export class ZoteroWatcher {
     };
     meta: { numChildren?: number };
   }): Promise<void> {
-    if (item.data.itemType === 'attachment' || item.data.itemType === 'note') return;
+    if (item.data.itemType === 'attachment' || item.data.itemType === 'note')
+      return;
 
     if (
       this.excludeCollectionKey &&

--- a/src/ingestion/zotero-writeback.test.ts
+++ b/src/ingestion/zotero-writeback.test.ts
@@ -21,12 +21,19 @@ describe('ZoteroWriteBack', () => {
       addTag: vi.fn().mockResolvedValue(undefined),
       getLibraryVersion: vi.fn().mockResolvedValue(100),
     };
-    writeBack = new ZoteroWriteBack(mockWebClient as unknown as ZoteroWebClient);
+    writeBack = new ZoteroWriteBack(
+      mockWebClient as unknown as ZoteroWebClient,
+    );
   });
 
   it('writes summary note and tag to Zotero', async () => {
-    const sourceContent = '---\ntitle: Test Paper\n---\n\nThis is the summary body.';
-    const promotedPaths = ['sources/test-paper.md', 'concepts/concept-1.md', 'concepts/concept-2.md'];
+    const sourceContent =
+      '---\ntitle: Test Paper\n---\n\nThis is the summary body.';
+    const promotedPaths = [
+      'sources/test-paper.md',
+      'concepts/concept-1.md',
+      'concepts/concept-2.md',
+    ];
 
     await writeBack.writeBack('ABC12345', sourceContent, promotedPaths);
 
@@ -40,11 +47,15 @@ describe('ZoteroWriteBack', () => {
       expect.stringContaining('2 concepts'),
       100,
     );
-    expect(mockWebClient.addTag).toHaveBeenCalledWith('ABC12345', 'vault:ingested');
+    expect(mockWebClient.addTag).toHaveBeenCalledWith(
+      'ABC12345',
+      'vault:ingested',
+    );
   });
 
   it('converts markdown to basic HTML', async () => {
-    const sourceContent = '---\ntitle: Test\n---\n\n**Bold** and *italic* text.\n\nSecond paragraph.';
+    const sourceContent =
+      '---\ntitle: Test\n---\n\n**Bold** and *italic* text.\n\nSecond paragraph.';
 
     await writeBack.writeBack('ABC12345', sourceContent, ['sources/test.md']);
 

--- a/src/ingestion/zotero-writeback.ts
+++ b/src/ingestion/zotero-writeback.ts
@@ -88,7 +88,9 @@ export class ZoteroWriteBack {
           const items = trimmed
             .split(/\n/)
             .filter((l) => l.trim())
-            .map((l) => `<li>${this.inlineFormat(l.replace(/^[-*]\s+/, ''))}</li>`)
+            .map(
+              (l) => `<li>${this.inlineFormat(l.replace(/^[-*]\s+/, ''))}</li>`,
+            )
             .join('\n');
           return `<ul>\n${items}\n</ul>`;
         }


### PR DESCRIPTION
## Summary
- **Fixed expired Mistral API key** causing 401/500 TTS errors reported by Mr. Rogers
- **Raised `synthesize_speech` character limit** from 5,000 → 50,000 to support podcast-length audio, relying on Mistral's server-side interleaving for long generations
- **Increased TTS request timeout** from 60s → 5 minutes to accommodate longer audio synthesis
- **Formatting fixes** across Zotero ingestion files (prettier line-length compliance)

## Test plan
- [x] Verified new Mistral API key works (successful TTS API call)
- [x] Container image rebuilt with updated limits
- [ ] Test podcast-length TTS generation end-to-end
- [ ] Monitor for timeout or quality issues with server-side interleaving

🤖 Generated with [Claude Code](https://claude.com/claude-code)