### PR TITLE
feat: EPUB book reader with chapter navigation and persistence

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -13,6 +13,7 @@
         "@types/better-sqlite3": "^7.6.13",
         "better-sqlite3": "^12.8.0",
         "gray-matter": "^4.0.3",
+        "jszip": "^3.10.1",
         "next": "16.2.1",
         "pdfjs-dist": "^5.6.205",
         "react": "19.2.4",
@@ -26,6 +27,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
+        "jsdom": "^29.0.2",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -42,6 +44,45 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
+      "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -284,6 +325,161 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
@@ -459,6 +655,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -2821,6 +3035,16 @@
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -3127,6 +3351,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3140,6 +3370,20 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/cssesc": {
@@ -3166,6 +3410,20 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -3237,6 +3495,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -3412,6 +3677,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -4638,6 +4916,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -4677,6 +4968,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -5073,6 +5370,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5280,6 +5584,57 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -5343,6 +5698,54 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5394,6 +5797,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -5885,6 +6297,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -6783,6 +7202,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6820,6 +7245,19 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -6968,6 +7406,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -7204,6 +7648,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -7355,6 +7809,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -7432,6 +7899,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -7916,6 +8389,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -8014,6 +8494,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8025,6 +8525,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -8253,6 +8779,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -8456,6 +8992,54 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8576,6 +9160,23 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -14,6 +14,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "better-sqlite3": "^12.8.0",
     "gray-matter": "^4.0.3",
+    "jszip": "^3.10.1",
     "next": "16.2.1",
     "pdfjs-dist": "^5.6.205",
     "react": "19.2.4",
@@ -27,6 +28,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
+    "jsdom": "^29.0.2",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -15,6 +15,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <a href="/upload" className="hover:text-gray-100">Upload</a>
               <a href="/vault" className="hover:text-gray-100">Vault</a>
               <a href="/read" className="hover:text-gray-100">Read</a>
+              <a href="/read/book" className="hover:text-gray-100">Book</a>
             </div>
           </div>
         </nav>

--- a/dashboard/src/app/read/book/bookStore.ts
+++ b/dashboard/src/app/read/book/bookStore.ts
@@ -1,0 +1,107 @@
+// Types
+export interface StoredBook {
+  id: string;
+  title: string;
+  author: string;
+  chapters: { title: string; text: string; wordCount: number }[];
+  addedAt: number;
+}
+
+export interface ReadingState {
+  bookId: string;
+  currentChapter: number;
+  position: number;
+  wpm: number;
+  chunkSize: 1 | 2 | 3;
+  displayMode: 'orp' | 'centered' | 'orp+context';
+  lastRead: number;
+}
+
+// IndexedDB — book storage
+const DB_NAME = 'book-reader';
+const STORE_NAME = 'books';
+const DB_VERSION = 1;
+
+function openDB(): Promise<IDBDatabase> {
+  if (typeof indexedDB === 'undefined') {
+    return Promise.reject(new Error('IndexedDB not available'));
+  }
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function getAllBooks(): Promise<StoredBook[]> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.getAll();
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function getBook(id: string): Promise<StoredBook | undefined> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.get(id);
+    request.onsuccess = () => resolve(request.result ?? undefined);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function saveBook(book: StoredBook): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.put(book);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function deleteBook(id: string): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.delete(id);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+// localStorage — reading state
+function stateKey(bookId: string): string {
+  return `book-state:${bookId}`;
+}
+
+export function getReadingState(bookId: string): ReadingState | null {
+  const raw = localStorage.getItem(stateKey(bookId));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as ReadingState;
+  } catch {
+    return null;
+  }
+}
+
+export function saveReadingState(state: ReadingState): void {
+  localStorage.setItem(stateKey(state.bookId), JSON.stringify(state));
+}
+
+export function deleteReadingState(bookId: string): void {
+  localStorage.removeItem(stateKey(bookId));
+}

--- a/dashboard/src/app/read/book/epubParser.test.ts
+++ b/dashboard/src/app/read/book/epubParser.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { extractTextFromHtml, resolveHref } from './epubParser';
+
+describe('extractTextFromHtml', () => {
+  it('strips HTML tags and returns text content', () => {
+    const html = '<html><body><p>Hello <b>world</b></p></body></html>';
+    expect(extractTextFromHtml(html)).toBe('Hello world');
+  });
+
+  it('joins multiple paragraphs with newlines', () => {
+    const html = '<html><body><p>First.</p><p>Second.</p></body></html>';
+    const result = extractTextFromHtml(html);
+    expect(result).toContain('First.');
+    expect(result).toContain('Second.');
+  });
+
+  it('returns empty string for empty body', () => {
+    const html = '<html><body></body></html>';
+    expect(extractTextFromHtml(html)).toBe('');
+  });
+
+  it('handles self-closing tags', () => {
+    const html = '<html><body><p>Line one<br/>Line two</p></body></html>';
+    const result = extractTextFromHtml(html);
+    expect(result).toContain('Line one');
+    expect(result).toContain('Line two');
+  });
+});
+
+describe('resolveHref', () => {
+  it('prepends opfDir to relative href', () => {
+    expect(resolveHref('chapter1.xhtml', 'OEBPS/')).toBe('OEBPS/chapter1.xhtml');
+  });
+
+  it('handles empty opfDir', () => {
+    expect(resolveHref('chapter1.xhtml', '')).toBe('chapter1.xhtml');
+  });
+
+  it('handles nested paths', () => {
+    expect(resolveHref('text/ch1.xhtml', 'OEBPS/')).toBe('OEBPS/text/ch1.xhtml');
+  });
+
+  it('resolves ../ segments', () => {
+    expect(resolveHref('../Text/ch1.xhtml', 'OEBPS/nav/')).toBe('OEBPS/Text/ch1.xhtml');
+  });
+
+  it('decodes URL-encoded characters', () => {
+    expect(resolveHref('chapter%201.xhtml', 'OEBPS/')).toBe('OEBPS/chapter 1.xhtml');
+  });
+});

--- a/dashboard/src/app/read/book/epubParser.ts
+++ b/dashboard/src/app/read/book/epubParser.ts
@@ -1,0 +1,187 @@
+import JSZip from 'jszip';
+
+// Types
+export interface ParsedBook {
+  title: string;
+  author: string;
+  chapters: ParsedChapter[];
+}
+
+export interface ParsedChapter {
+  title: string;
+  text: string;
+  wordCount: number;
+}
+
+// Public API
+export async function parseEpub(buffer: ArrayBuffer): Promise<ParsedBook> {
+  const zip = await JSZip.loadAsync(buffer);
+
+  const containerXml = await readZipText(zip, 'META-INF/container.xml');
+  if (!containerXml) throw new Error('Invalid EPUB: missing META-INF/container.xml');
+
+  const containerDoc = parseXml(containerXml);
+  const rootfileEl = containerDoc.getElementsByTagNameNS('*', 'rootfile')[0];
+  const opfPath = rootfileEl?.getAttribute('full-path');
+  if (!opfPath) throw new Error('Invalid EPUB: no rootfile path found');
+
+  const opfXml = await readZipText(zip, opfPath);
+  if (!opfXml) throw new Error(`Invalid EPUB: missing OPF file at ${opfPath}`);
+
+  const opfDoc = parseXml(opfXml);
+  const opfDir = opfPath.includes('/') ? opfPath.substring(0, opfPath.lastIndexOf('/') + 1) : '';
+
+  const DC_NS = 'http://purl.org/dc/elements/1.1/';
+  const title = opfDoc.getElementsByTagNameNS(DC_NS, 'title')[0]?.textContent?.trim() ?? 'Untitled';
+  const author = opfDoc.getElementsByTagNameNS(DC_NS, 'creator')[0]?.textContent?.trim() ?? '';
+
+  const manifest = new Map<string, string>();
+  const manifestItems = opfDoc.getElementsByTagNameNS('*', 'item');
+  for (let i = 0; i < manifestItems.length; i++) {
+    const item = manifestItems[i];
+    const id = item.getAttribute('id');
+    const href = item.getAttribute('href');
+    if (id && href) manifest.set(id, href);
+  }
+
+  const spineIds: string[] = [];
+  const spineItemrefs = opfDoc.getElementsByTagNameNS('*', 'itemref');
+  for (let i = 0; i < spineItemrefs.length; i++) {
+    const idref = spineItemrefs[i].getAttribute('idref');
+    if (idref) spineIds.push(idref);
+  }
+
+  const tocTitles = await parseToc(zip, opfDoc, opfDir, manifest);
+
+  const chapters: ParsedChapter[] = [];
+  let untitledIndex = 0;
+
+  for (const id of spineIds) {
+    const href = manifest.get(id);
+    if (!href) continue;
+
+    const filePath = resolveHref(href, opfDir);
+    const xhtml = await readZipText(zip, filePath);
+    if (!xhtml) continue;
+
+    const text = extractTextFromHtml(xhtml);
+    const wordCount = text ? text.trim().split(/\s+/).length : 0;
+
+    if (wordCount < 5) continue;
+
+    const chapterTitle = tocTitles.get(filePath) ?? `Chapter ${++untitledIndex}`;
+    chapters.push({ title: chapterTitle, text, wordCount });
+  }
+
+  if (chapters.length === 0) {
+    throw new Error('No readable chapters found in this EPUB.');
+  }
+
+  return { title, author, chapters };
+}
+
+// Exported helpers (tested directly)
+
+export function extractTextFromHtml(html: string): string {
+  let doc = new DOMParser().parseFromString(html, 'application/xhtml+xml');
+  if (doc.querySelector('parsererror')) {
+    doc = new DOMParser().parseFromString(html, 'text/html');
+  }
+  const body = doc.body ?? doc.documentElement;
+  return (body.textContent ?? '').trim();
+}
+
+export function resolveHref(href: string, opfDir: string): string {
+  const decoded = decodeURIComponent(href);
+  const combined = opfDir + decoded;
+  const parts = combined.split('/');
+  const resolved: string[] = [];
+  for (const part of parts) {
+    if (part === '..') {
+      resolved.pop();
+    } else if (part !== '.') {
+      resolved.push(part);
+    }
+  }
+  return resolved.join('/');
+}
+
+// Internal helpers
+
+function parseXml(xml: string): Document {
+  return new DOMParser().parseFromString(xml, 'application/xml');
+}
+
+async function readZipText(zip: JSZip, path: string): Promise<string | null> {
+  const file = zip.file(path);
+  if (!file) return null;
+  return file.async('text');
+}
+
+async function parseToc(
+  zip: JSZip,
+  opfDoc: Document,
+  opfDir: string,
+  manifest: Map<string, string>,
+): Promise<Map<string, string>> {
+  const titles = new Map<string, string>();
+
+  const manifestItems = opfDoc.getElementsByTagNameNS('*', 'item');
+  let navDir = opfDir;
+  for (let i = 0; i < manifestItems.length; i++) {
+    const item = manifestItems[i];
+    const props = item.getAttribute('properties') ?? '';
+    if (props.includes('nav')) {
+      const navHref = item.getAttribute('href');
+      if (!navHref) continue;
+
+      const navPath = resolveHref(navHref, opfDir);
+      navDir = navPath.includes('/') ? navPath.substring(0, navPath.lastIndexOf('/') + 1) : '';
+      const navXhtml = await readZipText(zip, navPath);
+      if (!navXhtml) continue;
+
+      const navDoc = new DOMParser().parseFromString(navXhtml, 'text/html');
+      const navElements = navDoc.getElementsByTagName('nav');
+      for (let n = 0; n < navElements.length; n++) {
+        const nav = navElements[n];
+        const epubType = nav.getAttribute('epub:type') ?? nav.getAttributeNS('http://www.idpf.org/2007/ops', 'type') ?? '';
+        if (epubType !== 'toc' && nav.id !== 'toc') continue;
+
+        const links = nav.getElementsByTagName('a');
+        for (let l = 0; l < links.length; l++) {
+          const a = links[l];
+          const rawHref = a.getAttribute('href')?.split('#')[0];
+          const text = a.textContent?.trim();
+          if (rawHref && text) titles.set(resolveHref(rawHref, navDir), text);
+        }
+      }
+
+      if (titles.size > 0) return titles;
+    }
+  }
+
+  const spineEl = opfDoc.getElementsByTagNameNS('*', 'spine')[0];
+  const tocId = spineEl?.getAttribute('toc');
+  if (tocId) {
+    const ncxHref = manifest.get(tocId);
+    if (ncxHref) {
+      const ncxPath = resolveHref(ncxHref, opfDir);
+      const ncxDir = ncxPath.includes('/') ? ncxPath.substring(0, ncxPath.lastIndexOf('/') + 1) : '';
+      const ncxXml = await readZipText(zip, ncxPath);
+      if (ncxXml) {
+        const ncxDoc = parseXml(ncxXml);
+        const navPoints = ncxDoc.getElementsByTagNameNS('*', 'navPoint');
+        for (let i = 0; i < navPoints.length; i++) {
+          const np = navPoints[i];
+          const textEl = np.getElementsByTagNameNS('*', 'text')[0];
+          const contentEl = np.getElementsByTagNameNS('*', 'content')[0];
+          const text = textEl?.textContent?.trim();
+          const src = contentEl?.getAttribute('src')?.split('#')[0];
+          if (text && src) titles.set(resolveHref(src, ncxDir), text);
+        }
+      }
+    }
+  }
+
+  return titles;
+}

--- a/dashboard/src/app/read/book/page.tsx
+++ b/dashboard/src/app/read/book/page.tsx
@@ -270,8 +270,9 @@ export default function BookReaderPage() {
   // -----------------------------------------------------------------------
 
   function goToChapter(index: number, pos: number) {
-    if (!currentBook) return;
-    const chapter = currentBook.chapters[index];
+    const book = currentBookRef.current;
+    if (!book) return;
+    const chapter = book.chapters[index];
     if (!chapter) return;
     setCurrentChapterIndex(index);
     setInitialPosition(pos);
@@ -351,7 +352,7 @@ export default function BookReaderPage() {
       setCurrentBook(book);
       setCurrentChapterIndex(0);
       setInitialPosition(0);
-      setChapterText(book.chapters[0].text);
+      setChapterText(book.chapters[0]?.text ?? '');
       readingStartTime.current = Date.now();
       totalPauseTime.current = 0;
       lastPauseStart.current = 0;

--- a/dashboard/src/app/read/book/page.tsx
+++ b/dashboard/src/app/read/book/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { useRSVPEngine, type TokenizedWord } from '../useRSVPEngine';
+import { useRSVPEngine } from '../useRSVPEngine';
 import {
   formatTime,
   getFontSize,
@@ -11,7 +11,7 @@ import {
   ContextDisplay,
   SourcePanel,
 } from '../components';
-import { parseEpub, type ParsedChapter } from './epubParser';
+import { parseEpub } from './epubParser';
 import {
   getAllBooks,
   getBook,
@@ -295,6 +295,7 @@ export default function BookReaderPage() {
     setCurrentChapterIndex(chIdx);
     setInitialPosition(pos);
     setChapterText(book.chapters[chIdx]?.text ?? '');
+    setTextVersion((v) => v + 1);
     readingStartTime.current = Date.now();
     totalPauseTime.current = 0;
     lastPauseStart.current = 0;
@@ -374,8 +375,8 @@ export default function BookReaderPage() {
   const fontSize = getFontSize(engine.currentChunk);
   const showSettings = !engine.isPlaying && phase === 'reading';
   const currentChapter = currentBook?.chapters[currentChapterIndex];
-  const chapterProgress = currentChapter
-    ? Math.round((engine.position / currentChapter.wordCount) * 100)
+  const chapterProgress = engine.totalWords > 0
+    ? Math.round((engine.position / engine.totalWords) * 100)
     : 0;
   const overallProgress = currentBook
     ? (() => {
@@ -663,7 +664,7 @@ export default function BookReaderPage() {
         </div>
       ) : (
         <div className="space-y-3">
-          {books
+          {[...books]
             .sort((a, b) => {
               const stateA = getReadingState(a.id);
               const stateB = getReadingState(b.id);

--- a/dashboard/src/app/read/book/page.tsx
+++ b/dashboard/src/app/read/book/page.tsx
@@ -1,0 +1,715 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { useRSVPEngine, type TokenizedWord } from '../useRSVPEngine';
+import {
+  formatTime,
+  getFontSize,
+  segmentClass,
+  ORPDisplay,
+  CenteredDisplay,
+  ContextDisplay,
+  SourcePanel,
+} from '../components';
+import { parseEpub, type ParsedChapter } from './epubParser';
+import {
+  getAllBooks,
+  getBook,
+  saveBook,
+  deleteBook,
+  getReadingState,
+  saveReadingState,
+  deleteReadingState,
+  type StoredBook,
+  type ReadingState,
+} from './bookStore';
+import { generateBookId, extractCurrentSentence } from './utils';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Phase = 'library' | 'upload' | 'reading' | 'complete';
+type DisplayMode = 'orp' | 'centered' | 'orp+context';
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+export default function BookReaderPage() {
+  const [phase, setPhase] = useState<Phase>('library');
+  const [books, setBooks] = useState<StoredBook[]>([]);
+  const [loadingLibrary, setLoadingLibrary] = useState(true);
+
+  // Upload state
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  // Reading state
+  const [currentBook, setCurrentBook] = useState<StoredBook | null>(null);
+  const [currentChapterIndex, setCurrentChapterIndex] = useState(0);
+  const [chapterText, setChapterText] = useState('');
+  const [wpm, setWpm] = useState(250);
+  const [chunkSize, setChunkSize] = useState<1 | 2 | 3>(1);
+  const [displayMode, setDisplayMode] = useState<DisplayMode>('orp');
+  const [sourceExpanded, setSourceExpanded] = useState(false);
+  const [initialPosition, setInitialPosition] = useState(0);
+  const [copiedSentence, setCopiedSentence] = useState(false);
+  const [textVersion, setTextVersion] = useState(0);
+
+  // Timing refs
+  const readingStartTime = useRef(0);
+  const totalPauseTime = useRef(0);
+  const lastPauseStart = useRef(0);
+  const autoSaveInterval = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Refs for values needed in stable callbacks (avoids stale closures)
+  const currentBookRef = useRef(currentBook);
+  const currentChapterIndexRef = useRef(currentChapterIndex);
+  useEffect(() => { currentBookRef.current = currentBook; }, [currentBook]);
+  useEffect(() => { currentChapterIndexRef.current = currentChapterIndex; }, [currentChapterIndex]);
+
+  const engine = useRSVPEngine({ text: chapterText, wpm, chunkSize, initialPosition, textVersion });
+
+  // Completion stats
+  const [completionStats, setCompletionStats] = useState<{
+    totalTime: number;
+    effectiveWpm: number;
+  } | null>(null);
+
+  // -----------------------------------------------------------------------
+  // Load library on mount
+  // -----------------------------------------------------------------------
+
+  useEffect(() => {
+    getAllBooks().then((b) => {
+      setBooks(b);
+      setLoadingLibrary(false);
+    });
+  }, []);
+
+  // -----------------------------------------------------------------------
+  // Auto-save on visibilitychange
+  // -----------------------------------------------------------------------
+
+  // Use engine position via ref so the callback stays stable during playback.
+  // Without this, engine.position in deps causes the 30s interval to restart every word.
+  const enginePositionRef = useRef(engine.position);
+  useEffect(() => { enginePositionRef.current = engine.position; }, [engine.position]);
+
+  const saveCurrentState = useCallback(() => {
+    const book = currentBookRef.current;
+    if (!book) return;
+    saveReadingState({
+      bookId: book.id,
+      currentChapter: currentChapterIndexRef.current,
+      position: enginePositionRef.current,
+      wpm,
+      chunkSize,
+      displayMode,
+      lastRead: Date.now(),
+    });
+  }, [wpm, chunkSize, displayMode]);
+
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.hidden && phase === 'reading') {
+        saveCurrentState();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, [phase, saveCurrentState]);
+
+  // Auto-save every 30s during playback
+  useEffect(() => {
+    if (phase === 'reading' && engine.isPlaying) {
+      autoSaveInterval.current = setInterval(saveCurrentState, 30000);
+    } else if (autoSaveInterval.current) {
+      clearInterval(autoSaveInterval.current);
+      autoSaveInterval.current = null;
+    }
+    return () => {
+      if (autoSaveInterval.current) clearInterval(autoSaveInterval.current);
+    };
+  }, [phase, engine.isPlaying, saveCurrentState]);
+
+  // Save on pause
+  useEffect(() => {
+    if (phase === 'reading' && !engine.isPlaying && currentBookRef.current) {
+      saveCurrentState();
+    }
+  }, [engine.isPlaying, phase, saveCurrentState]);
+
+  // Track pause time
+  useEffect(() => {
+    if (phase !== 'reading') return;
+    if (!engine.isPlaying) {
+      lastPauseStart.current = Date.now();
+    } else if (lastPauseStart.current > 0) {
+      totalPauseTime.current += Date.now() - lastPauseStart.current;
+      lastPauseStart.current = 0;
+    }
+  }, [engine.isPlaying, phase]);
+
+  // Detect chapter completion → auto-advance or book completion
+  useEffect(() => {
+    if (
+      phase === 'reading' &&
+      !engine.isPlaying &&
+      engine.position >= engine.totalWords &&
+      engine.totalWords > 0
+    ) {
+      const book = currentBookRef.current;
+      const chIdx = currentChapterIndexRef.current;
+      if (!book) return;
+      const isLastChapter = chIdx >= book.chapters.length - 1;
+
+      if (isLastChapter) {
+        // Book complete
+        if (lastPauseStart.current > 0) {
+          totalPauseTime.current += Date.now() - lastPauseStart.current;
+          lastPauseStart.current = 0;
+        }
+        const totalTime = (Date.now() - readingStartTime.current - totalPauseTime.current) / 1000;
+        const totalWords = book.chapters.reduce((sum, ch) => sum + ch.wordCount, 0);
+        const effectiveWpm = totalTime > 0 ? Math.round(totalWords / (totalTime / 60)) : 0;
+        setCompletionStats({ totalTime, effectiveWpm });
+        setPhase('complete');
+      } else {
+        // Advance to next chapter
+        goToChapter(chIdx + 1, 0);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [engine.isPlaying, engine.position, engine.totalWords, phase]);
+
+  // -----------------------------------------------------------------------
+  // Stable engine ref for keyboard handler
+  // -----------------------------------------------------------------------
+
+  const engineRef = useRef(engine);
+  useEffect(() => {
+    engineRef.current = engine;
+  }, [engine]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (phase !== 'reading' && phase !== 'complete') return;
+      const target = e.target as HTMLElement;
+      const tag = target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || tag === 'BUTTON' || target.getAttribute('role') === 'slider') return;
+
+      const eng = engineRef.current;
+
+      switch (e.code) {
+        case 'Space':
+          e.preventDefault();
+          eng.isPlaying ? eng.pause() : eng.play();
+          break;
+        case 'ArrowLeft':
+          eng.seek(-10);
+          break;
+        case 'ArrowRight':
+          eng.seek(10);
+          break;
+        case 'ArrowUp':
+          setWpm((w) => Math.min(800, w + 25));
+          break;
+        case 'ArrowDown':
+          setWpm((w) => Math.max(100, w - 25));
+          break;
+        case 'KeyR':
+          eng.restart();
+          break;
+        case 'KeyT':
+          setSourceExpanded((v) => !v);
+          break;
+        case 'KeyM':
+          setDisplayMode((m) => {
+            if (m === 'orp') return 'centered';
+            if (m === 'centered') return 'orp+context';
+            return 'orp';
+          });
+          break;
+        case 'KeyC':
+          setChunkSize((c) => {
+            if (c === 1) return 2;
+            if (c === 2) return 3;
+            return 1;
+          });
+          break;
+        case 'BracketLeft':
+          if (currentBook && currentChapterIndex > 0) {
+            goToChapter(currentChapterIndex - 1, 0);
+          }
+          break;
+        case 'BracketRight':
+          if (currentBook && currentChapterIndex < currentBook.chapters.length - 1) {
+            goToChapter(currentChapterIndex + 1, 0);
+          }
+          break;
+        case 'Escape':
+          saveCurrentState();
+          setPhase('library');
+          break;
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [phase, currentBook, currentChapterIndex]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  // -----------------------------------------------------------------------
+  // Actions
+  // -----------------------------------------------------------------------
+
+  function goToChapter(index: number, pos: number) {
+    if (!currentBook) return;
+    const chapter = currentBook.chapters[index];
+    if (!chapter) return;
+    setCurrentChapterIndex(index);
+    setInitialPosition(pos);
+    setChapterText(chapter.text);
+    setTextVersion((v) => v + 1); // Force engine re-init even if same text
+  }
+
+  async function openBook(bookId: string) {
+    const book = await getBook(bookId);
+    if (!book) return;
+
+    setCurrentBook(book);
+    const state = getReadingState(bookId);
+
+    const chIdx = state?.currentChapter ?? 0;
+    const pos = state?.position ?? 0;
+    if (state?.wpm) setWpm(state.wpm);
+    if (state?.chunkSize) setChunkSize(state.chunkSize);
+    if (state?.displayMode) setDisplayMode(state.displayMode);
+
+    setCurrentChapterIndex(chIdx);
+    setInitialPosition(pos);
+    setChapterText(book.chapters[chIdx]?.text ?? '');
+    readingStartTime.current = Date.now();
+    totalPauseTime.current = 0;
+    lastPauseStart.current = 0;
+    setPhase('reading');
+  }
+
+  async function handleRemoveBook(bookId: string) {
+    if (!confirm('Remove this book? Reading progress will be lost.')) return;
+    await deleteBook(bookId);
+    deleteReadingState(bookId);
+    setBooks((prev) => prev.filter((b) => b.id !== bookId));
+  }
+
+  async function handleFile(file: File) {
+    if (!file.name.toLowerCase().endsWith('.epub')) {
+      setUploadError('Please upload an .epub file.');
+      return;
+    }
+
+    setUploading(true);
+    setUploadError(null);
+
+    try {
+      const buffer = await file.arrayBuffer();
+      const id = await generateBookId(buffer);
+
+      // Check if book already exists
+      const existing = await getBook(id);
+      if (existing) {
+        if (!confirm(`"${existing.title}" is already in your library. Replace it? Reading progress will be reset.`)) {
+          setUploading(false);
+          return;
+        }
+        deleteReadingState(id);
+      }
+
+      const parsed = await parseEpub(buffer);
+      const book: StoredBook = {
+        id,
+        title: parsed.title,
+        author: parsed.author,
+        chapters: parsed.chapters,
+        addedAt: Date.now(),
+      };
+
+      await saveBook(book);
+      setBooks((prev) => {
+        const filtered = prev.filter((b) => b.id !== id);
+        return [...filtered, book];
+      });
+
+      // Go directly to reading
+      setCurrentBook(book);
+      setCurrentChapterIndex(0);
+      setInitialPosition(0);
+      setChapterText(book.chapters[0].text);
+      readingStartTime.current = Date.now();
+      totalPauseTime.current = 0;
+      lastPauseStart.current = 0;
+      setPhase('reading');
+    } catch (err) {
+      const message = err instanceof DOMException && err.name === 'QuotaExceededError'
+        ? 'Storage full. Remove some books to make room.'
+        : err instanceof Error
+          ? err.message
+          : 'Failed to parse EPUB file.';
+      setUploadError(message);
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Computed values
+  // -----------------------------------------------------------------------
+
+  const fontSize = getFontSize(engine.currentChunk);
+  const showSettings = !engine.isPlaying && phase === 'reading';
+  const currentChapter = currentBook?.chapters[currentChapterIndex];
+  const chapterProgress = currentChapter
+    ? Math.round((engine.position / currentChapter.wordCount) * 100)
+    : 0;
+  const overallProgress = currentBook
+    ? (() => {
+        const totalWords = currentBook.chapters.reduce((s, c) => s + c.wordCount, 0);
+        const wordsBefore = currentBook.chapters.slice(0, currentChapterIndex).reduce((s, c) => s + c.wordCount, 0);
+        return Math.round(((wordsBefore + engine.position) / totalWords) * 100);
+      })()
+    : 0;
+
+  // "Find my place" sentence
+  const currentSentence = (() => {
+    if (!currentChapter) return '';
+    const words = currentChapter.text.trim().split(/\s+/);
+    return extractCurrentSentence(words, engine.position);
+  })();
+
+  async function copySentence() {
+    await navigator.clipboard.writeText(currentSentence);
+    setCopiedSentence(true);
+    setTimeout(() => setCopiedSentence(false), 2000);
+  }
+
+  // -----------------------------------------------------------------------
+  // Render: complete phase
+  // -----------------------------------------------------------------------
+
+  if (phase === 'complete') {
+    const totalWords = currentBook?.chapters.reduce((s, c) => s + c.wordCount, 0) ?? 0;
+    return (
+      <div className="max-w-2xl mx-auto">
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-10 text-center">
+          <h2 className="text-2xl font-semibold text-gray-100 mb-2">Book Complete</h2>
+          <p className="text-gray-400 mb-8">{currentBook?.title}</p>
+
+          {completionStats && (
+            <div className="flex justify-center gap-12 mb-10">
+              <div>
+                <p className="text-3xl font-mono text-blue-400">{formatTime(completionStats.totalTime)}</p>
+                <p className="text-xs text-gray-500 mt-1 uppercase tracking-wide">Time</p>
+              </div>
+              <div>
+                <p className="text-3xl font-mono text-blue-400">{completionStats.effectiveWpm.toLocaleString()}</p>
+                <p className="text-xs text-gray-500 mt-1 uppercase tracking-wide">Effective WPM</p>
+              </div>
+              <div>
+                <p className="text-3xl font-mono text-blue-400">{totalWords.toLocaleString()}</p>
+                <p className="text-xs text-gray-500 mt-1 uppercase tracking-wide">Words</p>
+              </div>
+            </div>
+          )}
+
+          <button
+            className="px-6 py-2.5 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+            onClick={() => {
+              setCompletionStats(null);
+              setPhase('library');
+            }}
+          >
+            Back to Library
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // Render: reading phase
+  // -----------------------------------------------------------------------
+
+  if (phase === 'reading' && currentBook && currentChapter) {
+    return (
+      <div className="max-w-2xl mx-auto select-none">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-4">
+          <button
+            className="text-gray-500 hover:text-gray-300 text-sm transition-colors"
+            onClick={() => { saveCurrentState(); setPhase('library'); }}
+            title="Back to library (Esc)"
+          >
+            ← Library
+          </button>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm text-gray-400 truncate">{currentBook.title}</p>
+          </div>
+          <select
+            className="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm text-gray-200 focus:outline-none focus:border-gray-600 max-w-[200px]"
+            value={currentChapterIndex}
+            onChange={(e) => goToChapter(Number(e.target.value), 0)}
+          >
+            {currentBook.chapters.map((ch, i) => (
+              <option key={i} value={i}>{ch.title}</option>
+            ))}
+          </select>
+          <span className="text-xs text-gray-500 whitespace-nowrap">
+            {currentChapterIndex + 1}/{currentBook.chapters.length} — {chapterProgress}%
+          </span>
+        </div>
+
+        {/* Display area */}
+        <div className="py-20 flex items-center justify-center min-h-[160px]">
+          {displayMode === 'orp' && <ORPDisplay chunk={engine.currentChunk} fontSize={fontSize} />}
+          {displayMode === 'centered' && <CenteredDisplay chunk={engine.currentChunk} fontSize={fontSize} />}
+          {displayMode === 'orp+context' && (
+            <ContextDisplay chunk={engine.currentChunk} words={engine.words} position={engine.position} fontSize={fontSize} />
+          )}
+        </div>
+
+        {/* Find my place panel */}
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-3 mb-4">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-xs text-gray-500">
+              Chapter {currentChapterIndex + 1} — {chapterProgress}% · Book {overallProgress}%
+            </span>
+            <button
+              className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+              onClick={copySentence}
+              title="Copy sentence to clipboard"
+            >
+              {copiedSentence ? 'Copied!' : 'Copy'}
+            </button>
+          </div>
+          <p className="text-sm text-gray-400 leading-relaxed">{currentSentence}</p>
+        </div>
+
+        {/* Progress bar */}
+        <div className="mb-4">
+          <div
+            className="h-2 bg-gray-800 rounded-full cursor-pointer"
+            onClick={(e) => {
+              const rect = e.currentTarget.getBoundingClientRect();
+              const pct = (e.clientX - rect.left) / rect.width;
+              engine.jumpTo(Math.round(pct * engine.totalWords));
+            }}
+          >
+            <div
+              className="h-full bg-blue-600 rounded-full transition-all"
+              style={{ width: `${engine.progress * 100}%` }}
+            />
+          </div>
+          <div className="flex justify-between text-xs text-gray-500 mt-1">
+            <span>Word {engine.position} / {engine.totalWords}</span>
+            <span>{formatTime(engine.estimatedTimeLeft)} left</span>
+          </div>
+        </div>
+
+        {/* Transport controls */}
+        <div className="flex items-center justify-center gap-3 mb-4">
+          <button className="px-3 py-2 rounded bg-gray-800 text-gray-300 hover:bg-gray-700 text-sm transition-colors" onClick={() => engine.seek(-10)} title="Seek back 10s (←)">←10s</button>
+          <button className="px-5 py-2 rounded bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium transition-colors min-w-[80px]" onClick={() => (engine.isPlaying ? engine.pause() : engine.play())} title="Play/Pause (Space)">
+            {engine.isPlaying ? 'Pause' : 'Play'}
+          </button>
+          <button className="px-3 py-2 rounded bg-gray-800 text-gray-300 hover:bg-gray-700 text-sm transition-colors" onClick={() => engine.seek(10)} title="Seek forward 10s (→)">10s→</button>
+          <button className="px-3 py-2 rounded bg-gray-800 text-gray-300 hover:bg-gray-700 text-sm transition-colors" onClick={() => engine.restart()} title="Restart chapter (R)">↺</button>
+        </div>
+
+        {/* Status bar */}
+        <div className="flex items-center justify-center gap-4 text-xs text-gray-500 mb-4">
+          <span>WPM: <span className="text-gray-300">{wpm}</span> <span className="text-gray-600">(↑↓)</span></span>
+          <span>Chunk: <span className="text-gray-300">{chunkSize}</span> <span className="text-gray-600">(C)</span></span>
+          <span>Mode: <span className="text-gray-300">{displayMode}</span> <span className="text-gray-600">(M)</span></span>
+          <button className="text-gray-500 hover:text-gray-300 transition-colors" onClick={() => setSourceExpanded((v) => !v)} title="Toggle source (T)">
+            Source <span className="text-gray-600">(T)</span>
+          </button>
+          <span>Ch: <span className="text-gray-600">[ ]</span></span>
+        </div>
+
+        {/* Settings panel — visible on pause */}
+        {showSettings && (
+          <div className="bg-gray-900 border border-gray-800 rounded-lg p-4 mb-4">
+            <div className="flex flex-wrap gap-6 items-center">
+              <div className="flex items-center gap-3 flex-1 min-w-48">
+                <label className="text-xs text-gray-400 uppercase tracking-wide whitespace-nowrap">WPM</label>
+                <input type="range" min={100} max={800} step={25} value={wpm} onChange={(e) => setWpm(Number(e.target.value))} className="flex-1 accent-blue-500" />
+                <input type="number" min={100} max={800} step={25} value={wpm} onChange={(e) => setWpm(Math.min(800, Math.max(100, Number(e.target.value))))} className="w-16 bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm text-center text-gray-100 focus:outline-none focus:border-gray-600" />
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-gray-400 uppercase tracking-wide whitespace-nowrap">Words</span>
+                <div className="flex gap-1">
+                  {([1, 2, 3] as const).map((n) => (
+                    <button key={n} className={segmentClass(chunkSize === n)} onClick={() => setChunkSize(n)}>{n}</button>
+                  ))}
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-gray-400 uppercase tracking-wide whitespace-nowrap">Mode</span>
+                <div className="flex gap-1">
+                  {([
+                    { value: 'orp' as const, label: 'ORP' },
+                    { value: 'centered' as const, label: 'Centered' },
+                    { value: 'orp+context' as const, label: 'ORP + Context' },
+                  ]).map(({ value, label }) => (
+                    <button key={value} className={segmentClass(displayMode === value)} onClick={() => setDisplayMode(value)}>{label}</button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Source panel */}
+        {(sourceExpanded || showSettings) && (
+          <SourcePanel text={chapterText} words={engine.words} position={engine.position} />
+        )}
+      </div>
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // Render: upload phase
+  // -----------------------------------------------------------------------
+
+  if (phase === 'upload') {
+    return (
+      <div className="max-w-2xl mx-auto">
+        <div className="flex items-center gap-3 mb-6">
+          <button
+            className="text-gray-500 hover:text-gray-300 text-sm transition-colors"
+            onClick={() => setPhase('library')}
+          >
+            ← Library
+          </button>
+          <h2 className="text-xl font-semibold">Add Book</h2>
+        </div>
+
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+          <div
+            className={`border-2 border-dashed rounded-lg p-10 text-center transition-colors ${
+              dragging ? 'border-blue-500 bg-blue-950/20' : 'border-gray-700 hover:border-gray-600'
+            }`}
+            onDrop={(e) => { e.preventDefault(); setDragging(false); const f = e.dataTransfer.files[0]; if (f) handleFile(f); }}
+            onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
+            onDragLeave={() => setDragging(false)}
+          >
+            {uploading ? (
+              <p className="text-gray-400 text-sm">Parsing EPUB...</p>
+            ) : (
+              <>
+                <p className="text-gray-400 mb-2 text-sm">
+                  Drag and drop an EPUB file here, or{' '}
+                  <label className="text-blue-400 hover:text-blue-300 cursor-pointer underline">
+                    browse
+                    <input type="file" accept=".epub" className="hidden" onChange={(e) => { const f = e.target.files?.[0]; if (f) handleFile(f); }} />
+                  </label>
+                </p>
+                <p className="text-xs text-gray-600">Supports .epub files</p>
+              </>
+            )}
+          </div>
+
+          {uploadError && (
+            <p className="text-sm text-red-400 mt-3">{uploadError}</p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // Render: library phase (default)
+  // -----------------------------------------------------------------------
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-xl font-semibold">Book Library</h2>
+        <button
+          className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+          onClick={() => { setUploadError(null); setPhase('upload'); }}
+        >
+          Add Book
+        </button>
+      </div>
+
+      {loadingLibrary ? (
+        <p className="text-gray-500 text-sm">Loading...</p>
+      ) : books.length === 0 ? (
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-10 text-center">
+          <p className="text-gray-400 mb-4">No books yet</p>
+          <button
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+            onClick={() => { setUploadError(null); setPhase('upload'); }}
+          >
+            Upload an EPUB
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {books
+            .sort((a, b) => {
+              const stateA = getReadingState(a.id);
+              const stateB = getReadingState(b.id);
+              return (stateB?.lastRead ?? b.addedAt) - (stateA?.lastRead ?? a.addedAt);
+            })
+            .map((book) => {
+              const state = getReadingState(book.id);
+              const chIdx = state?.currentChapter ?? 0;
+              const totalWords = book.chapters.reduce((s, c) => s + c.wordCount, 0);
+              const wordsBefore = book.chapters.slice(0, chIdx).reduce((s, c) => s + c.wordCount, 0);
+              const overallPct = totalWords > 0 ? Math.round(((wordsBefore + (state?.position ?? 0)) / totalWords) * 100) : 0;
+              const lastRead = state?.lastRead ? new Date(state.lastRead).toLocaleDateString() : null;
+
+              return (
+                <div
+                  key={book.id}
+                  className="bg-gray-900 border border-gray-800 rounded-lg p-4 hover:border-gray-700 transition-colors cursor-pointer"
+                  onClick={() => openBook(book.id)}
+                >
+                  <div className="flex items-start justify-between">
+                    <div className="flex-1 min-w-0">
+                      <h3 className="text-gray-100 font-medium truncate">{book.title}</h3>
+                      {book.author && <p className="text-sm text-gray-500">{book.author}</p>}
+                      <div className="flex items-center gap-3 mt-2 text-xs text-gray-500">
+                        <span>Chapter {chIdx + 1} / {book.chapters.length}</span>
+                        <span>{overallPct}%</span>
+                        {lastRead && <span>Last read: {lastRead}</span>}
+                      </div>
+                      {/* Mini progress bar */}
+                      <div className="h-1 bg-gray-800 rounded-full mt-2 w-full">
+                        <div className="h-full bg-blue-600 rounded-full" style={{ width: `${overallPct}%` }} />
+                      </div>
+                    </div>
+                    <button
+                      className="text-gray-600 hover:text-red-400 text-sm ml-3 transition-colors"
+                      onClick={(e) => { e.stopPropagation(); handleRemoveBook(book.id); }}
+                      title="Remove book"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/app/read/book/utils.test.ts
+++ b/dashboard/src/app/read/book/utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { extractCurrentSentence } from './utils';
+
+describe('extractCurrentSentence', () => {
+  it('extracts a simple sentence around the given word index', () => {
+    const words = ['The', 'cat', 'sat.', 'The', 'dog', 'ran.'];
+    expect(extractCurrentSentence(words, 1)).toBe('The cat sat.');
+  });
+
+  it('extracts the second sentence when index is in it', () => {
+    const words = ['The', 'cat', 'sat.', 'The', 'dog', 'ran.'];
+    expect(extractCurrentSentence(words, 4)).toBe('The dog ran.');
+  });
+
+  it('handles index at the very start', () => {
+    const words = ['Hello', 'world.'];
+    expect(extractCurrentSentence(words, 0)).toBe('Hello world.');
+  });
+
+  it('handles text with no sentence-ending punctuation', () => {
+    const words = ['no', 'punctuation', 'here'];
+    expect(extractCurrentSentence(words, 1)).toBe('no punctuation here');
+  });
+
+  it('handles index at sentence boundary word', () => {
+    const words = ['First.', 'Second.'];
+    expect(extractCurrentSentence(words, 0)).toBe('First.');
+  });
+
+  it('handles exclamation marks', () => {
+    const words = ['Wow!', 'That', 'was', 'great.'];
+    expect(extractCurrentSentence(words, 2)).toBe('That was great.');
+  });
+
+  it('handles question marks', () => {
+    const words = ['Is', 'it?', 'Yes.'];
+    expect(extractCurrentSentence(words, 0)).toBe('Is it?');
+  });
+
+  it('truncates to 200 chars with ellipsis when sentence is too long', () => {
+    const words = Array.from({ length: 50 }, (_, i) => `longword${i.toString().padStart(2, '0')}`);
+    words[49] = words[49] + '.';
+    const result = extractCurrentSentence(words, 25);
+    expect(result.length).toBeLessThanOrEqual(203);
+    expect(result.startsWith('...')).toBe(true);
+  });
+
+  it('returns empty string for empty words array', () => {
+    expect(extractCurrentSentence([], 0)).toBe('');
+  });
+
+  it('clamps index to valid range', () => {
+    const words = ['Hello', 'world.'];
+    expect(extractCurrentSentence(words, 99)).toBe('Hello world.');
+  });
+});

--- a/dashboard/src/app/read/book/utils.ts
+++ b/dashboard/src/app/read/book/utils.ts
@@ -1,0 +1,45 @@
+/**
+ * Generate a book ID by hashing the first 4KB of file content.
+ */
+export async function generateBookId(buffer: ArrayBuffer): Promise<string> {
+  const slice = buffer.slice(0, 4096);
+  const hash = await crypto.subtle.digest('SHA-256', slice);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * Extract the sentence surrounding the word at `wordIndex`.
+ * Scans backward and forward for sentence-ending punctuation (. ! ?).
+ * Caps output at 200 characters, truncating from the left with "...".
+ */
+export function extractCurrentSentence(words: string[], wordIndex: number): string {
+  if (words.length === 0) return '';
+
+  const idx = Math.max(0, Math.min(wordIndex, words.length - 1));
+
+  // Scan backward for sentence boundary
+  let start = 0;
+  for (let i = idx - 1; i >= 0; i--) {
+    if (/[.!?]$/.test(words[i])) {
+      start = i + 1;
+      break;
+    }
+  }
+
+  // Scan forward for sentence boundary
+  let end = words.length - 1;
+  for (let i = idx; i < words.length; i++) {
+    if (/[.!?]$/.test(words[i])) {
+      end = i;
+      break;
+    }
+  }
+
+  const sentence = words.slice(start, end + 1).join(' ');
+
+  if (sentence.length <= 200) return sentence;
+
+  return '...' + sentence.slice(-200);
+}

--- a/dashboard/src/app/read/components.tsx
+++ b/dashboard/src/app/read/components.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import { getORPIndex, TokenizedWord } from './useRSVPEngine';
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+export function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export function getFontSize(chunk: TokenizedWord[]): number {
+  const maxLen = chunk.reduce((max, w) => Math.max(max, w.word.length), 0);
+  if (maxLen > 30) return 24;
+  if (maxLen > 20) return 32;
+  return 44;
+}
+
+export function segmentClass(active: boolean) {
+  return `px-3 py-1.5 text-sm rounded transition-colors ${
+    active
+      ? 'bg-blue-600 text-white'
+      : 'bg-gray-800 text-gray-400 hover:text-gray-200 cursor-pointer'
+  }`;
+}
+
+// ---------------------------------------------------------------------------
+// Helper components
+// ---------------------------------------------------------------------------
+
+export function ORPDisplay({ chunk, fontSize }: { chunk: TokenizedWord[]; fontSize: number }) {
+  if (chunk.length === 0) return null;
+
+  // Find longest word for ORP alignment
+  const longestWord = chunk.reduce((longest, w) =>
+    w.word.length > longest.word.length ? w : longest
+  );
+  const word = longestWord.word;
+  const pivot = getORPIndex(word);
+
+  const before = word.slice(0, pivot);
+  const pivotChar = word[pivot] ?? '';
+  const after = word.slice(pivot + 1);
+
+  // For multi-word chunks, join remaining words
+  const otherWords = chunk
+    .filter((w) => w !== longestWord)
+    .map((w) => w.word)
+    .join(' ');
+  const displayWord = chunk.length > 1
+    ? chunk.map((w) => w.word).join(' ')
+    : word;
+
+  // For multi-word chunks, build the full phrase and calculate pivot offset
+  // relative to the longest word's pivot character within the phrase
+  if (chunk.length > 1) {
+    const phrase = chunk.map((w) => w.word).join(' ');
+    // Find the character position of the pivot within the full phrase
+    let charsBeforeLongest = 0;
+    for (const w of chunk) {
+      if (w === longestWord) break;
+      charsBeforeLongest += w.word.length + 1; // +1 for space
+    }
+    const pivotInPhrase = charsBeforeLongest + pivot;
+    const phraseShiftCh = phrase.length / 2 - pivotInPhrase - 0.5;
+
+    return (
+      <div className="relative flex items-center justify-center" style={{ fontSize, fontFamily: 'ui-monospace, monospace', minHeight: '1.5em' }}>
+        <div className="absolute left-1/2 top-0 bottom-0 w-px bg-gray-800" />
+        <span style={{ transform: `translateX(${phraseShiftCh}ch)` }}>
+          {chunk.map((w, i) => {
+            const isLongest = w === longestWord;
+            return (
+              <span key={i}>
+                {i > 0 && ' '}
+                {isLongest ? (
+                  <>
+                    <span className="text-gray-300">{before}</span>
+                    <span className="text-red-500 font-bold">{pivotChar}</span>
+                    <span className="text-gray-300">{after}</span>
+                  </>
+                ) : (
+                  <span className="text-gray-300">{w.word}</span>
+                )}
+              </span>
+            );
+          })}
+        </span>
+      </div>
+    );
+  }
+
+  // Offset so the pivot character's center aligns with the center line.
+  // In monospace, each char is 1ch wide. The pivot center is at (pivot + 0.5)ch
+  // from the left edge. The word center is at (word.length / 2)ch.
+  // Shift = (word.length / 2 - pivot - 0.5)ch to the right.
+  const shiftCh = word.length / 2 - pivot - 0.5;
+
+  return (
+    <div
+      className="relative flex items-center justify-center"
+      style={{ fontSize, fontFamily: 'ui-monospace, monospace', minHeight: '1.5em' }}
+    >
+      <div className="absolute left-1/2 top-0 bottom-0 w-px bg-gray-800" />
+      <span
+        className="flex items-center"
+        style={{ transform: `translateX(${shiftCh}ch)` }}
+      >
+        <span className="text-gray-300">{before}</span>
+        <span className="text-red-500 font-bold">{pivotChar}</span>
+        <span className="text-gray-300">{after}</span>
+      </span>
+    </div>
+  );
+}
+
+export function CenteredDisplay({ chunk, fontSize }: { chunk: TokenizedWord[]; fontSize: number }) {
+  const text = chunk.map((w) => w.word).join(' ');
+  return (
+    <div
+      className="flex items-center justify-center text-gray-100"
+      style={{ fontSize, fontFamily: 'ui-monospace, monospace', minHeight: '1.5em' }}
+    >
+      {text}
+    </div>
+  );
+}
+
+export function ContextDisplay({
+  chunk,
+  words,
+  position,
+  fontSize,
+}: {
+  chunk: TokenizedWord[];
+  words: TokenizedWord[];
+  position: number;
+  fontSize: number;
+}) {
+  const before = words
+    .slice(Math.max(0, position - 10), position)
+    .map((w) => w.word)
+    .join(' ');
+  const after = words
+    .slice(position + chunk.length, position + chunk.length + 10)
+    .map((w) => w.word)
+    .join(' ');
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <p className="text-gray-700 text-sm truncate max-w-full text-center">{before}</p>
+      <ORPDisplay chunk={chunk} fontSize={fontSize} />
+      <p className="text-gray-700 text-sm truncate max-w-full text-center">{after}</p>
+    </div>
+  );
+}
+
+export function SourcePanel({ text, position }: { text: string; words: TokenizedWord[]; position: number }) {
+  const allWords = text.trim().split(/\s+/);
+  const start = Math.max(0, position - 250);
+  const end = Math.min(allWords.length, position + 250);
+  const slice = allWords.slice(start, end);
+
+  const highlightRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    highlightRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }, [position]);
+
+  return (
+    <div className="max-h-48 overflow-y-auto text-xs leading-relaxed text-gray-600 p-3 bg-gray-900 border border-gray-800 rounded-lg">
+      {slice.map((word, i) => {
+        const globalIdx = start + i;
+        const isHighlighted = globalIdx === position;
+        return (
+          <span key={globalIdx}>
+            {isHighlighted ? (
+              <span
+                ref={highlightRef}
+                className="bg-blue-900 text-blue-200 px-0.5 rounded"
+              >
+                {word}
+              </span>
+            ) : (
+              <span className="text-gray-600">{word}</span>
+            )}
+            {' '}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/src/app/read/components.tsx
+++ b/dashboard/src/app/read/components.tsx
@@ -46,15 +46,6 @@ export function ORPDisplay({ chunk, fontSize }: { chunk: TokenizedWord[]; fontSi
   const pivotChar = word[pivot] ?? '';
   const after = word.slice(pivot + 1);
 
-  // For multi-word chunks, join remaining words
-  const otherWords = chunk
-    .filter((w) => w !== longestWord)
-    .map((w) => w.word)
-    .join(' ');
-  const displayWord = chunk.length > 1
-    ? chunk.map((w) => w.word).join(' ')
-    : word;
-
   // For multi-word chunks, build the full phrase and calculate pivot offset
   // relative to the longest word's pivot character within the phrase
   if (chunk.length > 1) {

--- a/dashboard/src/app/read/page.tsx
+++ b/dashboard/src/app/read/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { useRSVPEngine, getORPIndex, TokenizedWord } from './useRSVPEngine';
+import { useRSVPEngine } from './useRSVPEngine';
+import { formatTime, getFontSize, segmentClass, ORPDisplay, CenteredDisplay, ContextDisplay, SourcePanel } from './components';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -10,191 +11,6 @@ import { useRSVPEngine, getORPIndex, TokenizedWord } from './useRSVPEngine';
 type Phase = 'input' | 'reading' | 'complete';
 type DisplayMode = 'orp' | 'centered' | 'orp+context';
 type InputTab = 'paste' | 'upload' | 'vault';
-
-// ---------------------------------------------------------------------------
-// Helper functions
-// ---------------------------------------------------------------------------
-
-function formatTime(seconds: number): string {
-  const m = Math.floor(seconds / 60);
-  const s = Math.floor(seconds % 60);
-  return `${m}:${s.toString().padStart(2, '0')}`;
-}
-
-function getFontSize(chunk: TokenizedWord[]): number {
-  const maxLen = chunk.reduce((max, w) => Math.max(max, w.word.length), 0);
-  if (maxLen > 30) return 24;
-  if (maxLen > 20) return 32;
-  return 44;
-}
-
-// ---------------------------------------------------------------------------
-// Helper components
-// ---------------------------------------------------------------------------
-
-function ORPDisplay({ chunk, fontSize }: { chunk: TokenizedWord[]; fontSize: number }) {
-  if (chunk.length === 0) return null;
-
-  // Find longest word for ORP alignment
-  const longestWord = chunk.reduce((longest, w) =>
-    w.word.length > longest.word.length ? w : longest
-  );
-  const word = longestWord.word;
-  const pivot = getORPIndex(word);
-
-  const before = word.slice(0, pivot);
-  const pivotChar = word[pivot] ?? '';
-  const after = word.slice(pivot + 1);
-
-  // For multi-word chunks, join remaining words
-  const otherWords = chunk
-    .filter((w) => w !== longestWord)
-    .map((w) => w.word)
-    .join(' ');
-  const displayWord = chunk.length > 1
-    ? chunk.map((w) => w.word).join(' ')
-    : word;
-
-  // For multi-word chunks, build the full phrase and calculate pivot offset
-  // relative to the longest word's pivot character within the phrase
-  if (chunk.length > 1) {
-    const phrase = chunk.map((w) => w.word).join(' ');
-    // Find the character position of the pivot within the full phrase
-    let charsBeforeLongest = 0;
-    for (const w of chunk) {
-      if (w === longestWord) break;
-      charsBeforeLongest += w.word.length + 1; // +1 for space
-    }
-    const pivotInPhrase = charsBeforeLongest + pivot;
-    const phraseShiftCh = phrase.length / 2 - pivotInPhrase - 0.5;
-
-    return (
-      <div className="relative flex items-center justify-center" style={{ fontSize, fontFamily: 'ui-monospace, monospace', minHeight: '1.5em' }}>
-        <div className="absolute left-1/2 top-0 bottom-0 w-px bg-gray-800" />
-        <span style={{ transform: `translateX(${phraseShiftCh}ch)` }}>
-          {chunk.map((w, i) => {
-            const isLongest = w === longestWord;
-            return (
-              <span key={i}>
-                {i > 0 && ' '}
-                {isLongest ? (
-                  <>
-                    <span className="text-gray-300">{before}</span>
-                    <span className="text-red-500 font-bold">{pivotChar}</span>
-                    <span className="text-gray-300">{after}</span>
-                  </>
-                ) : (
-                  <span className="text-gray-300">{w.word}</span>
-                )}
-              </span>
-            );
-          })}
-        </span>
-      </div>
-    );
-  }
-
-  // Offset so the pivot character's center aligns with the center line.
-  // In monospace, each char is 1ch wide. The pivot center is at (pivot + 0.5)ch
-  // from the left edge. The word center is at (word.length / 2)ch.
-  // Shift = (word.length / 2 - pivot - 0.5)ch to the right.
-  const shiftCh = word.length / 2 - pivot - 0.5;
-
-  return (
-    <div
-      className="relative flex items-center justify-center"
-      style={{ fontSize, fontFamily: 'ui-monospace, monospace', minHeight: '1.5em' }}
-    >
-      <div className="absolute left-1/2 top-0 bottom-0 w-px bg-gray-800" />
-      <span
-        className="flex items-center"
-        style={{ transform: `translateX(${shiftCh}ch)` }}
-      >
-        <span className="text-gray-300">{before}</span>
-        <span className="text-red-500 font-bold">{pivotChar}</span>
-        <span className="text-gray-300">{after}</span>
-      </span>
-    </div>
-  );
-}
-
-function CenteredDisplay({ chunk, fontSize }: { chunk: TokenizedWord[]; fontSize: number }) {
-  const text = chunk.map((w) => w.word).join(' ');
-  return (
-    <div
-      className="flex items-center justify-center text-gray-100"
-      style={{ fontSize, fontFamily: 'ui-monospace, monospace', minHeight: '1.5em' }}
-    >
-      {text}
-    </div>
-  );
-}
-
-function ContextDisplay({
-  chunk,
-  words,
-  position,
-  fontSize,
-}: {
-  chunk: TokenizedWord[];
-  words: TokenizedWord[];
-  position: number;
-  fontSize: number;
-}) {
-  const before = words
-    .slice(Math.max(0, position - 10), position)
-    .map((w) => w.word)
-    .join(' ');
-  const after = words
-    .slice(position + chunk.length, position + chunk.length + 10)
-    .map((w) => w.word)
-    .join(' ');
-
-  return (
-    <div className="flex flex-col items-center gap-2">
-      <p className="text-gray-700 text-sm truncate max-w-full text-center">{before}</p>
-      <ORPDisplay chunk={chunk} fontSize={fontSize} />
-      <p className="text-gray-700 text-sm truncate max-w-full text-center">{after}</p>
-    </div>
-  );
-}
-
-function SourcePanel({ text, position }: { text: string; words: TokenizedWord[]; position: number }) {
-  const allWords = text.trim().split(/\s+/);
-  const start = Math.max(0, position - 250);
-  const end = Math.min(allWords.length, position + 250);
-  const slice = allWords.slice(start, end);
-
-  const highlightRef = useRef<HTMLSpanElement>(null);
-
-  useEffect(() => {
-    highlightRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-  }, [position]);
-
-  return (
-    <div className="max-h-48 overflow-y-auto text-xs leading-relaxed text-gray-600 p-3 bg-gray-900 border border-gray-800 rounded-lg">
-      {slice.map((word, i) => {
-        const globalIdx = start + i;
-        const isHighlighted = globalIdx === position;
-        return (
-          <span key={globalIdx}>
-            {isHighlighted ? (
-              <span
-                ref={highlightRef}
-                className="bg-blue-900 text-blue-200 px-0.5 rounded"
-              >
-                {word}
-              </span>
-            ) : (
-              <span className="text-gray-600">{word}</span>
-            )}
-            {' '}
-          </span>
-        );
-      })}
-    </div>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Page component
@@ -357,14 +173,6 @@ export default function ReadPage() {
       inputTab === tab
         ? 'text-gray-100 border-b-2 border-blue-500'
         : 'text-gray-400 hover:text-gray-200'
-    }`;
-  }
-
-  function segmentClass(active: boolean) {
-    return `px-3 py-1.5 text-sm rounded transition-colors ${
-      active
-        ? 'bg-blue-600 text-white'
-        : 'bg-gray-800 text-gray-400 hover:text-gray-200 cursor-pointer'
     }`;
   }
 

--- a/dashboard/src/app/read/useRSVPEngine.ts
+++ b/dashboard/src/app/read/useRSVPEngine.ts
@@ -17,6 +17,8 @@ export interface RSVPEngineOptions {
   text: string;
   wpm: number;
   chunkSize: 1 | 2 | 3;
+  initialPosition?: number;
+  textVersion?: number;
 }
 
 export interface RSVPEngineState {
@@ -174,7 +176,7 @@ export function computeTimeLeft(
 // ---------------------------------------------------------------------------
 
 export function useRSVPEngine(options: RSVPEngineOptions): RSVPEngineState {
-  const { text, wpm, chunkSize } = options;
+  const { text, wpm, chunkSize, initialPosition, textVersion } = options;
 
   const [words, setWords] = useState<TokenizedWord[]>(() =>
     tokenizeWithDurations(text, wpm)
@@ -206,14 +208,16 @@ export function useRSVPEngine(options: RSVPEngineOptions): RSVPEngineState {
     chunkSizeRef.current = chunkSize;
   }, [chunkSize]);
 
-  // Re-tokenize when text changes — reset position
+  // Re-tokenize when text or textVersion changes — start at initialPosition or 0
   useEffect(() => {
     const newWords = tokenizeWithDurations(text, wpm);
     setWords(newWords);
-    setPosition(0);
+    const startPos = initialPosition ?? 0;
+    setPosition(startPos);
+    positionRef.current = startPos;
     setIsPlaying(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [text]);
+  }, [text, textVersion]);
 
   // Re-tokenize when WPM changes — keep position (live speed adjustment)
   useEffect(() => {

--- a/docs/superpowers/plans/2026-04-13-epub-book-reader.md
+++ b/docs/superpowers/plans/2026-04-13-epub-book-reader.md
@@ -23,10 +23,10 @@
 git checkout -b feat/epub-book-reader main
 ```
 
-- [ ] **Step 2: Install jszip**
+- [ ] **Step 2: Install jszip and jsdom (test environment)**
 
 ```bash
-cd dashboard && npm install jszip
+cd dashboard && npm install jszip && npm install -D jsdom
 ```
 
 - [ ] **Step 3: Verify build**
@@ -41,49 +41,25 @@ Expected: Build succeeds with no errors.
 
 ```bash
 git add dashboard/package.json dashboard/package-lock.json
-git commit -m "chore: add jszip dependency for EPUB parsing"
+git commit -m "chore: add jszip and jsdom dependencies for EPUB parsing"
 ```
 
 ---
 
-### Task 2: Add initialPosition to useRSVPEngine
+### Task 2: Add initialPosition and textVersion to useRSVPEngine
 
-The engine resets position to 0 whenever `text` changes. The book reader needs to resume at a saved position. Add an optional `initialPosition` field.
+The engine resets position to 0 whenever `text` changes. The book reader needs to:
+1. Resume at a saved position when opening a book
+2. Force a reset even when navigating to a chapter with identical text (e.g., re-selecting the current chapter)
+
+We add `initialPosition` (where to start) and `textVersion` (a counter the caller increments to force the effect to re-fire even when text is unchanged). The effect depends on `[text, textVersion]`.
 
 **Files:**
 - Modify: `dashboard/src/app/read/useRSVPEngine.ts:9-20` (options interface)
+- Modify: `dashboard/src/app/read/useRSVPEngine.ts:176` (destructure)
 - Modify: `dashboard/src/app/read/useRSVPEngine.ts:210-216` (text-change effect)
-- Test: `dashboard/src/app/read/useRSVPEngine.test.ts`
 
-- [ ] **Step 1: Write failing test**
-
-Add to the end of `dashboard/src/app/read/useRSVPEngine.test.ts`:
-
-```typescript
-// ---------------------------------------------------------------------------
-// tokenizeWithDurations — initialPosition support
-// ---------------------------------------------------------------------------
-
-describe("tokenizeWithDurations with initialPosition", () => {
-  it("is a pass-through — initialPosition is consumed by the hook, not tokenization", () => {
-    // This test documents that tokenizeWithDurations is unchanged.
-    // The initialPosition parameter lives in RSVPEngineOptions, consumed by the hook.
-    const words = tokenizeWithDurations("Hello world again", 600);
-    expect(words).toHaveLength(3);
-    expect(words[0].word).toBe("Hello");
-  });
-});
-```
-
-- [ ] **Step 2: Run test to verify it passes** (this is a documentation test)
-
-```bash
-npm test -- --run dashboard/src/app/read/useRSVPEngine.test.ts
-```
-
-Expected: All tests PASS.
-
-- [ ] **Step 3: Add initialPosition to the options interface**
+- [ ] **Step 1: Add initialPosition and textVersion to the options interface**
 
 In `dashboard/src/app/read/useRSVPEngine.ts`, update the `RSVPEngineOptions` interface:
 
@@ -93,21 +69,22 @@ export interface RSVPEngineOptions {
   wpm: number;
   chunkSize: 1 | 2 | 3;
   initialPosition?: number;
+  textVersion?: number;
 }
 ```
 
-- [ ] **Step 4: Update the text-change useEffect to use initialPosition**
+- [ ] **Step 2: Update the hook to destructure and use the new options**
 
-In `dashboard/src/app/read/useRSVPEngine.ts`, in the `useRSVPEngine` function, destructure the new option:
+In the `useRSVPEngine` function, update the destructure:
 
 ```typescript
-const { text, wpm, chunkSize, initialPosition } = options;
+const { text, wpm, chunkSize, initialPosition, textVersion } = options;
 ```
 
 Then update the text-change `useEffect` (the one with `setPosition(0)`) to:
 
 ```typescript
-  // Re-tokenize when text changes — reset position (or use initialPosition for resume)
+  // Re-tokenize when text or textVersion changes — start at initialPosition or 0
   useEffect(() => {
     const newWords = tokenizeWithDurations(text, wpm);
     setWords(newWords);
@@ -116,22 +93,22 @@ Then update the text-change `useEffect` (the one with `setPosition(0)`) to:
     positionRef.current = startPos;
     setIsPlaying(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [text]);
+  }, [text, textVersion]);
 ```
 
-- [ ] **Step 5: Run all tests**
+- [ ] **Step 3: Run all tests**
 
 ```bash
 npm test -- --run dashboard/src/app/read/useRSVPEngine.test.ts
 ```
 
-Expected: All tests PASS. Existing behavior unchanged (no callers pass `initialPosition`).
+Expected: All tests PASS. Existing behavior unchanged (no callers pass `initialPosition` or `textVersion`).
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
-git add dashboard/src/app/read/useRSVPEngine.ts dashboard/src/app/read/useRSVPEngine.test.ts
-git commit -m "feat(rsvp): add initialPosition option for resume support"
+git add dashboard/src/app/read/useRSVPEngine.ts
+git commit -m "feat(rsvp): add initialPosition and textVersion for chapter resume"
 ```
 
 ---
@@ -390,6 +367,7 @@ Pure module that takes an EPUB `ArrayBuffer` and returns structured chapter data
 Create `dashboard/src/app/read/book/epubParser.test.ts`:
 
 ```typescript
+// @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
 import { extractTextFromHtml, resolveHref } from './epubParser';
 
@@ -438,6 +416,14 @@ describe('resolveHref', () => {
 
   it('handles nested paths', () => {
     expect(resolveHref('text/ch1.xhtml', 'OEBPS/')).toBe('OEBPS/text/ch1.xhtml');
+  });
+
+  it('resolves ../ segments', () => {
+    expect(resolveHref('../Text/ch1.xhtml', 'OEBPS/nav/')).toBe('OEBPS/Text/ch1.xhtml');
+  });
+
+  it('decodes URL-encoded characters', () => {
+    expect(resolveHref('chapter%201.xhtml', 'OEBPS/')).toBe('OEBPS/chapter 1.xhtml');
   });
 });
 ```
@@ -488,7 +474,8 @@ export async function parseEpub(buffer: ArrayBuffer): Promise<ParsedBook> {
   if (!containerXml) throw new Error('Invalid EPUB: missing META-INF/container.xml');
 
   const containerDoc = parseXml(containerXml);
-  const rootfileEl = containerDoc.getElementsByTagName('rootfile')[0];
+  // Use getElementsByTagNameNS with wildcard to handle any namespace
+  const rootfileEl = containerDoc.getElementsByTagNameNS('*', 'rootfile')[0];
   const opfPath = rootfileEl?.getAttribute('full-path');
   if (!opfPath) throw new Error('Invalid EPUB: no rootfile path found');
 
@@ -506,7 +493,7 @@ export async function parseEpub(buffer: ArrayBuffer): Promise<ParsedBook> {
 
   // 4. Build manifest map (id → href)
   const manifest = new Map<string, string>();
-  const manifestItems = opfDoc.getElementsByTagName('item');
+  const manifestItems = opfDoc.getElementsByTagNameNS('*', 'item');
   for (let i = 0; i < manifestItems.length; i++) {
     const item = manifestItems[i];
     const id = item.getAttribute('id');
@@ -516,13 +503,13 @@ export async function parseEpub(buffer: ArrayBuffer): Promise<ParsedBook> {
 
   // 5. Get spine order
   const spineIds: string[] = [];
-  const spineItemrefs = opfDoc.getElementsByTagName('itemref');
+  const spineItemrefs = opfDoc.getElementsByTagNameNS('*', 'itemref');
   for (let i = 0; i < spineItemrefs.length; i++) {
     const idref = spineItemrefs[i].getAttribute('idref');
     if (idref) spineIds.push(idref);
   }
 
-  // 6. Parse TOC for chapter titles
+  // 6. Parse TOC for chapter titles (keys are paths relative to ZIP root)
   const tocTitles = await parseToc(zip, opfDoc, opfDir, manifest);
 
   // 7. Extract text from each spine item
@@ -543,7 +530,8 @@ export async function parseEpub(buffer: ArrayBuffer): Promise<ParsedBook> {
     // Skip chapters with fewer than 5 words (front matter, copyright, etc.)
     if (wordCount < 5) continue;
 
-    const chapterTitle = tocTitles.get(href) ?? `Chapter ${++untitledIndex}`;
+    // Match against TOC using ZIP-root-relative path
+    const chapterTitle = tocTitles.get(filePath) ?? `Chapter ${++untitledIndex}`;
     chapters.push({ title: chapterTitle, text, wordCount });
   }
 
@@ -560,18 +548,37 @@ export async function parseEpub(buffer: ArrayBuffer): Promise<ParsedBook> {
 
 /**
  * Strip HTML tags from XHTML content and return plain text.
+ * Tries strict XHTML first, falls back to lenient text/html for malformed content.
  */
 export function extractTextFromHtml(html: string): string {
-  const doc = new DOMParser().parseFromString(html, 'application/xhtml+xml');
+  // Try strict XHTML first
+  let doc = new DOMParser().parseFromString(html, 'application/xhtml+xml');
+  // If parse failed (malformed XHTML), DOMParser returns a document with <parsererror>
+  if (doc.querySelector('parsererror')) {
+    doc = new DOMParser().parseFromString(html, 'text/html');
+  }
   const body = doc.body ?? doc.documentElement;
   return (body.textContent ?? '').trim();
 }
 
 /**
  * Resolve a manifest href relative to the OPF directory.
+ * Handles `../` segments and URL-encoded characters.
  */
 export function resolveHref(href: string, opfDir: string): string {
-  return opfDir + href;
+  const decoded = decodeURIComponent(href);
+  const combined = opfDir + decoded;
+  // Resolve ../  segments
+  const parts = combined.split('/');
+  const resolved: string[] = [];
+  for (const part of parts) {
+    if (part === '..') {
+      resolved.pop();
+    } else if (part !== '.') {
+      resolved.push(part);
+    }
+  }
+  return resolved.join('/');
 }
 
 // ---------------------------------------------------------------------------
@@ -600,7 +607,8 @@ async function parseToc(
   const titles = new Map<string, string>();
 
   // Try EPUB 3 nav document first
-  const manifestItems = opfDoc.getElementsByTagName('item');
+  const manifestItems = opfDoc.getElementsByTagNameNS('*', 'item');
+  let navDir = opfDir; // directory of nav file, for resolving relative hrefs
   for (let i = 0; i < manifestItems.length; i++) {
     const item = manifestItems[i];
     const props = item.getAttribute('properties') ?? '';
@@ -608,24 +616,26 @@ async function parseToc(
       const navHref = item.getAttribute('href');
       if (!navHref) continue;
 
-      const navXhtml = await readZipText(zip, resolveHref(navHref, opfDir));
+      const navPath = resolveHref(navHref, opfDir);
+      navDir = navPath.includes('/') ? navPath.substring(0, navPath.lastIndexOf('/') + 1) : '';
+      const navXhtml = await readZipText(zip, navPath);
       if (!navXhtml) continue;
 
-      const navDoc = new DOMParser().parseFromString(navXhtml, 'application/xhtml+xml');
-      // Find all <a> elements inside <nav> elements
+      // Parse as text/html for robustness — nav docs are often loose HTML
+      const navDoc = new DOMParser().parseFromString(navXhtml, 'text/html');
       const navElements = navDoc.getElementsByTagName('nav');
       for (let n = 0; n < navElements.length; n++) {
         const nav = navElements[n];
-        // Check for epub:type="toc" or id="toc"
         const epubType = nav.getAttribute('epub:type') ?? nav.getAttributeNS('http://www.idpf.org/2007/ops', 'type') ?? '';
         if (epubType !== 'toc' && nav.id !== 'toc') continue;
 
         const links = nav.getElementsByTagName('a');
         for (let l = 0; l < links.length; l++) {
           const a = links[l];
-          const href = a.getAttribute('href')?.split('#')[0];
+          const rawHref = a.getAttribute('href')?.split('#')[0];
           const text = a.textContent?.trim();
-          if (href && text) titles.set(href, text);
+          // Normalize to ZIP-root-relative path for matching
+          if (rawHref && text) titles.set(resolveHref(rawHref, navDir), text);
         }
       }
 
@@ -634,22 +644,25 @@ async function parseToc(
   }
 
   // Fall back to NCX (EPUB 2)
-  const spineEl = opfDoc.getElementsByTagName('spine')[0];
+  const spineEl = opfDoc.getElementsByTagNameNS('*', 'spine')[0];
   const tocId = spineEl?.getAttribute('toc');
   if (tocId) {
     const ncxHref = manifest.get(tocId);
     if (ncxHref) {
-      const ncxXml = await readZipText(zip, resolveHref(ncxHref, opfDir));
+      const ncxPath = resolveHref(ncxHref, opfDir);
+      const ncxDir = ncxPath.includes('/') ? ncxPath.substring(0, ncxPath.lastIndexOf('/') + 1) : '';
+      const ncxXml = await readZipText(zip, ncxPath);
       if (ncxXml) {
         const ncxDoc = parseXml(ncxXml);
-        const navPoints = ncxDoc.getElementsByTagName('navPoint');
+        const navPoints = ncxDoc.getElementsByTagNameNS('*', 'navPoint');
         for (let i = 0; i < navPoints.length; i++) {
           const np = navPoints[i];
-          const textEl = np.getElementsByTagName('text')[0];
-          const contentEl = np.getElementsByTagName('content')[0];
+          const textEl = np.getElementsByTagNameNS('*', 'text')[0];
+          const contentEl = np.getElementsByTagNameNS('*', 'content')[0];
           const text = textEl?.textContent?.trim();
           const src = contentEl?.getAttribute('src')?.split('#')[0];
-          if (text && src) titles.set(src, text);
+          // Normalize to ZIP-root-relative path for matching
+          if (text && src) titles.set(resolveHref(src, ncxDir), text);
         }
       }
     }
@@ -868,6 +881,9 @@ const STORE_NAME = 'books';
 const DB_VERSION = 1;
 
 function openDB(): Promise<IDBDatabase> {
+  if (typeof indexedDB === 'undefined') {
+    return Promise.reject(new Error('IndexedDB not available'));
+  }
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION);
     request.onupgradeneeded = () => {
@@ -1039,6 +1055,7 @@ export default function BookReaderPage() {
   const [sourceExpanded, setSourceExpanded] = useState(false);
   const [initialPosition, setInitialPosition] = useState(0);
   const [copiedSentence, setCopiedSentence] = useState(false);
+  const [textVersion, setTextVersion] = useState(0);
 
   // Timing refs
   const readingStartTime = useRef(0);
@@ -1046,7 +1063,13 @@ export default function BookReaderPage() {
   const lastPauseStart = useRef(0);
   const autoSaveInterval = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const engine = useRSVPEngine({ text: chapterText, wpm, chunkSize, initialPosition });
+  // Refs for values needed in stable callbacks (avoids stale closures)
+  const currentBookRef = useRef(currentBook);
+  const currentChapterIndexRef = useRef(currentChapterIndex);
+  useEffect(() => { currentBookRef.current = currentBook; }, [currentBook]);
+  useEffect(() => { currentChapterIndexRef.current = currentChapterIndex; }, [currentChapterIndex]);
+
+  const engine = useRSVPEngine({ text: chapterText, wpm, chunkSize, initialPosition, textVersion });
 
   // Completion stats
   const [completionStats, setCompletionStats] = useState<{
@@ -1069,18 +1092,24 @@ export default function BookReaderPage() {
   // Auto-save on visibilitychange
   // -----------------------------------------------------------------------
 
+  // Use engine position via ref so the callback stays stable during playback.
+  // Without this, engine.position in deps causes the 30s interval to restart every word.
+  const enginePositionRef = useRef(engine.position);
+  useEffect(() => { enginePositionRef.current = engine.position; }, [engine.position]);
+
   const saveCurrentState = useCallback(() => {
-    if (!currentBook) return;
+    const book = currentBookRef.current;
+    if (!book) return;
     saveReadingState({
-      bookId: currentBook.id,
-      currentChapter: currentChapterIndex,
-      position: engine.position,
+      bookId: book.id,
+      currentChapter: currentChapterIndexRef.current,
+      position: enginePositionRef.current,
       wpm,
       chunkSize,
       displayMode,
       lastRead: Date.now(),
     });
-  }, [currentBook, currentChapterIndex, engine.position, wpm, chunkSize, displayMode]);
+  }, [wpm, chunkSize, displayMode]);
 
   useEffect(() => {
     const handleVisibility = () => {
@@ -1107,10 +1136,10 @@ export default function BookReaderPage() {
 
   // Save on pause
   useEffect(() => {
-    if (phase === 'reading' && !engine.isPlaying && currentBook) {
+    if (phase === 'reading' && !engine.isPlaying && currentBookRef.current) {
       saveCurrentState();
     }
-  }, [engine.isPlaying, phase, currentBook, saveCurrentState]);
+  }, [engine.isPlaying, phase, saveCurrentState]);
 
   // Track pause time
   useEffect(() => {
@@ -1131,8 +1160,10 @@ export default function BookReaderPage() {
       engine.position >= engine.totalWords &&
       engine.totalWords > 0
     ) {
-      if (!currentBook) return;
-      const isLastChapter = currentChapterIndex >= currentBook.chapters.length - 1;
+      const book = currentBookRef.current;
+      const chIdx = currentChapterIndexRef.current;
+      if (!book) return;
+      const isLastChapter = chIdx >= book.chapters.length - 1;
 
       if (isLastChapter) {
         // Book complete
@@ -1141,13 +1172,13 @@ export default function BookReaderPage() {
           lastPauseStart.current = 0;
         }
         const totalTime = (Date.now() - readingStartTime.current - totalPauseTime.current) / 1000;
-        const totalWords = currentBook.chapters.reduce((sum, ch) => sum + ch.wordCount, 0);
+        const totalWords = book.chapters.reduce((sum, ch) => sum + ch.wordCount, 0);
         const effectiveWpm = totalTime > 0 ? Math.round(totalWords / (totalTime / 60)) : 0;
         setCompletionStats({ totalTime, effectiveWpm });
         setPhase('complete');
       } else {
         // Advance to next chapter
-        goToChapter(currentChapterIndex + 1, 0);
+        goToChapter(chIdx + 1, 0);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1244,6 +1275,7 @@ export default function BookReaderPage() {
     setCurrentChapterIndex(index);
     setInitialPosition(pos);
     setChapterText(chapter.text);
+    setTextVersion((v) => v + 1); // Force engine re-init even if same text
   }
 
   async function openBook(bookId: string) {
@@ -1495,6 +1527,7 @@ export default function BookReaderPage() {
             {engine.isPlaying ? 'Pause' : 'Play'}
           </button>
           <button className="px-3 py-2 rounded bg-gray-800 text-gray-300 hover:bg-gray-700 text-sm transition-colors" onClick={() => engine.seek(10)} title="Seek forward 10s (→)">10s→</button>
+          <button className="px-3 py-2 rounded bg-gray-800 text-gray-300 hover:bg-gray-700 text-sm transition-colors" onClick={() => engine.restart()} title="Restart chapter (R)">↺</button>
         </div>
 
         {/* Status bar */}

--- a/docs/superpowers/plans/2026-04-13-epub-book-reader.md
+++ b/docs/superpowers/plans/2026-04-13-epub-book-reader.md
@@ -1,0 +1,1767 @@
+# EPUB Book Reader Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a persistent EPUB book reader at `/read/book` with chapter navigation and "find my place" for switching between RSVP and reMarkable.
+
+**Architecture:** Separate route reuses the existing `useRSVPEngine` hook. EPUB parsing via `jszip` + `DOMParser` (no heavy EPUB library). Books persist in IndexedDB, reading state in localStorage. Three-phase UI: library → upload → reading.
+
+**Tech Stack:** Next.js 16, React 19, jszip, IndexedDB, localStorage, Tailwind CSS, Vitest
+
+**Spec:** `docs/superpowers/specs/2026-04-13-epub-book-reader-design.md`
+
+---
+
+### Task 1: Setup — branch and dependency
+
+**Files:**
+- Modify: `dashboard/package.json`
+
+- [ ] **Step 1: Create feature branch**
+
+```bash
+git checkout -b feat/epub-book-reader main
+```
+
+- [ ] **Step 2: Install jszip**
+
+```bash
+cd dashboard && npm install jszip
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd dashboard && npm run build
+```
+
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dashboard/package.json dashboard/package-lock.json
+git commit -m "chore: add jszip dependency for EPUB parsing"
+```
+
+---
+
+### Task 2: Add initialPosition to useRSVPEngine
+
+The engine resets position to 0 whenever `text` changes. The book reader needs to resume at a saved position. Add an optional `initialPosition` field.
+
+**Files:**
+- Modify: `dashboard/src/app/read/useRSVPEngine.ts:9-20` (options interface)
+- Modify: `dashboard/src/app/read/useRSVPEngine.ts:210-216` (text-change effect)
+- Test: `dashboard/src/app/read/useRSVPEngine.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Add to the end of `dashboard/src/app/read/useRSVPEngine.test.ts`:
+
+```typescript
+// ---------------------------------------------------------------------------
+// tokenizeWithDurations — initialPosition support
+// ---------------------------------------------------------------------------
+
+describe("tokenizeWithDurations with initialPosition", () => {
+  it("is a pass-through — initialPosition is consumed by the hook, not tokenization", () => {
+    // This test documents that tokenizeWithDurations is unchanged.
+    // The initialPosition parameter lives in RSVPEngineOptions, consumed by the hook.
+    const words = tokenizeWithDurations("Hello world again", 600);
+    expect(words).toHaveLength(3);
+    expect(words[0].word).toBe("Hello");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes** (this is a documentation test)
+
+```bash
+npm test -- --run dashboard/src/app/read/useRSVPEngine.test.ts
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 3: Add initialPosition to the options interface**
+
+In `dashboard/src/app/read/useRSVPEngine.ts`, update the `RSVPEngineOptions` interface:
+
+```typescript
+export interface RSVPEngineOptions {
+  text: string;
+  wpm: number;
+  chunkSize: 1 | 2 | 3;
+  initialPosition?: number;
+}
+```
+
+- [ ] **Step 4: Update the text-change useEffect to use initialPosition**
+
+In `dashboard/src/app/read/useRSVPEngine.ts`, in the `useRSVPEngine` function, destructure the new option:
+
+```typescript
+const { text, wpm, chunkSize, initialPosition } = options;
+```
+
+Then update the text-change `useEffect` (the one with `setPosition(0)`) to:
+
+```typescript
+  // Re-tokenize when text changes — reset position (or use initialPosition for resume)
+  useEffect(() => {
+    const newWords = tokenizeWithDurations(text, wpm);
+    setWords(newWords);
+    const startPos = initialPosition ?? 0;
+    setPosition(startPos);
+    positionRef.current = startPos;
+    setIsPlaying(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [text]);
+```
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+npm test -- --run dashboard/src/app/read/useRSVPEngine.test.ts
+```
+
+Expected: All tests PASS. Existing behavior unchanged (no callers pass `initialPosition`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/src/app/read/useRSVPEngine.ts dashboard/src/app/read/useRSVPEngine.test.ts
+git commit -m "feat(rsvp): add initialPosition option for resume support"
+```
+
+---
+
+### Task 3: Extract shared display components
+
+Move reusable display components out of `page.tsx` into a shared module so both the existing reader and the book reader can import them.
+
+**Files:**
+- Create: `dashboard/src/app/read/components.tsx`
+- Modify: `dashboard/src/app/read/page.tsx`
+
+- [ ] **Step 1: Create components.tsx with extracted components**
+
+Create `dashboard/src/app/read/components.tsx`:
+
+```typescript
+'use client';
+
+import { useRef, useEffect } from 'react';
+import { getORPIndex, TokenizedWord } from './useRSVPEngine';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export function getFontSize(chunk: TokenizedWord[]): number {
+  const maxLen = chunk.reduce((max, w) => Math.max(max, w.word.length), 0);
+  if (maxLen > 30) return 24;
+  if (maxLen > 20) return 32;
+  return 44;
+}
+
+export function segmentClass(active: boolean): string {
+  return `px-3 py-1.5 text-sm rounded transition-colors ${
+    active
+      ? 'bg-blue-600 text-white'
+      : 'bg-gray-800 text-gray-400 hover:text-gray-200 cursor-pointer'
+  }`;
+}
+
+// ---------------------------------------------------------------------------
+// Display components
+// ---------------------------------------------------------------------------
+
+export function ORPDisplay({ chunk, fontSize }: { chunk: TokenizedWord[]; fontSize: number }) {
+  if (chunk.length === 0) return null;
+
+  const longestWord = chunk.reduce((longest, w) =>
+    w.word.length > longest.word.length ? w : longest
+  );
+  const word = longestWord.word;
+  const pivot = getORPIndex(word);
+
+  const before = word.slice(0, pivot);
+  const pivotChar = word[pivot] ?? '';
+  const after = word.slice(pivot + 1);
+
+  if (chunk.length > 1) {
+    const phrase = chunk.map((w) => w.word).join(' ');
+    let charsBeforeLongest = 0;
+    for (const w of chunk) {
+      if (w === longestWord) break;
+      charsBeforeLongest += w.word.length + 1;
+    }
+    const pivotInPhrase = charsBeforeLongest + pivot;
+    const phraseShiftCh = phrase.length / 2 - pivotInPhrase - 0.5;
+
+    return (
+      <div className="relative flex items-center justify-center" style={{ fontSize, fontFamily: 'ui-monospace, monospace', minHeight: '1.5em' }}>
+        <div className="absolute left-1/2 top-0 bottom-0 w-px bg-gray-800" />
+        <span style={{ transform: `translateX(${phraseShiftCh}ch)` }}>
+          {chunk.map((w, i) => {
+            const isLongest = w === longestWord;
+            return (
+              <span key={i}>
+                {i > 0 && ' '}
+                {isLongest ? (
+                  <>
+                    <span className="text-gray-300">{before}</span>
+                    <span className="text-red-500 font-bold">{pivotChar}</span>
+                    <span className="text-gray-300">{after}</span>
+                  </>
+                ) : (
+                  <span className="text-gray-300">{w.word}</span>
+                )}
+              </span>
+            );
+          })}
+        </span>
+      </div>
+    );
+  }
+
+  const shiftCh = word.length / 2 - pivot - 0.5;
+
+  return (
+    <div
+      className="relative flex items-center justify-center"
+      style={{ fontSize, fontFamily: 'ui-monospace, monospace', minHeight: '1.5em' }}
+    >
+      <div className="absolute left-1/2 top-0 bottom-0 w-px bg-gray-800" />
+      <span
+        className="flex items-center"
+        style={{ transform: `translateX(${shiftCh}ch)` }}
+      >
+        <span className="text-gray-300">{before}</span>
+        <span className="text-red-500 font-bold">{pivotChar}</span>
+        <span className="text-gray-300">{after}</span>
+      </span>
+    </div>
+  );
+}
+
+export function CenteredDisplay({ chunk, fontSize }: { chunk: TokenizedWord[]; fontSize: number }) {
+  const text = chunk.map((w) => w.word).join(' ');
+  return (
+    <div
+      className="flex items-center justify-center text-gray-100"
+      style={{ fontSize, fontFamily: 'ui-monospace, monospace', minHeight: '1.5em' }}
+    >
+      {text}
+    </div>
+  );
+}
+
+export function ContextDisplay({
+  chunk,
+  words,
+  position,
+  fontSize,
+}: {
+  chunk: TokenizedWord[];
+  words: TokenizedWord[];
+  position: number;
+  fontSize: number;
+}) {
+  const before = words
+    .slice(Math.max(0, position - 10), position)
+    .map((w) => w.word)
+    .join(' ');
+  const after = words
+    .slice(position + chunk.length, position + chunk.length + 10)
+    .map((w) => w.word)
+    .join(' ');
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <p className="text-gray-700 text-sm truncate max-w-full text-center">{before}</p>
+      <ORPDisplay chunk={chunk} fontSize={fontSize} />
+      <p className="text-gray-700 text-sm truncate max-w-full text-center">{after}</p>
+    </div>
+  );
+}
+
+export function SourcePanel({ text, position }: { text: string; words: TokenizedWord[]; position: number }) {
+  const allWords = text.trim().split(/\s+/);
+  const start = Math.max(0, position - 250);
+  const end = Math.min(allWords.length, position + 250);
+  const slice = allWords.slice(start, end);
+
+  const highlightRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    highlightRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }, [position]);
+
+  return (
+    <div className="max-h-48 overflow-y-auto text-xs leading-relaxed text-gray-600 p-3 bg-gray-900 border border-gray-800 rounded-lg">
+      {slice.map((word, i) => {
+        const globalIdx = start + i;
+        const isHighlighted = globalIdx === position;
+        return (
+          <span key={globalIdx}>
+            {isHighlighted ? (
+              <span
+                ref={highlightRef}
+                className="bg-blue-900 text-blue-200 px-0.5 rounded"
+              >
+                {word}
+              </span>
+            ) : (
+              <span className="text-gray-600">{word}</span>
+            )}
+            {' '}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Update page.tsx to import from components.tsx**
+
+In `dashboard/src/app/read/page.tsx`:
+
+1. Remove the `formatTime`, `getFontSize` function definitions (lines 18-29)
+2. Remove the `ORPDisplay`, `CenteredDisplay`, `ContextDisplay`, `SourcePanel` component definitions (lines 35-197)
+3. Remove the inline `segmentClass` function definition (lines 363-369)
+4. Add this import at the top (after the existing imports):
+
+```typescript
+import { formatTime, getFontSize, segmentClass, ORPDisplay, CenteredDisplay, ContextDisplay, SourcePanel } from './components';
+```
+
+5. Remove the `getORPIndex` and `TokenizedWord` imports from the useRSVPEngine import (they're no longer needed directly — components.tsx imports them).
+
+The useRSVPEngine import becomes:
+
+```typescript
+import { useRSVPEngine } from './useRSVPEngine';
+```
+
+- [ ] **Step 3: Verify build and existing reader still works**
+
+```bash
+cd dashboard && npm run build
+```
+
+Expected: Build succeeds. The existing `/read` page is functionally identical.
+
+- [ ] **Step 4: Run existing tests**
+
+```bash
+npm test -- --run dashboard/src/app/read/useRSVPEngine.test.ts
+```
+
+Expected: All tests PASS (no logic changed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/src/app/read/components.tsx dashboard/src/app/read/page.tsx
+git commit -m "refactor(read): extract shared display components for reuse"
+```
+
+---
+
+### Task 4: EPUB parser
+
+Pure module that takes an EPUB `ArrayBuffer` and returns structured chapter data. Uses `jszip` for unzipping and `DOMParser` for XML/XHTML parsing.
+
+**Files:**
+- Create: `dashboard/src/app/read/book/epubParser.ts`
+- Create: `dashboard/src/app/read/book/epubParser.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `dashboard/src/app/read/book/epubParser.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { extractTextFromHtml, resolveHref } from './epubParser';
+
+// ---------------------------------------------------------------------------
+// extractTextFromHtml
+// ---------------------------------------------------------------------------
+
+describe('extractTextFromHtml', () => {
+  it('strips HTML tags and returns text content', () => {
+    const html = '<html><body><p>Hello <b>world</b></p></body></html>';
+    expect(extractTextFromHtml(html)).toBe('Hello world');
+  });
+
+  it('joins multiple paragraphs with newlines', () => {
+    const html = '<html><body><p>First.</p><p>Second.</p></body></html>';
+    const result = extractTextFromHtml(html);
+    expect(result).toContain('First.');
+    expect(result).toContain('Second.');
+  });
+
+  it('returns empty string for empty body', () => {
+    const html = '<html><body></body></html>';
+    expect(extractTextFromHtml(html)).toBe('');
+  });
+
+  it('handles self-closing tags', () => {
+    const html = '<html><body><p>Line one<br/>Line two</p></body></html>';
+    const result = extractTextFromHtml(html);
+    expect(result).toContain('Line one');
+    expect(result).toContain('Line two');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveHref
+// ---------------------------------------------------------------------------
+
+describe('resolveHref', () => {
+  it('prepends opfDir to relative href', () => {
+    expect(resolveHref('chapter1.xhtml', 'OEBPS/')).toBe('OEBPS/chapter1.xhtml');
+  });
+
+  it('handles empty opfDir', () => {
+    expect(resolveHref('chapter1.xhtml', '')).toBe('chapter1.xhtml');
+  });
+
+  it('handles nested paths', () => {
+    expect(resolveHref('text/ch1.xhtml', 'OEBPS/')).toBe('OEBPS/text/ch1.xhtml');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -- --run dashboard/src/app/read/book/epubParser.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the EPUB parser**
+
+Create `dashboard/src/app/read/book/epubParser.ts`:
+
+```typescript
+import JSZip from 'jszip';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ParsedBook {
+  title: string;
+  author: string;
+  chapters: ParsedChapter[];
+}
+
+export interface ParsedChapter {
+  title: string;
+  text: string;
+  wordCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an EPUB file from an ArrayBuffer into structured chapter data.
+ */
+export async function parseEpub(buffer: ArrayBuffer): Promise<ParsedBook> {
+  const zip = await JSZip.loadAsync(buffer);
+
+  // 1. Read container.xml to find the OPF file
+  const containerXml = await readZipText(zip, 'META-INF/container.xml');
+  if (!containerXml) throw new Error('Invalid EPUB: missing META-INF/container.xml');
+
+  const containerDoc = parseXml(containerXml);
+  const rootfileEl = containerDoc.getElementsByTagName('rootfile')[0];
+  const opfPath = rootfileEl?.getAttribute('full-path');
+  if (!opfPath) throw new Error('Invalid EPUB: no rootfile path found');
+
+  // 2. Read and parse the OPF
+  const opfXml = await readZipText(zip, opfPath);
+  if (!opfXml) throw new Error(`Invalid EPUB: missing OPF file at ${opfPath}`);
+
+  const opfDoc = parseXml(opfXml);
+  const opfDir = opfPath.includes('/') ? opfPath.substring(0, opfPath.lastIndexOf('/') + 1) : '';
+
+  // 3. Extract metadata
+  const DC_NS = 'http://purl.org/dc/elements/1.1/';
+  const title = opfDoc.getElementsByTagNameNS(DC_NS, 'title')[0]?.textContent?.trim() ?? 'Untitled';
+  const author = opfDoc.getElementsByTagNameNS(DC_NS, 'creator')[0]?.textContent?.trim() ?? '';
+
+  // 4. Build manifest map (id → href)
+  const manifest = new Map<string, string>();
+  const manifestItems = opfDoc.getElementsByTagName('item');
+  for (let i = 0; i < manifestItems.length; i++) {
+    const item = manifestItems[i];
+    const id = item.getAttribute('id');
+    const href = item.getAttribute('href');
+    if (id && href) manifest.set(id, href);
+  }
+
+  // 5. Get spine order
+  const spineIds: string[] = [];
+  const spineItemrefs = opfDoc.getElementsByTagName('itemref');
+  for (let i = 0; i < spineItemrefs.length; i++) {
+    const idref = spineItemrefs[i].getAttribute('idref');
+    if (idref) spineIds.push(idref);
+  }
+
+  // 6. Parse TOC for chapter titles
+  const tocTitles = await parseToc(zip, opfDoc, opfDir, manifest);
+
+  // 7. Extract text from each spine item
+  const chapters: ParsedChapter[] = [];
+  let untitledIndex = 0;
+
+  for (const id of spineIds) {
+    const href = manifest.get(id);
+    if (!href) continue;
+
+    const filePath = resolveHref(href, opfDir);
+    const xhtml = await readZipText(zip, filePath);
+    if (!xhtml) continue;
+
+    const text = extractTextFromHtml(xhtml);
+    const wordCount = text ? text.trim().split(/\s+/).length : 0;
+
+    // Skip chapters with fewer than 5 words (front matter, copyright, etc.)
+    if (wordCount < 5) continue;
+
+    const chapterTitle = tocTitles.get(href) ?? `Chapter ${++untitledIndex}`;
+    chapters.push({ title: chapterTitle, text, wordCount });
+  }
+
+  if (chapters.length === 0) {
+    throw new Error('No readable chapters found in this EPUB.');
+  }
+
+  return { title, author, chapters };
+}
+
+// ---------------------------------------------------------------------------
+// Exported helpers (tested directly)
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip HTML tags from XHTML content and return plain text.
+ */
+export function extractTextFromHtml(html: string): string {
+  const doc = new DOMParser().parseFromString(html, 'application/xhtml+xml');
+  const body = doc.body ?? doc.documentElement;
+  return (body.textContent ?? '').trim();
+}
+
+/**
+ * Resolve a manifest href relative to the OPF directory.
+ */
+export function resolveHref(href: string, opfDir: string): string {
+  return opfDir + href;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function parseXml(xml: string): Document {
+  return new DOMParser().parseFromString(xml, 'application/xml');
+}
+
+async function readZipText(zip: JSZip, path: string): Promise<string | null> {
+  const file = zip.file(path);
+  if (!file) return null;
+  return file.async('text');
+}
+
+/**
+ * Try to parse the TOC (EPUB 3 nav or EPUB 2 NCX) and return a map of href → title.
+ */
+async function parseToc(
+  zip: JSZip,
+  opfDoc: Document,
+  opfDir: string,
+  manifest: Map<string, string>,
+): Promise<Map<string, string>> {
+  const titles = new Map<string, string>();
+
+  // Try EPUB 3 nav document first
+  const manifestItems = opfDoc.getElementsByTagName('item');
+  for (let i = 0; i < manifestItems.length; i++) {
+    const item = manifestItems[i];
+    const props = item.getAttribute('properties') ?? '';
+    if (props.includes('nav')) {
+      const navHref = item.getAttribute('href');
+      if (!navHref) continue;
+
+      const navXhtml = await readZipText(zip, resolveHref(navHref, opfDir));
+      if (!navXhtml) continue;
+
+      const navDoc = new DOMParser().parseFromString(navXhtml, 'application/xhtml+xml');
+      // Find all <a> elements inside <nav> elements
+      const navElements = navDoc.getElementsByTagName('nav');
+      for (let n = 0; n < navElements.length; n++) {
+        const nav = navElements[n];
+        // Check for epub:type="toc" or id="toc"
+        const epubType = nav.getAttribute('epub:type') ?? nav.getAttributeNS('http://www.idpf.org/2007/ops', 'type') ?? '';
+        if (epubType !== 'toc' && nav.id !== 'toc') continue;
+
+        const links = nav.getElementsByTagName('a');
+        for (let l = 0; l < links.length; l++) {
+          const a = links[l];
+          const href = a.getAttribute('href')?.split('#')[0];
+          const text = a.textContent?.trim();
+          if (href && text) titles.set(href, text);
+        }
+      }
+
+      if (titles.size > 0) return titles;
+    }
+  }
+
+  // Fall back to NCX (EPUB 2)
+  const spineEl = opfDoc.getElementsByTagName('spine')[0];
+  const tocId = spineEl?.getAttribute('toc');
+  if (tocId) {
+    const ncxHref = manifest.get(tocId);
+    if (ncxHref) {
+      const ncxXml = await readZipText(zip, resolveHref(ncxHref, opfDir));
+      if (ncxXml) {
+        const ncxDoc = parseXml(ncxXml);
+        const navPoints = ncxDoc.getElementsByTagName('navPoint');
+        for (let i = 0; i < navPoints.length; i++) {
+          const np = navPoints[i];
+          const textEl = np.getElementsByTagName('text')[0];
+          const contentEl = np.getElementsByTagName('content')[0];
+          const text = textEl?.textContent?.trim();
+          const src = contentEl?.getAttribute('src')?.split('#')[0];
+          if (text && src) titles.set(src, text);
+        }
+      }
+    }
+  }
+
+  return titles;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm test -- --run dashboard/src/app/read/book/epubParser.test.ts
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/src/app/read/book/epubParser.ts dashboard/src/app/read/book/epubParser.test.ts
+git commit -m "feat(book): add EPUB parser with jszip"
+```
+
+---
+
+### Task 5: Utility functions — book ID and sentence extraction
+
+**Files:**
+- Create: `dashboard/src/app/read/book/utils.ts`
+- Create: `dashboard/src/app/read/book/utils.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `dashboard/src/app/read/book/utils.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { extractCurrentSentence } from './utils';
+
+// ---------------------------------------------------------------------------
+// extractCurrentSentence
+// ---------------------------------------------------------------------------
+
+describe('extractCurrentSentence', () => {
+  it('extracts a simple sentence around the given word index', () => {
+    const words = ['The', 'cat', 'sat.', 'The', 'dog', 'ran.'];
+    expect(extractCurrentSentence(words, 1)).toBe('The cat sat.');
+  });
+
+  it('extracts the second sentence when index is in it', () => {
+    const words = ['The', 'cat', 'sat.', 'The', 'dog', 'ran.'];
+    expect(extractCurrentSentence(words, 4)).toBe('The dog ran.');
+  });
+
+  it('handles index at the very start', () => {
+    const words = ['Hello', 'world.'];
+    expect(extractCurrentSentence(words, 0)).toBe('Hello world.');
+  });
+
+  it('handles text with no sentence-ending punctuation', () => {
+    const words = ['no', 'punctuation', 'here'];
+    expect(extractCurrentSentence(words, 1)).toBe('no punctuation here');
+  });
+
+  it('handles index at sentence boundary word', () => {
+    const words = ['First.', 'Second.'];
+    expect(extractCurrentSentence(words, 0)).toBe('First.');
+  });
+
+  it('handles exclamation marks', () => {
+    const words = ['Wow!', 'That', 'was', 'great.'];
+    expect(extractCurrentSentence(words, 2)).toBe('That was great.');
+  });
+
+  it('handles question marks', () => {
+    const words = ['Is', 'it?', 'Yes.'];
+    expect(extractCurrentSentence(words, 0)).toBe('Is it?');
+  });
+
+  it('truncates to 200 chars with ellipsis when sentence is too long', () => {
+    // Build a sentence of 50 long words (each ~10 chars + space = ~550 chars)
+    const words = Array.from({ length: 50 }, (_, i) => `longword${i.toString().padStart(2, '0')}`);
+    words[49] = words[49] + '.';
+    const result = extractCurrentSentence(words, 25);
+    expect(result.length).toBeLessThanOrEqual(203); // 200 + "..."
+    expect(result.startsWith('...')).toBe(true);
+  });
+
+  it('returns empty string for empty words array', () => {
+    expect(extractCurrentSentence([], 0)).toBe('');
+  });
+
+  it('clamps index to valid range', () => {
+    const words = ['Hello', 'world.'];
+    expect(extractCurrentSentence(words, 99)).toBe('Hello world.');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -- --run dashboard/src/app/read/book/utils.test.ts
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement utils**
+
+Create `dashboard/src/app/read/book/utils.ts`:
+
+```typescript
+/**
+ * Generate a book ID by hashing the first 4KB of file content.
+ */
+export async function generateBookId(buffer: ArrayBuffer): Promise<string> {
+  const slice = buffer.slice(0, 4096);
+  const hash = await crypto.subtle.digest('SHA-256', slice);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
+ * Extract the sentence surrounding the word at `wordIndex`.
+ * Scans backward and forward for sentence-ending punctuation (. ! ?).
+ * Caps output at 200 characters, truncating from the left with "...".
+ */
+export function extractCurrentSentence(words: string[], wordIndex: number): string {
+  if (words.length === 0) return '';
+
+  const idx = Math.max(0, Math.min(wordIndex, words.length - 1));
+
+  // Scan backward for sentence boundary
+  let start = 0;
+  for (let i = idx - 1; i >= 0; i--) {
+    if (/[.!?]$/.test(words[i])) {
+      start = i + 1;
+      break;
+    }
+  }
+
+  // Scan forward for sentence boundary
+  let end = words.length - 1;
+  for (let i = idx; i < words.length; i++) {
+    if (/[.!?]$/.test(words[i])) {
+      end = i;
+      break;
+    }
+  }
+
+  const sentence = words.slice(start, end + 1).join(' ');
+
+  if (sentence.length <= 200) return sentence;
+
+  return '...' + sentence.slice(-200);
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+npm test -- --run dashboard/src/app/read/book/utils.test.ts
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/src/app/read/book/utils.ts dashboard/src/app/read/book/utils.test.ts
+git commit -m "feat(book): add book ID generation and sentence extraction utils"
+```
+
+---
+
+### Task 6: Book store — IndexedDB and localStorage persistence
+
+**Files:**
+- Create: `dashboard/src/app/read/book/bookStore.ts`
+
+- [ ] **Step 1: Implement the book store**
+
+Create `dashboard/src/app/read/book/bookStore.ts`:
+
+```typescript
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface StoredBook {
+  id: string;
+  title: string;
+  author: string;
+  chapters: { title: string; text: string; wordCount: number }[];
+  addedAt: number;
+}
+
+export interface ReadingState {
+  bookId: string;
+  currentChapter: number;
+  position: number;
+  wpm: number;
+  chunkSize: 1 | 2 | 3;
+  displayMode: 'orp' | 'centered' | 'orp+context';
+  lastRead: number;
+}
+
+// ---------------------------------------------------------------------------
+// IndexedDB — book storage
+// ---------------------------------------------------------------------------
+
+const DB_NAME = 'book-reader';
+const STORE_NAME = 'books';
+const DB_VERSION = 1;
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function getAllBooks(): Promise<StoredBook[]> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.getAll();
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function getBook(id: string): Promise<StoredBook | undefined> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.get(id);
+    request.onsuccess = () => resolve(request.result ?? undefined);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function saveBook(book: StoredBook): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.put(book);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function deleteBook(id: string): Promise<void> {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.delete(id);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// localStorage — reading state
+// ---------------------------------------------------------------------------
+
+function stateKey(bookId: string): string {
+  return `book-state:${bookId}`;
+}
+
+export function getReadingState(bookId: string): ReadingState | null {
+  const raw = localStorage.getItem(stateKey(bookId));
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as ReadingState;
+  } catch {
+    return null;
+  }
+}
+
+export function saveReadingState(state: ReadingState): void {
+  localStorage.setItem(stateKey(state.bookId), JSON.stringify(state));
+}
+
+export function deleteReadingState(bookId: string): void {
+  localStorage.removeItem(stateKey(bookId));
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd dashboard && npm run build
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/src/app/read/book/bookStore.ts
+git commit -m "feat(book): add IndexedDB and localStorage persistence"
+```
+
+---
+
+### Task 7: Book reader page
+
+The main page component with library, upload, and reading phases. This is the largest task.
+
+**Files:**
+- Create: `dashboard/src/app/read/book/page.tsx`
+
+- [ ] **Step 1: Create the book reader page**
+
+Create `dashboard/src/app/read/book/page.tsx`:
+
+```tsx
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { useRSVPEngine, type TokenizedWord } from '../useRSVPEngine';
+import {
+  formatTime,
+  getFontSize,
+  segmentClass,
+  ORPDisplay,
+  CenteredDisplay,
+  ContextDisplay,
+  SourcePanel,
+} from '../components';
+import { parseEpub, type ParsedChapter } from './epubParser';
+import {
+  getAllBooks,
+  getBook,
+  saveBook,
+  deleteBook,
+  getReadingState,
+  saveReadingState,
+  deleteReadingState,
+  type StoredBook,
+  type ReadingState,
+} from './bookStore';
+import { generateBookId, extractCurrentSentence } from './utils';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Phase = 'library' | 'upload' | 'reading' | 'complete';
+type DisplayMode = 'orp' | 'centered' | 'orp+context';
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+export default function BookReaderPage() {
+  const [phase, setPhase] = useState<Phase>('library');
+  const [books, setBooks] = useState<StoredBook[]>([]);
+  const [loadingLibrary, setLoadingLibrary] = useState(true);
+
+  // Upload state
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  // Reading state
+  const [currentBook, setCurrentBook] = useState<StoredBook | null>(null);
+  const [currentChapterIndex, setCurrentChapterIndex] = useState(0);
+  const [chapterText, setChapterText] = useState('');
+  const [wpm, setWpm] = useState(250);
+  const [chunkSize, setChunkSize] = useState<1 | 2 | 3>(1);
+  const [displayMode, setDisplayMode] = useState<DisplayMode>('orp');
+  const [sourceExpanded, setSourceExpanded] = useState(false);
+  const [initialPosition, setInitialPosition] = useState(0);
+  const [copiedSentence, setCopiedSentence] = useState(false);
+
+  // Timing refs
+  const readingStartTime = useRef(0);
+  const totalPauseTime = useRef(0);
+  const lastPauseStart = useRef(0);
+  const autoSaveInterval = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const engine = useRSVPEngine({ text: chapterText, wpm, chunkSize, initialPosition });
+
+  // Completion stats
+  const [completionStats, setCompletionStats] = useState<{
+    totalTime: number;
+    effectiveWpm: number;
+  } | null>(null);
+
+  // -----------------------------------------------------------------------
+  // Load library on mount
+  // -----------------------------------------------------------------------
+
+  useEffect(() => {
+    getAllBooks().then((b) => {
+      setBooks(b);
+      setLoadingLibrary(false);
+    });
+  }, []);
+
+  // -----------------------------------------------------------------------
+  // Auto-save on visibilitychange
+  // -----------------------------------------------------------------------
+
+  const saveCurrentState = useCallback(() => {
+    if (!currentBook) return;
+    saveReadingState({
+      bookId: currentBook.id,
+      currentChapter: currentChapterIndex,
+      position: engine.position,
+      wpm,
+      chunkSize,
+      displayMode,
+      lastRead: Date.now(),
+    });
+  }, [currentBook, currentChapterIndex, engine.position, wpm, chunkSize, displayMode]);
+
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.hidden && phase === 'reading') {
+        saveCurrentState();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, [phase, saveCurrentState]);
+
+  // Auto-save every 30s during playback
+  useEffect(() => {
+    if (phase === 'reading' && engine.isPlaying) {
+      autoSaveInterval.current = setInterval(saveCurrentState, 30000);
+    } else if (autoSaveInterval.current) {
+      clearInterval(autoSaveInterval.current);
+      autoSaveInterval.current = null;
+    }
+    return () => {
+      if (autoSaveInterval.current) clearInterval(autoSaveInterval.current);
+    };
+  }, [phase, engine.isPlaying, saveCurrentState]);
+
+  // Save on pause
+  useEffect(() => {
+    if (phase === 'reading' && !engine.isPlaying && currentBook) {
+      saveCurrentState();
+    }
+  }, [engine.isPlaying, phase, currentBook, saveCurrentState]);
+
+  // Track pause time
+  useEffect(() => {
+    if (phase !== 'reading') return;
+    if (!engine.isPlaying) {
+      lastPauseStart.current = Date.now();
+    } else if (lastPauseStart.current > 0) {
+      totalPauseTime.current += Date.now() - lastPauseStart.current;
+      lastPauseStart.current = 0;
+    }
+  }, [engine.isPlaying, phase]);
+
+  // Detect chapter completion → auto-advance or book completion
+  useEffect(() => {
+    if (
+      phase === 'reading' &&
+      !engine.isPlaying &&
+      engine.position >= engine.totalWords &&
+      engine.totalWords > 0
+    ) {
+      if (!currentBook) return;
+      const isLastChapter = currentChapterIndex >= currentBook.chapters.length - 1;
+
+      if (isLastChapter) {
+        // Book complete
+        if (lastPauseStart.current > 0) {
+          totalPauseTime.current += Date.now() - lastPauseStart.current;
+          lastPauseStart.current = 0;
+        }
+        const totalTime = (Date.now() - readingStartTime.current - totalPauseTime.current) / 1000;
+        const totalWords = currentBook.chapters.reduce((sum, ch) => sum + ch.wordCount, 0);
+        const effectiveWpm = totalTime > 0 ? Math.round(totalWords / (totalTime / 60)) : 0;
+        setCompletionStats({ totalTime, effectiveWpm });
+        setPhase('complete');
+      } else {
+        // Advance to next chapter
+        goToChapter(currentChapterIndex + 1, 0);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [engine.isPlaying, engine.position, engine.totalWords, phase]);
+
+  // -----------------------------------------------------------------------
+  // Stable engine ref for keyboard handler
+  // -----------------------------------------------------------------------
+
+  const engineRef = useRef(engine);
+  useEffect(() => {
+    engineRef.current = engine;
+  }, [engine]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (phase !== 'reading' && phase !== 'complete') return;
+      const target = e.target as HTMLElement;
+      const tag = target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || tag === 'BUTTON' || target.getAttribute('role') === 'slider') return;
+
+      const eng = engineRef.current;
+
+      switch (e.code) {
+        case 'Space':
+          e.preventDefault();
+          eng.isPlaying ? eng.pause() : eng.play();
+          break;
+        case 'ArrowLeft':
+          eng.seek(-10);
+          break;
+        case 'ArrowRight':
+          eng.seek(10);
+          break;
+        case 'ArrowUp':
+          setWpm((w) => Math.min(800, w + 25));
+          break;
+        case 'ArrowDown':
+          setWpm((w) => Math.max(100, w - 25));
+          break;
+        case 'KeyR':
+          eng.restart();
+          break;
+        case 'KeyT':
+          setSourceExpanded((v) => !v);
+          break;
+        case 'KeyM':
+          setDisplayMode((m) => {
+            if (m === 'orp') return 'centered';
+            if (m === 'centered') return 'orp+context';
+            return 'orp';
+          });
+          break;
+        case 'KeyC':
+          setChunkSize((c) => {
+            if (c === 1) return 2;
+            if (c === 2) return 3;
+            return 1;
+          });
+          break;
+        case 'BracketLeft':
+          if (currentBook && currentChapterIndex > 0) {
+            goToChapter(currentChapterIndex - 1, 0);
+          }
+          break;
+        case 'BracketRight':
+          if (currentBook && currentChapterIndex < currentBook.chapters.length - 1) {
+            goToChapter(currentChapterIndex + 1, 0);
+          }
+          break;
+        case 'Escape':
+          saveCurrentState();
+          setPhase('library');
+          break;
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [phase, currentBook, currentChapterIndex]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  // -----------------------------------------------------------------------
+  // Actions
+  // -----------------------------------------------------------------------
+
+  function goToChapter(index: number, pos: number) {
+    if (!currentBook) return;
+    const chapter = currentBook.chapters[index];
+    if (!chapter) return;
+    setCurrentChapterIndex(index);
+    setInitialPosition(pos);
+    setChapterText(chapter.text);
+  }
+
+  async function openBook(bookId: string) {
+    const book = await getBook(bookId);
+    if (!book) return;
+
+    setCurrentBook(book);
+    const state = getReadingState(bookId);
+
+    const chIdx = state?.currentChapter ?? 0;
+    const pos = state?.position ?? 0;
+    if (state?.wpm) setWpm(state.wpm);
+    if (state?.chunkSize) setChunkSize(state.chunkSize);
+    if (state?.displayMode) setDisplayMode(state.displayMode);
+
+    setCurrentChapterIndex(chIdx);
+    setInitialPosition(pos);
+    setChapterText(book.chapters[chIdx]?.text ?? '');
+    readingStartTime.current = Date.now();
+    totalPauseTime.current = 0;
+    lastPauseStart.current = 0;
+    setPhase('reading');
+  }
+
+  async function handleRemoveBook(bookId: string) {
+    if (!confirm('Remove this book? Reading progress will be lost.')) return;
+    await deleteBook(bookId);
+    deleteReadingState(bookId);
+    setBooks((prev) => prev.filter((b) => b.id !== bookId));
+  }
+
+  async function handleFile(file: File) {
+    if (!file.name.toLowerCase().endsWith('.epub')) {
+      setUploadError('Please upload an .epub file.');
+      return;
+    }
+
+    setUploading(true);
+    setUploadError(null);
+
+    try {
+      const buffer = await file.arrayBuffer();
+      const id = await generateBookId(buffer);
+
+      // Check if book already exists
+      const existing = await getBook(id);
+      if (existing) {
+        if (!confirm(`"${existing.title}" is already in your library. Replace it? Reading progress will be reset.`)) {
+          setUploading(false);
+          return;
+        }
+        deleteReadingState(id);
+      }
+
+      const parsed = await parseEpub(buffer);
+      const book: StoredBook = {
+        id,
+        title: parsed.title,
+        author: parsed.author,
+        chapters: parsed.chapters,
+        addedAt: Date.now(),
+      };
+
+      await saveBook(book);
+      setBooks((prev) => {
+        const filtered = prev.filter((b) => b.id !== id);
+        return [...filtered, book];
+      });
+
+      // Go directly to reading
+      setCurrentBook(book);
+      setCurrentChapterIndex(0);
+      setInitialPosition(0);
+      setChapterText(book.chapters[0].text);
+      readingStartTime.current = Date.now();
+      totalPauseTime.current = 0;
+      lastPauseStart.current = 0;
+      setPhase('reading');
+    } catch (err) {
+      const message = err instanceof DOMException && err.name === 'QuotaExceededError'
+        ? 'Storage full. Remove some books to make room.'
+        : err instanceof Error
+          ? err.message
+          : 'Failed to parse EPUB file.';
+      setUploadError(message);
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Computed values
+  // -----------------------------------------------------------------------
+
+  const fontSize = getFontSize(engine.currentChunk);
+  const showSettings = !engine.isPlaying && phase === 'reading';
+  const currentChapter = currentBook?.chapters[currentChapterIndex];
+  const chapterProgress = currentChapter
+    ? Math.round((engine.position / currentChapter.wordCount) * 100)
+    : 0;
+  const overallProgress = currentBook
+    ? (() => {
+        const totalWords = currentBook.chapters.reduce((s, c) => s + c.wordCount, 0);
+        const wordsBefore = currentBook.chapters.slice(0, currentChapterIndex).reduce((s, c) => s + c.wordCount, 0);
+        return Math.round(((wordsBefore + engine.position) / totalWords) * 100);
+      })()
+    : 0;
+
+  // "Find my place" sentence
+  const currentSentence = (() => {
+    if (!currentChapter) return '';
+    const words = currentChapter.text.trim().split(/\s+/);
+    return extractCurrentSentence(words, engine.position);
+  })();
+
+  async function copySentence() {
+    await navigator.clipboard.writeText(currentSentence);
+    setCopiedSentence(true);
+    setTimeout(() => setCopiedSentence(false), 2000);
+  }
+
+  // -----------------------------------------------------------------------
+  // Render: complete phase
+  // -----------------------------------------------------------------------
+
+  if (phase === 'complete') {
+    const totalWords = currentBook?.chapters.reduce((s, c) => s + c.wordCount, 0) ?? 0;
+    return (
+      <div className="max-w-2xl mx-auto">
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-10 text-center">
+          <h2 className="text-2xl font-semibold text-gray-100 mb-2">Book Complete</h2>
+          <p className="text-gray-400 mb-8">{currentBook?.title}</p>
+
+          {completionStats && (
+            <div className="flex justify-center gap-12 mb-10">
+              <div>
+                <p className="text-3xl font-mono text-blue-400">{formatTime(completionStats.totalTime)}</p>
+                <p className="text-xs text-gray-500 mt-1 uppercase tracking-wide">Time</p>
+              </div>
+              <div>
+                <p className="text-3xl font-mono text-blue-400">{completionStats.effectiveWpm.toLocaleString()}</p>
+                <p className="text-xs text-gray-500 mt-1 uppercase tracking-wide">Effective WPM</p>
+              </div>
+              <div>
+                <p className="text-3xl font-mono text-blue-400">{totalWords.toLocaleString()}</p>
+                <p className="text-xs text-gray-500 mt-1 uppercase tracking-wide">Words</p>
+              </div>
+            </div>
+          )}
+
+          <button
+            className="px-6 py-2.5 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+            onClick={() => {
+              setCompletionStats(null);
+              setPhase('library');
+            }}
+          >
+            Back to Library
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // Render: reading phase
+  // -----------------------------------------------------------------------
+
+  if (phase === 'reading' && currentBook && currentChapter) {
+    return (
+      <div className="max-w-2xl mx-auto select-none">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-4">
+          <button
+            className="text-gray-500 hover:text-gray-300 text-sm transition-colors"
+            onClick={() => { saveCurrentState(); setPhase('library'); }}
+            title="Back to library (Esc)"
+          >
+            ← Library
+          </button>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm text-gray-400 truncate">{currentBook.title}</p>
+          </div>
+          <select
+            className="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm text-gray-200 focus:outline-none focus:border-gray-600 max-w-[200px]"
+            value={currentChapterIndex}
+            onChange={(e) => goToChapter(Number(e.target.value), 0)}
+          >
+            {currentBook.chapters.map((ch, i) => (
+              <option key={i} value={i}>{ch.title}</option>
+            ))}
+          </select>
+          <span className="text-xs text-gray-500 whitespace-nowrap">
+            {currentChapterIndex + 1}/{currentBook.chapters.length} — {chapterProgress}%
+          </span>
+        </div>
+
+        {/* Display area */}
+        <div className="py-20 flex items-center justify-center min-h-[160px]">
+          {displayMode === 'orp' && <ORPDisplay chunk={engine.currentChunk} fontSize={fontSize} />}
+          {displayMode === 'centered' && <CenteredDisplay chunk={engine.currentChunk} fontSize={fontSize} />}
+          {displayMode === 'orp+context' && (
+            <ContextDisplay chunk={engine.currentChunk} words={engine.words} position={engine.position} fontSize={fontSize} />
+          )}
+        </div>
+
+        {/* Find my place panel */}
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-3 mb-4">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-xs text-gray-500">
+              Chapter {currentChapterIndex + 1} — {chapterProgress}% · Book {overallProgress}%
+            </span>
+            <button
+              className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+              onClick={copySentence}
+              title="Copy sentence to clipboard"
+            >
+              {copiedSentence ? 'Copied!' : 'Copy'}
+            </button>
+          </div>
+          <p className="text-sm text-gray-400 leading-relaxed">{currentSentence}</p>
+        </div>
+
+        {/* Progress bar */}
+        <div className="mb-4">
+          <div
+            className="h-2 bg-gray-800 rounded-full cursor-pointer"
+            onClick={(e) => {
+              const rect = e.currentTarget.getBoundingClientRect();
+              const pct = (e.clientX - rect.left) / rect.width;
+              engine.jumpTo(Math.round(pct * engine.totalWords));
+            }}
+          >
+            <div
+              className="h-full bg-blue-600 rounded-full transition-all"
+              style={{ width: `${engine.progress * 100}%` }}
+            />
+          </div>
+          <div className="flex justify-between text-xs text-gray-500 mt-1">
+            <span>Word {engine.position} / {engine.totalWords}</span>
+            <span>{formatTime(engine.estimatedTimeLeft)} left</span>
+          </div>
+        </div>
+
+        {/* Transport controls */}
+        <div className="flex items-center justify-center gap-3 mb-4">
+          <button className="px-3 py-2 rounded bg-gray-800 text-gray-300 hover:bg-gray-700 text-sm transition-colors" onClick={() => engine.seek(-10)} title="Seek back 10s (←)">←10s</button>
+          <button className="px-5 py-2 rounded bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium transition-colors min-w-[80px]" onClick={() => (engine.isPlaying ? engine.pause() : engine.play())} title="Play/Pause (Space)">
+            {engine.isPlaying ? 'Pause' : 'Play'}
+          </button>
+          <button className="px-3 py-2 rounded bg-gray-800 text-gray-300 hover:bg-gray-700 text-sm transition-colors" onClick={() => engine.seek(10)} title="Seek forward 10s (→)">10s→</button>
+        </div>
+
+        {/* Status bar */}
+        <div className="flex items-center justify-center gap-4 text-xs text-gray-500 mb-4">
+          <span>WPM: <span className="text-gray-300">{wpm}</span> <span className="text-gray-600">(↑↓)</span></span>
+          <span>Chunk: <span className="text-gray-300">{chunkSize}</span> <span className="text-gray-600">(C)</span></span>
+          <span>Mode: <span className="text-gray-300">{displayMode}</span> <span className="text-gray-600">(M)</span></span>
+          <button className="text-gray-500 hover:text-gray-300 transition-colors" onClick={() => setSourceExpanded((v) => !v)} title="Toggle source (T)">
+            Source <span className="text-gray-600">(T)</span>
+          </button>
+          <span>Ch: <span className="text-gray-600">[ ]</span></span>
+        </div>
+
+        {/* Settings panel — visible on pause */}
+        {showSettings && (
+          <div className="bg-gray-900 border border-gray-800 rounded-lg p-4 mb-4">
+            <div className="flex flex-wrap gap-6 items-center">
+              <div className="flex items-center gap-3 flex-1 min-w-48">
+                <label className="text-xs text-gray-400 uppercase tracking-wide whitespace-nowrap">WPM</label>
+                <input type="range" min={100} max={800} step={25} value={wpm} onChange={(e) => setWpm(Number(e.target.value))} className="flex-1 accent-blue-500" />
+                <input type="number" min={100} max={800} step={25} value={wpm} onChange={(e) => setWpm(Math.min(800, Math.max(100, Number(e.target.value))))} className="w-16 bg-gray-800 border border-gray-700 rounded px-2 py-1 text-sm text-center text-gray-100 focus:outline-none focus:border-gray-600" />
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-gray-400 uppercase tracking-wide whitespace-nowrap">Words</span>
+                <div className="flex gap-1">
+                  {([1, 2, 3] as const).map((n) => (
+                    <button key={n} className={segmentClass(chunkSize === n)} onClick={() => setChunkSize(n)}>{n}</button>
+                  ))}
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-gray-400 uppercase tracking-wide whitespace-nowrap">Mode</span>
+                <div className="flex gap-1">
+                  {([
+                    { value: 'orp' as const, label: 'ORP' },
+                    { value: 'centered' as const, label: 'Centered' },
+                    { value: 'orp+context' as const, label: 'ORP + Context' },
+                  ]).map(({ value, label }) => (
+                    <button key={value} className={segmentClass(displayMode === value)} onClick={() => setDisplayMode(value)}>{label}</button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Source panel */}
+        {(sourceExpanded || showSettings) && (
+          <SourcePanel text={chapterText} words={engine.words} position={engine.position} />
+        )}
+      </div>
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // Render: upload phase
+  // -----------------------------------------------------------------------
+
+  if (phase === 'upload') {
+    return (
+      <div className="max-w-2xl mx-auto">
+        <div className="flex items-center gap-3 mb-6">
+          <button
+            className="text-gray-500 hover:text-gray-300 text-sm transition-colors"
+            onClick={() => setPhase('library')}
+          >
+            ← Library
+          </button>
+          <h2 className="text-xl font-semibold">Add Book</h2>
+        </div>
+
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+          <div
+            className={`border-2 border-dashed rounded-lg p-10 text-center transition-colors ${
+              dragging ? 'border-blue-500 bg-blue-950/20' : 'border-gray-700 hover:border-gray-600'
+            }`}
+            onDrop={(e) => { e.preventDefault(); setDragging(false); const f = e.dataTransfer.files[0]; if (f) handleFile(f); }}
+            onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
+            onDragLeave={() => setDragging(false)}
+          >
+            {uploading ? (
+              <p className="text-gray-400 text-sm">Parsing EPUB...</p>
+            ) : (
+              <>
+                <p className="text-gray-400 mb-2 text-sm">
+                  Drag and drop an EPUB file here, or{' '}
+                  <label className="text-blue-400 hover:text-blue-300 cursor-pointer underline">
+                    browse
+                    <input type="file" accept=".epub" className="hidden" onChange={(e) => { const f = e.target.files?.[0]; if (f) handleFile(f); }} />
+                  </label>
+                </p>
+                <p className="text-xs text-gray-600">Supports .epub files</p>
+              </>
+            )}
+          </div>
+
+          {uploadError && (
+            <p className="text-sm text-red-400 mt-3">{uploadError}</p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // -----------------------------------------------------------------------
+  // Render: library phase (default)
+  // -----------------------------------------------------------------------
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-xl font-semibold">Book Library</h2>
+        <button
+          className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+          onClick={() => { setUploadError(null); setPhase('upload'); }}
+        >
+          Add Book
+        </button>
+      </div>
+
+      {loadingLibrary ? (
+        <p className="text-gray-500 text-sm">Loading...</p>
+      ) : books.length === 0 ? (
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-10 text-center">
+          <p className="text-gray-400 mb-4">No books yet</p>
+          <button
+            className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+            onClick={() => { setUploadError(null); setPhase('upload'); }}
+          >
+            Upload an EPUB
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {books
+            .sort((a, b) => {
+              const stateA = getReadingState(a.id);
+              const stateB = getReadingState(b.id);
+              return (stateB?.lastRead ?? b.addedAt) - (stateA?.lastRead ?? a.addedAt);
+            })
+            .map((book) => {
+              const state = getReadingState(book.id);
+              const chIdx = state?.currentChapter ?? 0;
+              const totalWords = book.chapters.reduce((s, c) => s + c.wordCount, 0);
+              const wordsBefore = book.chapters.slice(0, chIdx).reduce((s, c) => s + c.wordCount, 0);
+              const overallPct = totalWords > 0 ? Math.round(((wordsBefore + (state?.position ?? 0)) / totalWords) * 100) : 0;
+              const lastRead = state?.lastRead ? new Date(state.lastRead).toLocaleDateString() : null;
+
+              return (
+                <div
+                  key={book.id}
+                  className="bg-gray-900 border border-gray-800 rounded-lg p-4 hover:border-gray-700 transition-colors cursor-pointer"
+                  onClick={() => openBook(book.id)}
+                >
+                  <div className="flex items-start justify-between">
+                    <div className="flex-1 min-w-0">
+                      <h3 className="text-gray-100 font-medium truncate">{book.title}</h3>
+                      {book.author && <p className="text-sm text-gray-500">{book.author}</p>}
+                      <div className="flex items-center gap-3 mt-2 text-xs text-gray-500">
+                        <span>Chapter {chIdx + 1} / {book.chapters.length}</span>
+                        <span>{overallPct}%</span>
+                        {lastRead && <span>Last read: {lastRead}</span>}
+                      </div>
+                      {/* Mini progress bar */}
+                      <div className="h-1 bg-gray-800 rounded-full mt-2 w-full">
+                        <div className="h-full bg-blue-600 rounded-full" style={{ width: `${overallPct}%` }} />
+                      </div>
+                    </div>
+                    <button
+                      className="text-gray-600 hover:text-red-400 text-sm ml-3 transition-colors"
+                      onClick={(e) => { e.stopPropagation(); handleRemoveBook(book.id); }}
+                      title="Remove book"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd dashboard && npm run build
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/src/app/read/book/page.tsx
+git commit -m "feat(book): add book reader page with library, upload, and reading phases"
+```
+
+---
+
+### Task 8: Add navigation link
+
+**Files:**
+- Modify: `dashboard/src/app/layout.tsx:14-17`
+
+- [ ] **Step 1: Add "Book" link to the nav bar**
+
+In `dashboard/src/app/layout.tsx`, find the navigation links array and add a "Book" entry after "Read":
+
+```tsx
+<a href="/read" className="text-gray-400 hover:text-gray-100 transition-colors text-sm">Read</a>
+<a href="/read/book" className="text-gray-400 hover:text-gray-100 transition-colors text-sm">Book</a>
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd dashboard && npm run build
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/src/app/layout.tsx
+git commit -m "feat(nav): add Book link to dashboard navigation"
+```
+
+---
+
+### Task 9: Run all tests and integration check
+
+- [ ] **Step 1: Run all tests**
+
+```bash
+npm test -- --run
+```
+
+Expected: All tests pass, including new epubParser and utils tests.
+
+- [ ] **Step 2: Start the dashboard and verify**
+
+```bash
+cd dashboard && npm run dev &
+```
+
+Then check:
+1. Navigate to `/read` — existing speed reader works identically
+2. Navigate to `/read/book` — shows empty library with "Upload an EPUB" prompt
+3. Upload an EPUB file — parses and transitions to reading phase
+4. Verify chapter dropdown populates with chapter titles
+5. Verify RSVP playback works (Space to play/pause)
+6. Verify "Find my place" sentence updates during playback
+7. Verify Copy button copies sentence to clipboard
+8. Verify `[` and `]` navigate chapters
+9. Pause, reload page, navigate back to `/read/book` — book appears in library with progress
+10. Click the book — resumes at saved position
+11. Verify existing `/read` still works independently (paste text, play, etc.)
+
+- [ ] **Step 3: Kill dev server and commit any fixes**
+
+```bash
+kill %1
+```
+
+If any fixes were needed, commit them with a descriptive message.

--- a/docs/superpowers/specs/2026-04-13-epub-book-reader-design.md
+++ b/docs/superpowers/specs/2026-04-13-epub-book-reader-design.md
@@ -1,0 +1,190 @@
+# EPUB Book Reader — Design Spec
+
+## Overview
+
+A dedicated book reading page at `/read/book` that loads EPUB files, parses them into chapters, and presents them through the existing RSVP engine. Designed for switching between speed reading on the dashboard and reading the same book on a reMarkable tablet. Books persist in the browser via IndexedDB so they never need re-uploading.
+
+Separate from the existing `/read` speed reader, which stays untouched for ad-hoc text/file reading. Both share the `useRSVPEngine` hook.
+
+## Route & File Structure
+
+```
+dashboard/src/app/read/book/page.tsx       — Book reader page (library + reading phases)
+dashboard/src/app/read/book/useBookStore.ts — IndexedDB + localStorage persistence
+dashboard/src/app/read/book/epubParser.ts   — EPUB → chapter extraction
+dashboard/src/app/read/useRSVPEngine.ts     — Shared engine (minor change: initialPosition support)
+```
+
+## Dependencies
+
+- `jszip` — unzip EPUB files client-side
+- No new API routes or backend changes
+
+An EPUB is a ZIP containing XML/XHTML files. Rather than pulling in `epubjs` (which has SSR/bundler compatibility issues with Next.js and is overkill for text extraction), we use `jszip` to unzip and `DOMParser` to parse the XML metadata and XHTML chapter content directly.
+
+## Data Model
+
+### Book (IndexedDB)
+
+```typescript
+interface StoredBook {
+  id: string;              // SHA-256 hash of first 4KB of file content
+  title: string;           // from EPUB metadata (dc:title), fallback to filename
+  author: string;          // from EPUB metadata (dc:creator), empty string if missing
+  chapters: Chapter[];     // ordered by spine
+  addedAt: number;         // timestamp
+}
+
+interface Chapter {
+  title: string;           // from TOC, fallback to "Chapter N"
+  text: string;            // plain text content (HTML stripped)
+  wordCount: number;       // precomputed for progress display
+}
+```
+
+The book ID uses a content hash of the first 4KB to avoid collisions from files with the same name and size.
+
+### Reading State (localStorage)
+
+```typescript
+interface ReadingState {
+  bookId: string;
+  currentChapter: number;  // 0-indexed
+  position: number;        // word index within current chapter
+  wpm: number;
+  chunkSize: 1 | 2 | 3;
+  displayMode: 'orp' | 'centered' | 'orp+context';
+  lastRead: number;        // timestamp
+}
+```
+
+Key format: `book-state:{bookId}`
+
+## Phases
+
+The page has three phases: **library**, **upload**, and **reading**.
+
+### Library Phase (landing state)
+
+Shows all stored books. This is what users see on return visits.
+
+- Each book card shows: title, author, chapter progress ("Chapter 5 / 12"), overall book progress ("42%"), last read date
+- Click a book → resume reading at saved position
+- "Add Book" button → switches to upload phase
+- Remove button per book (confirms before deleting from IndexedDB + localStorage)
+- Empty state: "No books yet" with prominent upload prompt
+
+### Upload Phase
+
+Minimal — just a drop zone.
+
+- Drag-and-drop or browse for `.epub` files
+- Loading spinner with "Parsing..." during extraction (large books may take a few seconds)
+- On load: parse EPUB, extract chapters, store in IndexedDB
+- If book already exists (same id): ask "Replace existing book? Reading progress will be reset." vs cancel
+- After successful parse: transition directly to reading phase at chapter 0
+- Parse error: inline error message, stay on upload phase
+- IndexedDB quota error: "Storage full. Remove some books to make room."
+
+### Reading Phase
+
+The RSVP reader with chapter awareness and "find my place" features.
+
+**Layout (top to bottom):**
+
+1. **Header bar**: book title, chapter dropdown, chapter progress ("Chapter 5 / 12 — 34%"), back-to-library button
+2. **RSVP display**: center of screen, same engine and display modes as existing reader
+3. **"Find my place" panel**: current full sentence as static text, copy button
+4. **Transport controls**: play/pause, seek, restart — same as existing reader
+5. **Status bar**: WPM, chunk size, display mode indicators with keyboard hints
+6. **Settings panel**: appears on pause — WPM slider, chunk size, display mode toggles
+7. **Source panel**: expandable, shows chapter text with current word highlighted
+
+## Chapter Navigation
+
+- **Dropdown** in header lists all chapters by TOC title
+- Selecting a chapter: feeds that chapter's text to the engine, resets position to 0, auto-saves state
+- **Auto-advance**: completing a chapter transitions to the next one automatically (paused at word 0)
+- **End of book**: completing the final chapter shows a completion screen with total stats and a "Back to Library" button
+- **Keyboard**: `[` prev chapter, `]` next chapter
+- Chapter changes are persisted immediately
+
+## "Find My Place" Panel
+
+Always visible below the RSVP display. Purpose: when switching to the reMarkable, glance at this to know where you are.
+
+**Sentence extraction:**
+- From the current word position, scan backward in the chapter text to the previous sentence-ending punctuation (`. ! ?` followed by a space or end of string, or start of text)
+- Scan forward to the next sentence-ending punctuation (or end of text)
+- Display the full sentence as static, readable text
+- Cap at 200 characters; if longer, truncate from the left with "..." so the current word is always visible
+
+Known limitation: abbreviations like "Dr." may cause incorrect sentence boundaries. Proper sentence detection requires NLP and is not worth the complexity.
+
+**UI:**
+- Gray text on dark background, comfortable reading size (~14-16px)
+- Copy button (clipboard icon) on the right — copies sentence to clipboard
+- Shows "Chapter X — Y%" label above the sentence for quick reference
+
+## Persistence
+
+### Auto-save triggers
+- Every pause
+- Every chapter change
+- Every 30 seconds during playback (via interval)
+- On `visibilitychange` when `document.hidden` becomes true (reliable across mobile/desktop, unlike `beforeunload`)
+
+### Resume behavior
+- Clicking a book from the library loads its reading state and jumps to the saved chapter + position
+- The RSVP engine supports an `initialPosition` option so it can start at a non-zero position without a race condition (see Engine Changes below)
+- Settings (WPM, chunk size, display mode) are restored
+
+### Storage management
+- IndexedDB store name: `book-reader`
+- Object store: `books`
+- localStorage keys: `book-state:{bookId}`
+- Removing a book clears both IndexedDB entry and localStorage state
+
+## Engine Changes
+
+The existing `useRSVPEngine` hook resets position to 0 whenever `text` changes. For book reader resume, the hook needs a minor addition:
+
+- Add an optional `initialPosition` field to `RSVPEngineOptions`
+- In the text-change `useEffect`, use `initialPosition ?? 0` instead of hardcoded `0`
+- This is backward-compatible — the existing speed reader passes no `initialPosition` and gets the current behavior
+
+## EPUB Parsing
+
+Using `jszip` + `DOMParser`:
+
+1. Load EPUB from `ArrayBuffer` (from file upload) into JSZip
+2. Read `META-INF/container.xml` → find the OPF file path (rootfile)
+3. Parse the OPF file:
+   - Extract metadata: `dc:title`, `dc:creator`
+   - Read the `<spine>` element for ordered `itemref` entries
+   - Read the `<manifest>` to map item IDs to file paths
+4. For each spine item: read the XHTML file from the ZIP, parse with `DOMParser`, extract `textContent` from `<body>`
+5. Read the TOC file (NCX or XHTML nav) for chapter titles; map to spine items by href; fallback to "Chapter N" for untitled items
+6. Filter out chapters with fewer than 5 words (front matter, copyright pages)
+
+## Keyboard Shortcuts
+
+All existing RSVP shortcuts carry over, plus:
+
+| Key | Action |
+|-----|--------|
+| `[` | Previous chapter |
+| `]` | Next chapter |
+| `Escape` | Back to library |
+
+## Navigation
+
+Add "Book" as a link in the dashboard nav bar, alongside the existing Read link. Route: `/read/book`.
+
+## Styling
+
+Follows existing dashboard patterns:
+- Inline Tailwind CSS
+- Dark theme: `bg-gray-950`, `text-gray-100`, `border-gray-800`
+- Cards: `bg-gray-900 border border-gray-800 rounded-lg`
+- Accent: `blue-500` for controls, `red-500` for ORP pivot

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint-plugin-no-catch-all": "^1.1.0",
         "globals": "^15.12.0",
         "husky": "^9.1.7",
+        "jsdom": "^29.0.2",
         "prettier": "^3.8.1",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0",
@@ -37,6 +38,200 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
+      "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -637,6 +832,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@grammyjs/files": {
@@ -1658,6 +1871,16 @@
         "prebuild-install": "^7.1.1"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -1824,6 +2047,72 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/dateformat": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -1849,6 +2138,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -1896,6 +2192,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2412,6 +2721,19 @@
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -2524,6 +2846,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2549,6 +2878,86 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -2621,6 +3030,16 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/luxon": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -2639,6 +3058,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",
@@ -2834,6 +3260,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -3133,6 +3572,16 @@
         "node": ">= 12.13.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3224,6 +3673,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/section-matter": {
@@ -3431,6 +3893,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -3510,6 +3979,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -3611,6 +4113,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -3789,11 +4301,34 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -3851,6 +4386,23 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yaml": {
       "version": "2.8.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-no-catch-all": "^1.1.0",
     "globals": "^15.12.0",
     "husky": "^9.1.7",
+    "jsdom": "^29.0.2",
     "prettier": "^3.8.1",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",


### PR DESCRIPTION
## Summary

- Adds a persistent EPUB book reader at `/read/book` for reading entire books using RSVP speed reading
- Designed for switching between speed reading on the dashboard and reading the same book on a reMarkable tablet
- Books stored in IndexedDB (never need re-uploading), reading state persisted in localStorage
- EPUB parsing via jszip + DOMParser (no heavy EPUB library, handles both EPUB 2 and 3)

### Key features
- **Library view**: stored books with progress indicators, sorted by last read
- **Chapter navigation**: dropdown selector + `[`/`]` keyboard shortcuts, auto-advance on chapter completion
- **"Find my place" panel**: always-visible current sentence with copy button — glance at this when switching to reMarkable
- **Full RSVP controls**: play/pause, seek, WPM adjustment, display modes (ORP/centered/context)
- **Resume support**: re-open a book and pick up exactly where you left off
- **Completion screen**: stats for finished books

### Architecture
- Separate route (`/read/book`) — existing `/read` speed reader untouched
- Shared display components extracted to `components.tsx` for reuse
- Engine extended with `initialPosition` + `textVersion` for chapter resume (backward-compatible)
- 19 new tests, all passing

## Test plan

- [ ] Upload an EPUB file — verify it parses and shows chapters
- [ ] Play RSVP — verify display modes, keyboard shortcuts, seek controls work
- [ ] Switch chapters via dropdown and `[`/`]` keys
- [ ] Verify "find my place" sentence updates during playback, copy button works
- [ ] Close browser, reopen `/read/book` — verify book appears in library with progress
- [ ] Click book — verify it resumes at saved chapter and position
- [ ] Verify existing `/read` speed reader still works identically
- [ ] Complete a book — verify completion screen shows stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)