### PR TITLE
feat(study): S2 concept lifecycle — discovery, approval, dashboard

### DIFF
--- a/dashboard/src/app/api/study/concepts/approve/route.ts
+++ b/dashboard/src/app/api/study/concepts/approve/route.ts
@@ -4,12 +4,12 @@ export async function POST(request: Request) {
   try {
     const body = await request.json() as { conceptIds?: string[]; domain?: string };
 
-    if (body.domain !== undefined) {
+    if (typeof body.domain === 'string' && body.domain.length > 0) {
       const ids = approveDomain(body.domain);
       return Response.json({ approved: ids.length, ids });
     }
 
-    if (body.conceptIds !== undefined) {
+    if (Array.isArray(body.conceptIds) && body.conceptIds.length > 0) {
       const approved = approveConcepts(body.conceptIds);
       return Response.json({ approved });
     }

--- a/dashboard/src/app/api/study/concepts/approve/route.ts
+++ b/dashboard/src/app/api/study/concepts/approve/route.ts
@@ -1,0 +1,21 @@
+import { approveConcepts, approveDomain } from '@/lib/study-db';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json() as { conceptIds?: string[]; domain?: string };
+
+    if (body.domain !== undefined) {
+      const ids = approveDomain(body.domain);
+      return Response.json({ approved: ids.length, ids });
+    }
+
+    if (body.conceptIds !== undefined) {
+      const approved = approveConcepts(body.conceptIds);
+      return Response.json({ approved });
+    }
+
+    return Response.json({ error: 'Provide domain or conceptIds' }, { status: 400 });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/study/concepts/pending/route.ts
+++ b/dashboard/src/app/api/study/concepts/pending/route.ts
@@ -1,0 +1,10 @@
+import { getPendingConcepts } from '@/lib/study-db';
+
+export async function GET() {
+  try {
+    const groups = getPendingConcepts();
+    return Response.json({ groups });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/study/concepts/route.ts
+++ b/dashboard/src/app/api/study/concepts/route.ts
@@ -1,0 +1,11 @@
+import { getActiveConcepts, getConceptStats } from '@/lib/study-db';
+
+export async function GET() {
+  try {
+    const concepts = getActiveConcepts();
+    const stats = getConceptStats();
+    return Response.json({ concepts, stats });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -16,6 +16,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <a href="/vault" className="hover:text-gray-100">Vault</a>
               <a href="/read" className="hover:text-gray-100">Read</a>
               <a href="/read/book" className="hover:text-gray-100">Book</a>
+              <a href="/study" className="hover:text-gray-100">Study</a>
             </div>
           </div>
         </nav>

--- a/dashboard/src/app/study/page.tsx
+++ b/dashboard/src/app/study/page.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import type { ConceptSummary, PendingGroup, ConceptStats } from '@/lib/study-db';
+
+const BLOOM_LABELS: Record<number, string> = {
+  1: 'L1',
+  2: 'L2',
+  3: 'L3',
+  4: 'L4',
+  5: 'L5',
+  6: 'L6',
+};
+
+export default function StudyPage() {
+  const [concepts, setConcepts] = useState<ConceptSummary[]>([]);
+  const [pendingGroups, setPendingGroups] = useState<PendingGroup[]>([]);
+  const [stats, setStats] = useState<ConceptStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [conceptsRes, pendingRes] = await Promise.all([
+        fetch('/api/study/concepts'),
+        fetch('/api/study/concepts/pending'),
+      ]);
+      const conceptsData = await conceptsRes.json() as { concepts: ConceptSummary[]; stats: ConceptStats };
+      const pendingData = await pendingRes.json() as { groups: PendingGroup[] };
+      setConcepts(conceptsData.concepts ?? []);
+      setStats(conceptsData.stats ?? null);
+      setPendingGroups(pendingData.groups ?? []);
+    } catch {
+      // silently fail; data stays stale
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const approveDomain = useCallback(async (domain: string) => {
+    await fetch('/api/study/concepts/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ domain }),
+    });
+    await fetchData();
+  }, [fetchData]);
+
+  const approveConcept = useCallback(async (id: string) => {
+    await fetch('/api/study/concepts/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ conceptIds: [id] }),
+    });
+    await fetchData();
+  }, [fetchData]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-gray-500">Loading...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl space-y-8">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">Study</h2>
+        {stats && (
+          <p className="text-sm text-gray-500">
+            {stats.active} active · {stats.pending} pending · {stats.domains} domains
+          </p>
+        )}
+      </div>
+
+      {/* Section 1 — Pending Approval */}
+      {pendingGroups.length > 0 && (
+        <section className="space-y-4">
+          <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">Pending Approval</h3>
+          <div className="space-y-3">
+            {pendingGroups.map((group) => {
+              const domainLabel = group.domain ?? 'Uncategorised';
+              return (
+                <div key={group.domain ?? '\x00null'} className="rounded-lg border border-gray-800 bg-gray-900 p-4">
+                  <div className="flex items-center justify-between mb-3">
+                    <div>
+                      <span className="font-medium text-gray-100">{domainLabel}</span>
+                      <span className="ml-2 text-xs text-gray-500">{group.concepts.length} concept{group.concepts.length !== 1 ? 's' : ''}</span>
+                    </div>
+                    {group.domain !== null && (
+                      <button
+                        onClick={() => approveDomain(group.domain!)}
+                        className="text-xs px-3 py-1.5 rounded-md bg-blue-700 hover:bg-blue-600 text-white transition-colors"
+                      >
+                        Approve all
+                      </button>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {group.concepts.map((concept) => (
+                      <button
+                        key={concept.id}
+                        onClick={() => approveConcept(concept.id)}
+                        title={concept.subdomain ?? undefined}
+                        className="text-xs px-2.5 py-1 rounded-md bg-gray-800 hover:bg-gray-700 text-gray-300 hover:text-gray-100 border border-gray-700 transition-colors"
+                      >
+                        {concept.title}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* Section 2 — Active Concepts */}
+      <section className="space-y-4">
+        <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">Active Concepts</h3>
+        {concepts.length === 0 ? (
+          <div className="rounded-lg border border-gray-800 bg-gray-900 p-8 text-center">
+            <p className="text-sm text-gray-500">No active concepts yet. Approve pending concepts above to get started.</p>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-gray-800 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-900 border-b border-gray-800">
+                <tr>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider">Concept</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider">Domain</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-16">Bloom</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-48">Mastery</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-16">Due</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-800 bg-gray-950">
+                {concepts.map((concept) => (
+                  <tr key={concept.id} className="hover:bg-gray-900 transition-colors">
+                    <td className="px-4 py-3 text-gray-100">
+                      <span className="font-medium">{concept.title}</span>
+                      {concept.subdomain && (
+                        <span className="ml-1.5 text-xs text-gray-500">{concept.subdomain}</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-gray-400">{concept.domain ?? '—'}</td>
+                    <td className="px-4 py-3 text-gray-400">
+                      {concept.bloomCeiling === 0 ? '—' : (BLOOM_LABELS[concept.bloomCeiling] ?? `L${concept.bloomCeiling}`)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <div className="flex-1 h-1.5 rounded-full bg-gray-800 overflow-hidden">
+                          <div
+                            className="h-full rounded-full bg-blue-500"
+                            style={{ width: `${Math.min(100, Math.round(concept.masteryOverall * 100))}%` }}
+                          />
+                        </div>
+                        <span className="text-xs text-gray-500 w-8 text-right">
+                          {Math.round(concept.masteryOverall * 100)}%
+                        </span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      {concept.dueCount > 0 ? (
+                        <span className="text-xs font-medium text-amber-400">{concept.dueCount}</span>
+                      ) : (
+                        <span className="text-xs text-gray-600">0</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/dashboard/src/lib/db/schema.ts
+++ b/dashboard/src/lib/db/schema.ts
@@ -1,4 +1,4 @@
-import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { sql } from 'drizzle-orm';
 
 export const ingestion_jobs = sqliteTable('ingestion_jobs', {
@@ -24,4 +24,35 @@ export const settings = sqliteTable('settings', {
   key: text('key').primaryKey(),
   value: text('value').notNull(),
   updated_at: text('updated_at').default(sql`(datetime('now'))`),
+});
+
+// Study system tables (must match src/db/schema/study.ts SQL columns exactly)
+
+export const concepts = sqliteTable('concepts', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  domain: text('domain'),
+  subdomain: text('subdomain'),
+  course: text('course'),
+  vault_note_path: text('vault_note_path'),
+  status: text('status').default('active'),
+  mastery_L1: real('mastery_L1').default(0.0),
+  mastery_L2: real('mastery_L2').default(0.0),
+  mastery_L3: real('mastery_L3').default(0.0),
+  mastery_L4: real('mastery_L4').default(0.0),
+  mastery_L5: real('mastery_L5').default(0.0),
+  mastery_L6: real('mastery_L6').default(0.0),
+  mastery_overall: real('mastery_overall').default(0.0),
+  bloom_ceiling: integer('bloom_ceiling').default(0),
+  created_at: text('created_at').notNull(),
+  last_activity_at: text('last_activity_at'),
+});
+
+export const learning_activities = sqliteTable('learning_activities', {
+  id: text('id').primaryKey(),
+  concept_id: text('concept_id').notNull(),
+  activity_type: text('activity_type').notNull(),
+  bloom_level: integer('bloom_level').notNull(),
+  due_at: text('due_at').notNull(),
+  mastery_state: text('mastery_state').default('new'),
 });

--- a/dashboard/src/lib/study-db.ts
+++ b/dashboard/src/lib/study-db.ts
@@ -7,7 +7,7 @@
  * mapped to camelCase response interfaces.
  */
 
-import { eq, and, lte, asc, desc, count, sql } from 'drizzle-orm';
+import { eq, and, lte, asc, desc, count, sql, inArray } from 'drizzle-orm';
 import { getDb } from './db/index';
 import { concepts, learning_activities } from './db/schema';
 
@@ -154,16 +154,12 @@ export function approveConcepts(ids: string[]): number {
   if (ids.length === 0) return 0;
   const db = getDb();
 
-  let changed = 0;
-  for (const id of ids) {
-    const result = db
-      .update(concepts)
-      .set({ status: 'active' })
-      .where(and(eq(concepts.id, id), eq(concepts.status, 'pending')))
-      .run();
-    changed += result.changes;
-  }
-  return changed;
+  const result = db
+    .update(concepts)
+    .set({ status: 'active' })
+    .where(and(inArray(concepts.id, ids), eq(concepts.status, 'pending')))
+    .run();
+  return result.changes;
 }
 
 /**

--- a/dashboard/src/lib/study-db.ts
+++ b/dashboard/src/lib/study-db.ts
@@ -1,0 +1,222 @@
+/**
+ * Dashboard-side DB access for the study system.
+ *
+ * Reads/writes the concepts and learning_activities tables in the shared
+ * SQLite database (store/messages.db). Follows the same pattern as
+ * ingestion-db.ts: Drizzle ORM over better-sqlite3, snake_case columns
+ * mapped to camelCase response interfaces.
+ */
+
+import { eq, and, lte, asc, desc, count, sql } from 'drizzle-orm';
+import { getDb } from './db/index';
+import { concepts, learning_activities } from './db/schema';
+
+// ---------------------------------------------------------------------------
+// Response interfaces (camelCase)
+// ---------------------------------------------------------------------------
+
+export interface ConceptSummary {
+  id: string;
+  title: string;
+  domain: string | null;
+  subdomain: string | null;
+  course: string | null;
+  vaultNotePath: string | null;
+  status: string;
+  masteryOverall: number;
+  bloomCeiling: number;
+  dueCount: number;
+  createdAt: string;
+  lastActivityAt: string | null;
+}
+
+export interface PendingGroup {
+  domain: string | null;
+  concepts: Array<{
+    id: string;
+    title: string;
+    subdomain: string | null;
+    createdAt: string;
+  }>;
+}
+
+export interface ConceptStats {
+  total: number;
+  pending: number;
+  active: number;
+  domains: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+type ConceptRow = typeof concepts.$inferSelect;
+
+function rowToSummary(row: ConceptRow, dueCount: number): ConceptSummary {
+  return {
+    id: row.id,
+    title: row.title,
+    domain: row.domain ?? null,
+    subdomain: row.subdomain ?? null,
+    course: row.course ?? null,
+    vaultNotePath: row.vault_note_path ?? null,
+    status: row.status ?? 'active',
+    masteryOverall: row.mastery_overall ?? 0,
+    bloomCeiling: row.bloom_ceiling ?? 0,
+    dueCount,
+    createdAt: row.created_at,
+    lastActivityAt: row.last_activity_at ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Query functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Get all active concepts with their due activity counts.
+ */
+export function getActiveConcepts(): ConceptSummary[] {
+  const db = getDb();
+
+  const rows = db
+    .select()
+    .from(concepts)
+    .where(eq(concepts.status, 'active'))
+    .orderBy(desc(concepts.last_activity_at))
+    .all();
+
+  if (rows.length === 0) return [];
+
+  const today = new Date().toISOString();
+
+  const dueCounts = db
+    .select({
+      concept_id: learning_activities.concept_id,
+      due_count: count(learning_activities.id),
+    })
+    .from(learning_activities)
+    .where(lte(learning_activities.due_at, today))
+    .groupBy(learning_activities.concept_id)
+    .all();
+
+  const dueMap = new Map<string, number>();
+  for (const row of dueCounts) {
+    dueMap.set(row.concept_id, row.due_count);
+  }
+
+  return rows.map((row) => rowToSummary(row, dueMap.get(row.id) ?? 0));
+}
+
+/**
+ * Get pending concepts grouped by domain.
+ */
+export function getPendingConcepts(): PendingGroup[] {
+  const db = getDb();
+
+  const rows = db
+    .select({
+      id: concepts.id,
+      title: concepts.title,
+      domain: concepts.domain,
+      subdomain: concepts.subdomain,
+      created_at: concepts.created_at,
+    })
+    .from(concepts)
+    .where(eq(concepts.status, 'pending'))
+    .orderBy(asc(concepts.domain), asc(concepts.title))
+    .all();
+
+  // Group by domain in JS using a string sentinel for null domains
+  const groupMap = new Map<string, PendingGroup>();
+  for (const row of rows) {
+    const domain = row.domain ?? null;
+    const mapKey = domain ?? '\x00null';
+    if (!groupMap.has(mapKey)) {
+      groupMap.set(mapKey, { domain, concepts: [] });
+    }
+    groupMap.get(mapKey)!.concepts.push({
+      id: row.id,
+      title: row.title,
+      subdomain: row.subdomain ?? null,
+      createdAt: row.created_at,
+    });
+  }
+
+  return Array.from(groupMap.values());
+}
+
+/**
+ * Approve a list of concept IDs (pending → active). Returns count changed.
+ */
+export function approveConcepts(ids: string[]): number {
+  if (ids.length === 0) return 0;
+  const db = getDb();
+
+  let changed = 0;
+  for (const id of ids) {
+    const result = db
+      .update(concepts)
+      .set({ status: 'active' })
+      .where(and(eq(concepts.id, id), eq(concepts.status, 'pending')))
+      .run();
+    changed += result.changes;
+  }
+  return changed;
+}
+
+/**
+ * Approve all pending concepts in a domain. Returns the approved IDs.
+ */
+export function approveDomain(domain: string): string[] {
+  const db = getDb();
+
+  const pending = db
+    .select({ id: concepts.id })
+    .from(concepts)
+    .where(and(eq(concepts.domain, domain), eq(concepts.status, 'pending')))
+    .all();
+
+  if (pending.length === 0) return [];
+
+  const ids = pending.map((r) => r.id);
+  approveConcepts(ids);
+  return ids;
+}
+
+/**
+ * Return aggregate counts: total concepts, pending, active, distinct domains.
+ */
+export function getConceptStats(): ConceptStats {
+  const db = getDb();
+
+  const statusCounts = db
+    .select({
+      status: concepts.status,
+      cnt: count(concepts.id),
+    })
+    .from(concepts)
+    .groupBy(concepts.status)
+    .all();
+
+  let total = 0;
+  let pending = 0;
+  let active = 0;
+  for (const row of statusCounts) {
+    const n = row.cnt;
+    total += n;
+    if (row.status === 'pending') pending = n;
+    if (row.status === 'active') active = n;
+  }
+
+  const domainRow = db
+    .select({ domains: sql<number>`count(distinct ${concepts.domain})` })
+    .from(concepts)
+    .where(eq(concepts.status, 'active'))
+    .get();
+
+  const domains = domainRow?.domains ?? 0;
+
+  return { total, pending, active, domains };
+}

--- a/groups/review_agent/CLAUDE.md
+++ b/groups/review_agent/CLAUDE.md
@@ -25,6 +25,8 @@ For each document, generate:
 ---
 title: Self-Attention Mechanism
 type: concept
+domain: "Artificial Intelligence"
+subdomain: "Deep Learning Architectures"
 topics: [deep-learning, attention, transformers]
 source_doc: "Vaswani et al. 2017 - Attention Is All You Need"
 source_file: "upload/processed/{jobId}-{filename}"
@@ -43,6 +45,12 @@ Related concepts mentioned with [[wikilinks]].
 
 [^1]: Author, §Section, p.Page
 ```
+
+**Domain and subdomain classification:**
+- `domain` is the broad knowledge area (e.g., "Knowledge Management", "Cognitive Psychology", "Digital Transformation", "Research Methods", "Information Systems", "Artificial Intelligence")
+- `subdomain` is the specific topic area within the domain (e.g., "KM Models", "Learning & Memory", "Business Process Management")
+- Use consistent domain names across concepts from the same knowledge area
+- When uncertain, use the broadest applicable domain and a descriptive subdomain
 
 ### Source Overview Note
 

--- a/scripts/migrate-vault-concepts.ts
+++ b/scripts/migrate-vault-concepts.ts
@@ -1,0 +1,254 @@
+#!/usr/bin/env tsx
+/**
+ * S2.8 — One-time vault concept migration script
+ *
+ * Scans existing vault concept notes and backfills them into the concepts table.
+ * Idempotent: running twice inserts 0 the second time.
+ *
+ * Usage: npx tsx scripts/migrate-vault-concepts.ts
+ */
+
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+import { parseFrontmatter } from '../src/vault/frontmatter.js';
+import { initDatabase } from '../src/db/index.js';
+
+// Initialize the database (runs migrations)
+initDatabase();
+
+// Dynamic import AFTER db is initialized
+const { createConcept, getConceptByVaultPath } = await import(
+  '../src/study/queries.js'
+);
+
+// ====================================================================
+// Domain inference heuristic
+// ====================================================================
+
+interface InferenceRule {
+  keywords: string[];
+  domain: string;
+  subdomain: string;
+}
+
+const INFERENCE_RULES: InferenceRule[] = [
+  {
+    keywords: [
+      'knowledge-management',
+      'km-',
+      'tacit-knowledge',
+      'explicit-knowledge',
+      'seci',
+      'nonaka',
+      'knowledge-creation',
+      'knowledge-sharing',
+    ],
+    domain: 'Knowledge Management',
+    subdomain: 'KM Theory',
+  },
+  {
+    keywords: [
+      'organizational-learning',
+      'learning-organization',
+      'absorptive-capacity',
+    ],
+    domain: 'Knowledge Management',
+    subdomain: 'Organizational Learning',
+  },
+  {
+    keywords: [
+      'cognitive-load',
+      'working-memory',
+      'instructional-design',
+      'sweller',
+    ],
+    domain: 'Cognitive Psychology',
+    subdomain: 'Cognitive Load Theory',
+  },
+  {
+    keywords: [
+      'spaced-repetition',
+      'retrieval-practice',
+      'metacognition',
+      'self-regulated-learning',
+    ],
+    domain: 'Cognitive Psychology',
+    subdomain: 'Learning & Memory',
+  },
+  {
+    keywords: [
+      'digital-transformation',
+      'digitalization',
+      'digital-strategy',
+    ],
+    domain: 'Digital Transformation',
+    subdomain: 'DT Strategy',
+  },
+  {
+    keywords: [
+      'business-process',
+      'bpm',
+      'workflow',
+      'process-improvement',
+    ],
+    domain: 'Digital Transformation',
+    subdomain: 'Business Process Management',
+  },
+  {
+    keywords: [
+      'research-methodology',
+      'scientific-methods',
+      'qualitative-research',
+      'quantitative-research',
+      'action-research',
+      'case-study-research',
+    ],
+    domain: 'Research Methods',
+    subdomain: 'Research Design',
+  },
+  {
+    keywords: [
+      'philosophy-of-science',
+      'epistemology',
+      'ontology',
+      'paradigm',
+    ],
+    domain: 'Research Methods',
+    subdomain: 'Philosophy of Science',
+  },
+  {
+    keywords: [
+      'information-systems',
+      'sociotechnical',
+      'technology-acceptance',
+    ],
+    domain: 'Information Systems',
+    subdomain: 'IS Theory',
+  },
+  {
+    keywords: [
+      'artificial-intelligence',
+      'ai-',
+      'machine-learning',
+      'deep-learning',
+      'neural-network',
+      'llm',
+      'transformer',
+    ],
+    domain: 'Artificial Intelligence',
+    subdomain: 'AI Foundations',
+  },
+];
+
+/**
+ * Infer domain and subdomain from a topics array using keyword matching.
+ * Returns null if no rule matches.
+ */
+function inferDomain(
+  topics: string[],
+): { domain: string; subdomain: string } | null {
+  const haystack = topics.join(' ').toLowerCase();
+  for (const rule of INFERENCE_RULES) {
+    if (rule.keywords.some((kw) => haystack.includes(kw))) {
+      return { domain: rule.domain, subdomain: rule.subdomain };
+    }
+  }
+  return null;
+}
+
+// ====================================================================
+// Main migration
+// ====================================================================
+
+const VAULT_DIR = process.env.VAULT_DIR ?? './vault';
+const conceptsDir = join(VAULT_DIR, 'concepts');
+
+let files: string[];
+try {
+  files = readdirSync(conceptsDir).filter((f) => f.endsWith('.md'));
+} catch (err) {
+  console.error(`Failed to read concepts directory: ${conceptsDir}`);
+  console.error(err);
+  process.exit(1);
+}
+
+console.log(`Found ${files.length} concept files in ${conceptsDir}`);
+
+let inserted = 0;
+let skippedExists = 0;
+let skippedNoTitle = 0;
+let unclassified = 0;
+
+for (const filename of files) {
+  const relPath = `concepts/${filename}`;
+
+  // Idempotency: skip if already in DB
+  const existing = getConceptByVaultPath(relPath);
+  if (existing) {
+    skippedExists++;
+    continue;
+  }
+
+  const fullPath = join(conceptsDir, filename);
+  const raw = readFileSync(fullPath, 'utf-8');
+  const { data } = parseFrontmatter(raw);
+
+  // Skip notes without a title
+  const title = typeof data.title === 'string' ? data.title.trim() : null;
+  if (!title) {
+    skippedNoTitle++;
+    console.warn(`  [skip] No title: ${relPath}`);
+    continue;
+  }
+
+  // Resolve domain
+  let domain: string | null = null;
+  let subdomain: string | null = null;
+
+  if (typeof data.domain === 'string' && data.domain.trim()) {
+    domain = data.domain.trim();
+    subdomain =
+      typeof data.subdomain === 'string' ? data.subdomain.trim() : null;
+  } else {
+    // Infer from topics
+    const topics = Array.isArray(data.topics)
+      ? (data.topics as unknown[])
+          .filter((t): t is string => typeof t === 'string')
+      : [];
+    const inferred = inferDomain(topics);
+    if (inferred) {
+      domain = inferred.domain;
+      subdomain = inferred.subdomain;
+    }
+    // If no inference match, domain stays null — concept is still inserted
+  }
+
+  const course =
+    typeof data.course === 'string' && data.course.trim()
+      ? data.course.trim()
+      : null;
+
+  createConcept({
+    id: randomUUID(),
+    title,
+    domain,
+    subdomain,
+    course,
+    vaultNotePath: relPath,
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+  });
+
+  if (!domain) unclassified++;
+  console.log(`  [insert] ${title} → ${domain ?? '(unclassified)'} / ${subdomain ?? ''}`);
+  inserted++;
+}
+
+console.log('');
+console.log('=== Migration complete ===');
+console.log(`  Inserted:            ${inserted}`);
+console.log(`  Skipped (exists):    ${skippedExists}`);
+console.log(`  Skipped (no title):  ${skippedNoTitle}`);
+console.log(`  Unclassified:        ${unclassified}`);
+console.log(`  Total files:         ${files.length}`);

--- a/src/ingestion/draft-validator.ts
+++ b/src/ingestion/draft-validator.ts
@@ -250,6 +250,21 @@ export function validateDrafts(
         file: conceptFile,
       });
     }
+
+    if (!fm.domain) {
+      warnings.push({
+        check: 'concept-domain',
+        message: `Concept note "${conceptFile}" is missing "domain" frontmatter field. Add a broad knowledge area (e.g., "Knowledge Management", "Cognitive Psychology").`,
+        file: conceptFile,
+      });
+    }
+    if (!fm.subdomain) {
+      warnings.push({
+        check: 'concept-subdomain',
+        message: `Concept note "${conceptFile}" is missing "subdomain" frontmatter field. Add a specific topic area within the domain.`,
+        file: conceptFile,
+      });
+    }
   }
 
   // --- Quality warnings (don't block promotion) ---

--- a/src/ingestion/index.ts
+++ b/src/ingestion/index.ts
@@ -593,7 +593,8 @@ export class IngestionPipeline {
       const discovered = discoverConcepts(promotedPaths, this.vaultDir);
       let inserted = 0;
       for (const concept of discovered) {
-        const existing = getConceptByVaultPath(concept.vaultNotePath!);
+        if (!concept.vaultNotePath) continue;
+        const existing = getConceptByVaultPath(concept.vaultNotePath);
         if (!existing) {
           createConcept(concept);
           inserted++;

--- a/src/ingestion/index.ts
+++ b/src/ingestion/index.ts
@@ -48,6 +48,8 @@ import { ZoteroWatcher } from './zotero-watcher.js';
 import { ZoteroWriteBack } from './zotero-writeback.js';
 import { ZoteroLocalClient, ZoteroWebClient } from './zotero-client.js';
 import { ZoteroMetadata } from './types.js';
+import { discoverConcepts } from '../study/concept-discovery.js';
+import { createConcept, getConceptByVaultPath } from '../study/queries.js';
 
 const RATE_LIMIT_PATTERNS = [
   /rate.?limit/i,
@@ -584,6 +586,30 @@ export class IngestionPipeline {
           'Citation linking failed — continuing without it',
         );
       }
+    }
+
+    // --- Concept discovery (non-blocking) ---
+    try {
+      const discovered = discoverConcepts(promotedPaths, this.vaultDir);
+      let inserted = 0;
+      for (const concept of discovered) {
+        const existing = getConceptByVaultPath(concept.vaultNotePath!);
+        if (!existing) {
+          createConcept(concept);
+          inserted++;
+        }
+      }
+      if (inserted > 0) {
+        logger.info(
+          { jobId: job.id, discovered: discovered.length, inserted },
+          `study: Discovered ${inserted} new concept(s)`,
+        );
+      }
+    } catch (err) {
+      logger.warn(
+        { jobId: job.id, err },
+        'Concept discovery failed — continuing without it',
+      );
     }
 
     // Move source file to processed/ (skip for Zotero — file is managed by Zotero)

--- a/src/study/concept-discovery.test.ts
+++ b/src/study/concept-discovery.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { discoverConcepts } from './concept-discovery.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeFrontmatter(fields: Record<string, unknown>): string {
+  const lines = ['---'];
+  for (const [k, v] of Object.entries(fields)) {
+    if (Array.isArray(v)) {
+      lines.push(`${k}: [${v.map((x) => JSON.stringify(x)).join(', ')}]`);
+    } else {
+      lines.push(`${k}: ${JSON.stringify(v)}`);
+    }
+  }
+  lines.push('---');
+  lines.push('');
+  lines.push('Content here...');
+  return lines.join('\n');
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('discoverConcepts', () => {
+  let vaultDir: string;
+
+  beforeEach(() => {
+    vaultDir = join(tmpdir(), `concept-discovery-test-${Date.now()}`);
+    mkdirSync(join(vaultDir, 'concepts'), { recursive: true });
+    mkdirSync(join(vaultDir, 'sources'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(vaultDir, { recursive: true, force: true });
+  });
+
+  it('returns one concept with all fields when frontmatter has domain and subdomain', () => {
+    writeFileSync(
+      join(vaultDir, 'concepts', 'action-research.md'),
+      makeFrontmatter({
+        title: 'Action Research',
+        type: 'concept',
+        domain: 'research-methodology',
+        subdomain: 'qualitative',
+        topics: ['research', 'methods'],
+        generated_by: 'claude',
+      }),
+    );
+
+    const results = discoverConcepts(['concepts/action-research.md'], vaultDir);
+
+    expect(results).toHaveLength(1);
+    const concept = results[0];
+    expect(concept.title).toBe('Action Research');
+    expect(concept.domain).toBe('research-methodology');
+    expect(concept.subdomain).toBe('qualitative');
+    expect(concept.vaultNotePath).toBe('concepts/action-research.md');
+    expect(concept.status).toBe('pending');
+    expect(typeof concept.id).toBe('string');
+    expect(concept.id.length).toBeGreaterThan(0);
+    expect(typeof concept.createdAt).toBe('string');
+    expect(concept.createdAt.length).toBeGreaterThan(0);
+  });
+
+  it('returns null domain and subdomain when frontmatter does not have them', () => {
+    writeFileSync(
+      join(vaultDir, 'concepts', 'action-research.md'),
+      makeFrontmatter({
+        title: 'Action Research',
+        type: 'concept',
+        topics: ['research-methodology', 'scientific-methods'],
+        source_doc: 'Scientific Methods Lecture 2',
+        generated_by: 'claude',
+        verification_status: 'unverified',
+        created: '2026-04-03',
+      }),
+    );
+
+    const results = discoverConcepts(['concepts/action-research.md'], vaultDir);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].domain).toBeNull();
+    expect(results[0].subdomain).toBeNull();
+  });
+
+  it('skips source notes (type=source)', () => {
+    writeFileSync(
+      join(vaultDir, 'sources', 'vaswani.md'),
+      makeFrontmatter({
+        title: 'Attention is All You Need',
+        type: 'source',
+      }),
+    );
+
+    const results = discoverConcepts(['sources/vaswani.md'], vaultDir);
+
+    expect(results).toHaveLength(0);
+  });
+
+  it('skips paths not starting with concepts/', () => {
+    writeFileSync(
+      join(vaultDir, 'sources', 'some-note.md'),
+      makeFrontmatter({
+        title: 'Some Note',
+        type: 'concept',
+        domain: 'science',
+      }),
+    );
+
+    const results = discoverConcepts(['sources/some-note.md'], vaultDir);
+
+    expect(results).toHaveLength(0);
+  });
+
+  it('returns empty array when the file does not exist', () => {
+    const results = discoverConcepts(['concepts/ghost.md'], vaultDir);
+
+    expect(results).toHaveLength(0);
+  });
+
+  it('handles multiple paths with mixed types and returns only concepts', () => {
+    writeFileSync(
+      join(vaultDir, 'concepts', 'alpha.md'),
+      makeFrontmatter({ title: 'Alpha Concept', type: 'concept', domain: 'math' }),
+    );
+    writeFileSync(
+      join(vaultDir, 'concepts', 'beta.md'),
+      makeFrontmatter({ title: 'Beta Concept', type: 'concept' }),
+    );
+    writeFileSync(
+      join(vaultDir, 'sources', 'gamma.md'),
+      makeFrontmatter({ title: 'Gamma Source', type: 'source' }),
+    );
+
+    const results = discoverConcepts(
+      ['concepts/alpha.md', 'concepts/beta.md', 'sources/gamma.md'],
+      vaultDir,
+    );
+
+    expect(results).toHaveLength(2);
+    const titles = results.map((r) => r.title).sort();
+    expect(titles).toEqual(['Alpha Concept', 'Beta Concept']);
+  });
+
+  it('skips concept notes without a title field', () => {
+    writeFileSync(
+      join(vaultDir, 'concepts', 'no-title.md'),
+      makeFrontmatter({ type: 'concept', domain: 'math' }),
+    );
+
+    // makeFrontmatter always writes title as a key — override with a note that has no title
+    writeFileSync(
+      join(vaultDir, 'concepts', 'no-title.md'),
+      '---\ntype: concept\ndomain: math\n---\n\nContent.',
+    );
+
+    const results = discoverConcepts(['concepts/no-title.md'], vaultDir);
+
+    expect(results).toHaveLength(0);
+  });
+
+  it('populates course field when present in frontmatter', () => {
+    writeFileSync(
+      join(vaultDir, 'concepts', 'business-process.md'),
+      makeFrontmatter({
+        title: 'Business Process',
+        type: 'concept',
+        course: 'BI-2081',
+        domain: 'business',
+      }),
+    );
+
+    const results = discoverConcepts(
+      ['concepts/business-process.md'],
+      vaultDir,
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0].course).toBe('BI-2081');
+  });
+});

--- a/src/study/concept-discovery.ts
+++ b/src/study/concept-discovery.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+
+import { parseFrontmatter } from '../vault/frontmatter.js';
+import type { NewConcept } from './queries.js';
+
+/**
+ * Reads promoted vault note paths, parses YAML frontmatter, and returns
+ * NewConcept objects for every valid concept note. Pure file I/O — no DB calls.
+ *
+ * Skipped paths:
+ *  - not starting with `concepts/`
+ *  - file does not exist
+ *  - frontmatter `type` !== 'concept'
+ *  - frontmatter has no `title`
+ */
+export function discoverConcepts(
+  promotedPaths: string[],
+  vaultDir: string,
+): NewConcept[] {
+  const results: NewConcept[] = [];
+
+  for (const notePath of promotedPaths) {
+    // 1. Only process notes inside the concepts/ directory
+    if (!notePath.startsWith('concepts/')) continue;
+
+    // 2. Read the file — skip silently if it does not exist
+    let raw: string;
+    try {
+      raw = readFileSync(join(vaultDir, notePath), 'utf-8');
+    } catch {
+      continue;
+    }
+
+    // 3. Parse frontmatter
+    const { data } = parseFrontmatter(raw);
+
+    // 4. Must be type=concept with a title
+    if (data['type'] !== 'concept') continue;
+    const title = data['title'];
+    if (typeof title !== 'string' || title.trim() === '') continue;
+
+    // 5. Map optional fields — fall back to null
+    const domain =
+      typeof data['domain'] === 'string' ? data['domain'] : null;
+    const subdomain =
+      typeof data['subdomain'] === 'string' ? data['subdomain'] : null;
+    const course =
+      typeof data['course'] === 'string' ? data['course'] : null;
+
+    results.push({
+      id: randomUUID(),
+      title: title.trim(),
+      domain,
+      subdomain,
+      course,
+      vaultNotePath: notePath,
+      status: 'pending',
+      createdAt: new Date().toISOString(),
+    });
+  }
+
+  return results;
+}

--- a/src/study/index.ts
+++ b/src/study/index.ts
@@ -2,3 +2,4 @@ export * from './types.js';
 export * from './sm2.js';
 export * from './mastery.js';
 export * from './queries.js';
+export * from './concept-discovery.js';

--- a/src/study/queries.ts
+++ b/src/study/queries.ts
@@ -49,6 +49,14 @@ export function getConceptById(id: string): Concept | undefined {
     .get();
 }
 
+export function getConceptByVaultPath(vaultNotePath: string): Concept | undefined {
+  return getDb()
+    .select()
+    .from(schema.concepts)
+    .where(eq(schema.concepts.vaultNotePath, vaultNotePath))
+    .get();
+}
+
 export function getConceptsByDomain(domain: string): Concept[] {
   return getDb()
     .select()


### PR DESCRIPTION
## Summary

- **Concept discovery** hooks into the ingestion pipeline — when vault notes are promoted to `concepts/`, frontmatter is parsed and pending concept rows are created automatically
- **Dashboard `/study` page** with pending concept approval (domain-batch + individual), active concepts table with mastery bars and Bloom's level indicators
- **Migration script** backfills 899 existing vault concepts with topic-to-domain heuristic classification
- **Ingestion updates** — agent prompt now generates `domain`/`subdomain` frontmatter, draft validator warns on missing fields

## Changes

| Area | What |
|------|------|
| `src/study/concept-discovery.ts` | Pure frontmatter reader — `discoverConcepts()` returns `NewConcept[]` from promoted vault notes |
| `src/study/queries.ts` | Added `getConceptByVaultPath()` for dedup |
| `src/ingestion/index.ts` | Non-blocking discovery hook in `handlePromotion()` |
| `groups/review_agent/CLAUDE.md` | Added domain/subdomain to concept note schema |
| `src/ingestion/draft-validator.ts` | Should-fix warnings for missing domain/subdomain |
| `dashboard/src/lib/db/schema.ts` | Added concepts + learning_activities Drizzle tables |
| `dashboard/src/lib/study-db.ts` | 5 query functions (active concepts, pending, approve, stats) |
| `dashboard/src/app/api/study/concepts/` | 3 API routes (GET concepts, GET pending, POST approve) |
| `dashboard/src/app/study/page.tsx` | Study overview page with approval UI |
| `scripts/migrate-vault-concepts.ts` | One-time vault backfill with domain inference |

## Test plan

- [x] 8 new concept discovery tests pass
- [x] 235/235 study + ingestion + migration tests pass
- [x] `npm run build` clean
- [x] `cd dashboard && npx tsc --noEmit` clean
- [ ] Run migration script and verify concepts appear on `/study`
- [ ] Approve concepts from dashboard, verify status change
- [ ] Ingest a new PDF, verify pending concepts appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)