### PR TITLE
fix(book): split fragment-based EPUB chapters

### DIFF
--- a/dashboard/src/app/read/book/epubParser.integration.test.ts
+++ b/dashboard/src/app/read/book/epubParser.integration.test.ts
@@ -1,0 +1,355 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { parseEpub } from './epubParser';
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal EPUB zip from parts
+// ---------------------------------------------------------------------------
+
+interface EpubParts {
+  opfPath?: string;
+  opfContent: string;
+  files: Record<string, string>; // path → content
+}
+
+async function buildEpub(parts: EpubParts): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  const opfPath = parts.opfPath ?? 'OEBPS/content.opf';
+
+  zip.file('META-INF/container.xml', `<?xml version="1.0"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+  <rootfiles>
+    <rootfile full-path="${opfPath}" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>`);
+
+  zip.file(opfPath, parts.opfContent);
+
+  for (const [path, content] of Object.entries(parts.files)) {
+    zip.file(path, content);
+  }
+
+  return zip.generateAsync({ type: 'arraybuffer' });
+}
+
+function xhtml(body: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><title>Test</title></head>
+<body>${body}</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Basic multi-file EPUB with EPUB3 nav (happy path)
+// ---------------------------------------------------------------------------
+
+describe('parseEpub integration', () => {
+  it('parses a simple multi-file EPUB3 with nav TOC', async () => {
+    const buffer = await buildEpub({
+      opfContent: `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Test Book</dc:title>
+    <dc:creator>Test Author</dc:creator>
+  </metadata>
+  <manifest>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+    <item id="ch1" href="ch1.xhtml" media-type="application/xhtml+xml"/>
+    <item id="ch2" href="ch2.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="ch1"/>
+    <itemref idref="ch2"/>
+  </spine>
+</package>`,
+      files: {
+        'OEBPS/nav.xhtml': xhtml(`
+          <nav epub:type="toc" id="toc">
+            <ol>
+              <li><a href="ch1.xhtml">Introduction</a></li>
+              <li><a href="ch2.xhtml">Methods</a></li>
+            </ol>
+          </nav>
+        `),
+        'OEBPS/ch1.xhtml': xhtml('<p>This is the introduction chapter with enough words to pass the filter easily.</p>'),
+        'OEBPS/ch2.xhtml': xhtml('<p>This is the methods chapter with enough words to pass the filter easily too.</p>'),
+      },
+    });
+
+    const book = await parseEpub(buffer);
+    expect(book.title).toBe('Test Book');
+    expect(book.author).toBe('Test Author');
+    expect(book.chapters).toHaveLength(2);
+    expect(book.chapters[0].title).toBe('Introduction');
+    expect(book.chapters[1].title).toBe('Methods');
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2: Single-file EPUB with fragment-based chapters in nav TOC
+  //
+  // This is common in EPUBs produced by InDesign or Calibre where the entire
+  // book is in one XHTML file and chapters are anchored by id fragments.
+  // -------------------------------------------------------------------------
+
+  it('handles single-file EPUB with fragment-based TOC entries', async () => {
+    const buffer = await buildEpub({
+      opfContent: `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Single File Book</dc:title>
+    <dc:creator>Author</dc:creator>
+  </metadata>
+  <manifest>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+    <item id="content" href="content.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="content"/>
+  </spine>
+</package>`,
+      files: {
+        'OEBPS/nav.xhtml': xhtml(`
+          <nav epub:type="toc" id="toc">
+            <ol>
+              <li><a href="content.xhtml#ch1">Chapter 1: The Beginning</a></li>
+              <li><a href="content.xhtml#ch2">Chapter 2: The Middle</a></li>
+              <li><a href="content.xhtml#ch3">Chapter 3: The End</a></li>
+            </ol>
+          </nav>
+        `),
+        'OEBPS/content.xhtml': xhtml(`
+          <h1 id="ch1">Chapter 1: The Beginning</h1>
+          <p>This is the first chapter of the book. It contains introductory material about the topic we are exploring in great detail.</p>
+          <p>There is more content here to ensure we have enough words for the chapter to be meaningful and pass any word count filters.</p>
+
+          <h1 id="ch2">Chapter 2: The Middle</h1>
+          <p>This is the second chapter which covers the main body of the work. We explore the methodology and present our findings here.</p>
+          <p>Additional content to make this chapter substantial enough to demonstrate the splitting behavior correctly.</p>
+
+          <h1 id="ch3">Chapter 3: The End</h1>
+          <p>This is the final chapter with conclusions and future work. We summarize everything that was discussed previously.</p>
+          <p>Some more concluding remarks to ensure adequate word count for the chapter filter.</p>
+        `),
+      },
+    });
+
+    const book = await parseEpub(buffer);
+
+    // BUG: Currently the parser produces only 1 chapter because all TOC entries
+    // point to content.xhtml (fragment stripped), and the entire file text is
+    // extracted as a single chapter.
+    //
+    // Expected: 3 chapters split at the fragment anchors
+    // Actual: 1 chapter with the title of the last TOC entry that matches
+
+    // This assertion documents the EXPECTED behavior:
+    expect(book.chapters.length).toBeGreaterThanOrEqual(3);
+    expect(book.chapters[0].title).toBe('Chapter 1: The Beginning');
+    expect(book.chapters[1].title).toBe('Chapter 2: The Middle');
+    expect(book.chapters[2].title).toBe('Chapter 3: The End');
+
+    // Each chapter should contain only its own text, not the full file
+    expect(book.chapters[0].text).toContain('introductory material');
+    expect(book.chapters[0].text).not.toContain('methodology');
+    expect(book.chapters[1].text).toContain('methodology');
+    expect(book.chapters[1].text).not.toContain('conclusions');
+    expect(book.chapters[2].text).toContain('conclusions');
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3: EPUB2 with NCX TOC (no EPUB3 nav)
+  // -------------------------------------------------------------------------
+
+  it('falls back to NCX TOC for EPUB2 books', async () => {
+    const buffer = await buildEpub({
+      opfContent: `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>EPUB2 Book</dc:title>
+    <dc:creator>Legacy Author</dc:creator>
+  </metadata>
+  <manifest>
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>
+    <item id="ch1" href="ch1.xhtml" media-type="application/xhtml+xml"/>
+    <item id="ch2" href="ch2.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine toc="ncx">
+    <itemref idref="ch1"/>
+    <itemref idref="ch2"/>
+  </spine>
+</package>`,
+      files: {
+        'OEBPS/toc.ncx': `<?xml version="1.0"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+  <navMap>
+    <navPoint id="np1">
+      <navLabel><text>Kapittel 1: Innledning</text></navLabel>
+      <content src="ch1.xhtml"/>
+    </navPoint>
+    <navPoint id="np2">
+      <navLabel><text>Kapittel 2: Metode</text></navLabel>
+      <content src="ch2.xhtml"/>
+    </navPoint>
+  </navMap>
+</ncx>`,
+        'OEBPS/ch1.xhtml': xhtml('<p>Dette er det første kapittelet med introduksjon til temaet vi utforsker i detalj.</p>'),
+        'OEBPS/ch2.xhtml': xhtml('<p>Dette er det andre kapittelet om metode og tilnærming vi bruker i denne studien.</p>'),
+      },
+    });
+
+    const book = await parseEpub(buffer);
+    expect(book.chapters).toHaveLength(2);
+    expect(book.chapters[0].title).toBe('Kapittel 1: Innledning');
+    expect(book.chapters[1].title).toBe('Kapittel 2: Metode');
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 4: NCX with fragment-based chapters (same bug as test 2)
+  // -------------------------------------------------------------------------
+
+  it('handles NCX TOC with fragment-based chapter references', async () => {
+    const buffer = await buildEpub({
+      opfContent: `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>NCX Fragment Book</dc:title>
+    <dc:creator>Author</dc:creator>
+  </metadata>
+  <manifest>
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>
+    <item id="content" href="content.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine toc="ncx">
+    <itemref idref="content"/>
+  </spine>
+</package>`,
+      files: {
+        'OEBPS/toc.ncx': `<?xml version="1.0"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/">
+  <navMap>
+    <navPoint id="np1">
+      <navLabel><text>Del 1</text></navLabel>
+      <content src="content.xhtml#part1"/>
+    </navPoint>
+    <navPoint id="np2">
+      <navLabel><text>Del 2</text></navLabel>
+      <content src="content.xhtml#part2"/>
+    </navPoint>
+  </navMap>
+</ncx>`,
+        'OEBPS/content.xhtml': xhtml(`
+          <div id="part1">
+            <h1>Del 1</h1>
+            <p>Innhold i del 1. Her er det nok tekst til å passere filteret for minimum antall ord i et kapittel.</p>
+          </div>
+          <div id="part2">
+            <h1>Del 2</h1>
+            <p>Innhold i del 2. Også her er det tilstrekkelig med tekst til å demonstrere at kapittelet blir riktig splittet.</p>
+          </div>
+        `),
+      },
+    });
+
+    const book = await parseEpub(buffer);
+    expect(book.chapters.length).toBeGreaterThanOrEqual(2);
+    expect(book.chapters[0].title).toBe('Del 1');
+    expect(book.chapters[1].title).toBe('Del 2');
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 5: Mixed — some files + some fragments within the same file
+  // -------------------------------------------------------------------------
+
+  it('handles mix of separate files and fragment-based chapters', async () => {
+    const buffer = await buildEpub({
+      opfContent: `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Mixed Book</dc:title>
+    <dc:creator>Author</dc:creator>
+  </metadata>
+  <manifest>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+    <item id="preface" href="preface.xhtml" media-type="application/xhtml+xml"/>
+    <item id="body" href="body.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="preface"/>
+    <itemref idref="body"/>
+  </spine>
+</package>`,
+      files: {
+        'OEBPS/nav.xhtml': xhtml(`
+          <nav epub:type="toc" id="toc">
+            <ol>
+              <li><a href="preface.xhtml">Preface</a></li>
+              <li><a href="body.xhtml#ch1">Chapter 1</a></li>
+              <li><a href="body.xhtml#ch2">Chapter 2</a></li>
+            </ol>
+          </nav>
+        `),
+        'OEBPS/preface.xhtml': xhtml('<p>This is the preface with introductory remarks about the book and its purpose for the reader.</p>'),
+        'OEBPS/body.xhtml': xhtml(`
+          <section id="ch1">
+            <h1>Chapter 1</h1>
+            <p>Content of chapter one with sufficient text to demonstrate the split works correctly here.</p>
+          </section>
+          <section id="ch2">
+            <h1>Chapter 2</h1>
+            <p>Content of chapter two with more text so we can verify each section is treated independently.</p>
+          </section>
+        `),
+      },
+    });
+
+    const book = await parseEpub(buffer);
+
+    // Preface should be its own chapter, and body.xhtml should be split into 2
+    expect(book.chapters.length).toBeGreaterThanOrEqual(3);
+    expect(book.chapters[0].title).toBe('Preface');
+    expect(book.chapters[1].title).toBe('Chapter 1');
+    expect(book.chapters[2].title).toBe('Chapter 2');
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 6: Front matter filtered out (< 5 words)
+  // -------------------------------------------------------------------------
+
+  it('filters out spine items with fewer than 5 words', async () => {
+    const buffer = await buildEpub({
+      opfContent: `<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Filtered Book</dc:title>
+    <dc:creator>Author</dc:creator>
+  </metadata>
+  <manifest>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+    <item id="cover" href="cover.xhtml" media-type="application/xhtml+xml"/>
+    <item id="ch1" href="ch1.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="cover"/>
+    <itemref idref="ch1"/>
+  </spine>
+</package>`,
+      files: {
+        'OEBPS/nav.xhtml': xhtml(`
+          <nav epub:type="toc" id="toc">
+            <ol>
+              <li><a href="ch1.xhtml">Chapter 1</a></li>
+            </ol>
+          </nav>
+        `),
+        'OEBPS/cover.xhtml': xhtml('<p>Cover</p>'),
+        'OEBPS/ch1.xhtml': xhtml('<p>This is the actual chapter with real content that passes the word filter.</p>'),
+      },
+    });
+
+    const book = await parseEpub(buffer);
+    expect(book.chapters).toHaveLength(1);
+    expect(book.chapters[0].title).toBe('Chapter 1');
+  });
+});

--- a/dashboard/src/app/read/book/epubParser.ts
+++ b/dashboard/src/app/read/book/epubParser.ts
@@ -13,6 +13,11 @@ export interface ParsedChapter {
   wordCount: number;
 }
 
+interface TocEntry {
+  title: string;
+  fragment: string | null;
+}
+
 // Public API
 export async function parseEpub(buffer: ArrayBuffer): Promise<ParsedBook> {
   const zip = await JSZip.loadAsync(buffer);
@@ -51,7 +56,7 @@ export async function parseEpub(buffer: ArrayBuffer): Promise<ParsedBook> {
     if (idref) spineIds.push(idref);
   }
 
-  const tocTitles = await parseToc(zip, opfDoc, opfDir, manifest);
+  const tocMap = await parseToc(zip, opfDoc, opfDir, manifest);
 
   const chapters: ParsedChapter[] = [];
   let untitledIndex = 0;
@@ -64,13 +69,24 @@ export async function parseEpub(buffer: ArrayBuffer): Promise<ParsedBook> {
     const xhtml = await readZipText(zip, filePath);
     if (!xhtml) continue;
 
-    const text = extractTextFromHtml(xhtml);
-    const wordCount = text ? text.trim().split(/\s+/).length : 0;
+    const tocEntries = tocMap.get(filePath);
+    const hasFragments = tocEntries?.some(e => e.fragment !== null);
 
-    if (wordCount < 5) continue;
+    if (hasFragments && tocEntries) {
+      // File has fragment-based chapters — split content at anchor points
+      const fragmentChapters = splitHtmlByFragments(xhtml, tocEntries);
+      for (const ch of fragmentChapters) {
+        if (ch.wordCount >= 5) chapters.push(ch);
+      }
+    } else {
+      // Single chapter per file (original behavior)
+      const text = extractTextFromHtml(xhtml);
+      const wordCount = text ? text.trim().split(/\s+/).length : 0;
+      if (wordCount < 5) continue;
 
-    const chapterTitle = tocTitles.get(filePath) ?? `Chapter ${++untitledIndex}`;
-    chapters.push({ title: chapterTitle, text, wordCount });
+      const chapterTitle = tocEntries?.[0]?.title ?? `Chapter ${++untitledIndex}`;
+      chapters.push({ title: chapterTitle, text, wordCount });
+    }
   }
 
   if (chapters.length === 0) {
@@ -118,13 +134,87 @@ async function readZipText(zip: JSZip, path: string): Promise<string | null> {
   return file.async('text');
 }
 
+function splitHref(href: string): [string, string | null] {
+  const hashIndex = href.indexOf('#');
+  if (hashIndex < 0) return [href, null];
+  return [href.substring(0, hashIndex), href.substring(hashIndex + 1)];
+}
+
+export function splitHtmlByFragments(
+  html: string,
+  entries: TocEntry[],
+): ParsedChapter[] {
+  const fragmentEntries = entries.filter(
+    (e): e is TocEntry & { fragment: string } => e.fragment !== null,
+  );
+  if (fragmentEntries.length === 0) return [];
+
+  let doc = new DOMParser().parseFromString(html, 'application/xhtml+xml');
+  if (doc.querySelector('parsererror')) {
+    doc = new DOMParser().parseFromString(html, 'text/html');
+  }
+  const body = doc.body ?? doc.documentElement;
+
+  // Locate fragment elements in the DOM; keep only those that exist
+  const fragmentEls = fragmentEntries
+    .map(e => ({ title: e.title, fragment: e.fragment, el: doc.getElementById(e.fragment) }))
+    .filter((f): f is { title: string; fragment: string; el: HTMLElement } => f.el !== null);
+
+  if (fragmentEls.length === 0) {
+    // Fragments listed in TOC but not found in the document — fall back to full text
+    const text = (body.textContent ?? '').trim();
+    return [{ title: entries[0].title, text, wordCount: text ? text.split(/\s+/).length : 0 }];
+  }
+
+  // Walk every text node in document order and assign it to the latest
+  // fragment element that precedes (or contains) it.
+  const walker = doc.createTreeWalker(body, NodeFilter.SHOW_TEXT);
+  const sections = new Map<string, string[]>();
+  for (const f of fragmentEls) sections.set(f.fragment, []);
+
+  let currentIdx = -1; // index into fragmentEls; -1 = before first fragment
+  let textNode: Node | null;
+
+  while ((textNode = walker.nextNode())) {
+    const content = textNode.textContent ?? '';
+    if (!content.trim()) continue;
+
+    // Advance the current fragment pointer whenever the text node is
+    // after (or inside) the next fragment element in document order.
+    while (currentIdx + 1 < fragmentEls.length) {
+      const next = fragmentEls[currentIdx + 1].el;
+      const pos = next.compareDocumentPosition(textNode);
+      if (pos & (Node.DOCUMENT_POSITION_FOLLOWING | Node.DOCUMENT_POSITION_CONTAINED_BY)) {
+        currentIdx++;
+      } else {
+        break;
+      }
+    }
+
+    if (currentIdx >= 0) {
+      sections.get(fragmentEls[currentIdx].fragment)!.push(content);
+    }
+    // Text before the first fragment anchor is discarded (front matter / preamble)
+  }
+
+  return fragmentEls.map(f => {
+    const text = (sections.get(f.fragment) ?? []).join(' ').replace(/\s+/g, ' ').trim();
+    return { title: f.title, text, wordCount: text ? text.split(/\s+/).length : 0 };
+  });
+}
+
 async function parseToc(
   zip: JSZip,
   opfDoc: Document,
   opfDir: string,
   manifest: Map<string, string>,
-): Promise<Map<string, string>> {
-  const titles = new Map<string, string>();
+): Promise<Map<string, TocEntry[]>> {
+  const entries = new Map<string, TocEntry[]>();
+
+  const addEntry = (resolvedPath: string, title: string, fragment: string | null) => {
+    if (!entries.has(resolvedPath)) entries.set(resolvedPath, []);
+    entries.get(resolvedPath)!.push({ title, fragment });
+  };
 
   const manifestItems = opfDoc.getElementsByTagNameNS('*', 'item');
   let navDir = opfDir;
@@ -150,13 +240,15 @@ async function parseToc(
         const links = nav.getElementsByTagName('a');
         for (let l = 0; l < links.length; l++) {
           const a = links[l];
-          const rawHref = a.getAttribute('href')?.split('#')[0];
+          const rawHref = a.getAttribute('href');
           const text = a.textContent?.trim();
-          if (rawHref && text) titles.set(resolveHref(rawHref, navDir), text);
+          if (!rawHref || !text) continue;
+          const [hrefPath, fragment] = splitHref(rawHref);
+          addEntry(resolveHref(hrefPath, navDir), text, fragment);
         }
       }
 
-      if (titles.size > 0) return titles;
+      if (entries.size > 0) return entries;
     }
   }
 
@@ -176,12 +268,14 @@ async function parseToc(
           const textEl = np.getElementsByTagNameNS('*', 'text')[0];
           const contentEl = np.getElementsByTagNameNS('*', 'content')[0];
           const text = textEl?.textContent?.trim();
-          const src = contentEl?.getAttribute('src')?.split('#')[0];
-          if (text && src) titles.set(resolveHref(src, ncxDir), text);
+          const src = contentEl?.getAttribute('src');
+          if (!text || !src) continue;
+          const [srcPath, fragment] = splitHref(src);
+          addEntry(resolveHref(srcPath, ncxDir), text, fragment);
         }
       }
     }
   }
 
-  return titles;
+  return entries;
 }


### PR DESCRIPTION
## Summary

- EPUBs produced by InDesign store all content in a single XHTML file with chapters separated by fragment anchors (`content.xhtml#ch1`, `#ch2`). The parser was stripping fragments, collapsing all TOC entries for the same file into one chapter.
- `parseToc` now preserves fragment info. New `splitHtmlByFragments` uses DOM TreeWalker + `compareDocumentPosition` to split text at anchor boundaries.
- Verified against "Landet som ble for rikt" (Kagge Forlag, InDesign EPUB): 22 chapters now correctly parsed instead of 1.

## Test plan

- [x] Existing unit tests pass (9 tests)
- [x] New integration tests pass (6 tests covering: multi-file, single-file fragments, NCX fragments, mixed, filtering)
- [x] Dashboard builds without type errors
- [x] Manually verified with real InDesign EPUB

🤖 Generated with [Claude Code](https://claude.com/claude-code)