### PR TITLE
feat(study): S3 generation + engine — activity generator, progression engine, session builder

### DIFF
--- a/docs/superpowers/plans/2026-04-15-s3-generation-engine.md
+++ b/docs/superpowers/plans/2026-04-15-s3-generation-engine.md
@@ -1,0 +1,677 @@
+# S3: Generation + Engine — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Your role:** You are the engineer implementing this. The plan tells you *what* to build and *why*. You decide *how* within the stated constraints. If you disagree with an approach or see a better alternative, flag it before implementing — don't silently deviate and don't silently comply with something you think is wrong.
+
+**Goal:** The system can generate learning activities for concepts, recommend what to study based on mastery state, compose balanced daily sessions, and trigger background generation when concepts advance to new Bloom's levels.
+
+**Architecture:** Three new modules in `src/study/`: engine.ts (concept progression logic — recommendations, advancement detection, de-escalation), session-builder.ts (daily session composition with new/review/stretch blocks), generator.ts (container dispatch for batch activity generation). A generator container agent (`groups/study-generator/`) produces structured JSON activities written to IPC. The existing IPC watcher receives them via a new handler.
+
+**Tech Stack:** TypeScript, Drizzle ORM (better-sqlite3), Vitest, NanoClaw container agents (Claude via OneCLI)
+
+**Branch:** Create `feat/s3-generation-engine` off `main`. S2 merged via PR #29.
+
+**Spec:** `docs/superpowers/specs/2026-04-12-multi-method-study-system-design.md` (v2.1, Sections 4.3, 4.5, 4.6, 6.1–6.3)
+
+**Master plan:** `docs/superpowers/plans/2026-04-13-study-system-master-plan.md` (S3 checklist)
+
+---
+
+## Codebase Conventions (Hard Constraints)
+
+These apply to **every task**. Subagents must follow these — they're not obvious from context alone.
+
+1. **`.js` extensions on all relative imports in `src/`.** The backend uses Node ESM resolution. Write `import { foo } from './bar.js'`, not `'./bar'`.
+2. **camelCase Drizzle properties, snake_case SQL columns** (backend `src/db/schema/study.ts`).
+3. **Drizzle query builder operators** (`eq`, `and`, `lte`, `desc`, `asc`, `count`, `sql`, `inArray`, `gte`) — not raw SQL strings — for operations the builder supports. Use `sql` template only for things like `datetime('now')` or computed expressions.
+4. **Vitest** for all tests. Pattern: `describe` → `it` → `expect`. Test file discovery: `src/**/*.test.ts`.
+5. **Test DB setup:** `_initTestDatabase()` from `src/db/index.js` creates in-memory SQLite with all migrations. `_closeDatabase()` in afterEach. Pattern: see `src/study/queries.test.ts`.
+6. **Commit messages** use conventional commits: `feat(study):`, `test(study):`.
+7. **Existing types from `src/study/types.ts`** — `ActivityType`, `BloomLevel`, `MasteryState`, `GeneratedActivity` (stub), `SessionComposition` (stub), `BloomAdvancement` (stub). Expand stubs in S3.1; don't create parallel types.
+8. **Existing queries from `src/study/queries.ts`** — `completeActivity()` returns `{ logEntryId, newDueAt, masteryUpdated, bloomCeilingBefore, bloomCeilingAfter }`. The engine wraps this; it does NOT duplicate the SM-2/mastery transaction logic.
+
+---
+
+## Spec Deviations
+
+- **No RAG integration in generator prompt.** The spec says "queries RAG for concept's vault content." For S3, generator.ts reads the vault note directly from disk (via `vault_note_path`) and includes content in the prompt. RAG integration deferred to S5 when the study agent (which also needs RAG) is built — one integration point instead of two.
+- **No morning scheduled task.** Master plan mentions a "morning safety net" for generation. Deferred to S7 (scheduled tasks sprint). S3 implements only the post-session trigger.
+- **Synthesis opportunities are advisory-only.** `getSynthesisOpportunities()` returns opportunities but does NOT auto-generate synthesis activities. That requires the dashboard chat (S5) and scheduling (S7).
+- **No automated quality validation of generated content.** Master plan S3.2 says the generator "validates against quality rules (rejects anti-patterns)." S3 relies on the CLAUDE.md prompt to enforce quality rules at generation time. Automated content validation (detecting yes/no questions, "list all X" prompts, etc.) would require a second LLM call — deferred. The IPC handler validates structural correctness only (required fields, valid types, bloom range).
+- **No automatic generation on concept approval.** Newly approved concepts start with zero activities. The session builder can only include existing activities. Initial activity generation for new concepts is triggered by the concept approval flow in S4 (the API route will call `generateActivities` after approval) and the morning scheduled task in S7. S3 provides the generator machinery; S4 and S7 provide the triggers.
+
+---
+
+## Key Decisions
+
+### D1: processCompletion wraps completeActivity — clean layering
+
+The engine's `processCompletion()` calls `queries.ts:completeActivity()` for all transactional DB work (SM-2 update → activity log → mastery recomputation → concept update). Then it adds business logic: advancement detection (`bloomCeilingAfter > bloomCeilingBefore`), checking whether activities already exist at the new level, and de-escalation advice.
+
+**Boundary:** `completeActivity()` = atomic data consistency (queries layer). `processCompletion()` = progression decisions (engine layer). The engine never imports `getDb()` — all DB access goes through query functions.
+
+### D2: Generator agent writes output to IPC
+
+The generator agent writes a JSON file to its IPC tasks directory (`/workspace/ipc/tasks/`). On the host this maps to `data/ipc/study-generator/tasks/`. The existing IPC watcher picks it up; the new `study_generated_activities` case in `processTaskIpc()` validates and inserts activities. Generator.ts just spawns the container — it doesn't parse output or touch the DB.
+
+### D3: Session builder is pure — reads DB, returns data, no writes
+
+`buildDailySession()` calls `getDueActivities()` + `getActiveConcepts()`, composes blocks, returns a `SessionComposition`. It does NOT create a `study_sessions` DB row — the API route (S4) does that. Two queries + in-memory merge is simpler than a complex join.
+
+### D4: Rate limiting is per-invocation, not persistent
+
+Generator tracks concepts processed via a module-level counter. Max 10 per cycle. No persistent queue — remaining concepts are picked up by the next trigger (S7's morning task). `resetGenerationCycle()` resets the counter at the start of each trigger.
+
+---
+
+## Essential Reading
+
+> **For coordinators:** Extract relevant patterns from these files and inline them into subagent prompts. Subagents won't read the files themselves.
+
+| File | Why |
+|------|-----|
+| `src/study/queries.ts` | `completeActivity()` signature and return type — engine wraps this. All existing CRUD functions — new queries follow same patterns. |
+| `src/study/types.ts` | Existing stubs for `GeneratedActivity`, `SessionComposition`, `BloomAdvancement` — expand these. `ActivityType` union for generator. |
+| `src/study/mastery.ts` | `computeMastery()`, `computeBloomCeiling()`, `computeOverallMastery()` — engine calls these for independent advancement checks |
+| `src/study/sm2.ts` | `computeDueDate()` — IPC handler uses this for initial `due_at` on generated activities |
+| `src/db/schema/study.ts` | `learningActivities` columns — IPC handler must produce valid `NewLearningActivity` rows. `activityConcepts` table for multi-concept activities. |
+| `src/ipc.ts:265–400` | `processTaskIpc()` switch statement — add new case for `study_generated_activities` |
+| `src/container-runner.ts:300–400` | `runContainerAgent()` signature, `ContainerInput` interface — generator.ts calls this |
+| `src/types.ts:36–44` | `RegisteredGroup` interface — generator.ts constructs one for the study-generator group |
+| `src/config.ts:53` | `VAULT_DIR` — generator reads vault notes from here |
+| `src/study/queries.test.ts:40–100` | Test fixture helpers — `makeConcept()`, `makeActivity()`, `makeSession()` patterns |
+| `groups/study-generator/CLAUDE.md` | Current scaffold — replace with full prompt |
+
+---
+
+## Task Numbering
+
+This plan uses its own sequential task IDs (S3.1–S3.8) that don't map 1:1 to the master plan's S3.1–S3.9 checklist.
+
+| Plan task | Master plan items | What |
+|-----------|-------------------|------|
+| S3.1 | — | Expand type stubs + new query functions |
+| S3.2 | S3.4 + S3.5 | Engine module (TDD) |
+| S3.3 | S3.6 + S3.7 | Session builder (TDD) |
+| S3.4 | S3.1 | Generator agent CLAUDE.md |
+| S3.5 | S3.2 + S3.3 | Generator orchestration + tests |
+| S3.6 | S3.8 | IPC handler for generated activities |
+| S3.7 | S3.9 | Post-session generation trigger |
+| S3.8 | — | Barrel export + verification |
+
+---
+
+## Parallelization & Model Recommendations
+
+**Dependencies:**
+- S3.1 → S3.2, S3.3, S3.5, S3.6 (types + queries before logic)
+- S3.4 is fully independent (markdown, no code imports)
+- S3.2 + S3.3 can run in parallel (engine + session builder — independent modules)
+- S3.5 depends on S3.1 + S3.4 (types must exist, CLAUDE.md must exist for container)
+- S3.6 depends on S3.1 (needs types for validation)
+- S3.7 depends on S3.2 + S3.5 (engine + generator wired together)
+
+**Parallel opportunities:**
+- S3.1 + S3.4 (types/queries + CLAUDE.md — fully independent)
+- S3.2 + S3.3 (engine + session builder — independent codepaths, both need only S3.1)
+- S3.5 + S3.6 (generator + IPC handler — independent, both need S3.1)
+
+| Task | Can parallel with | Model | Rationale |
+|------|-------------------|-------|-----------|
+| S3.1 | S3.4 | Sonnet | Types + CRUD queries following existing patterns |
+| S3.2 | S3.3 | Sonnet | Engine logic with algorithm from spec, well-specified |
+| S3.3 | S3.2 | Sonnet | Session builder with composition rules from spec |
+| S3.4 | S3.1 | Sonnet | Markdown writing from spec quality rules |
+| S3.5 | S3.6 | Sonnet | Container dispatch following existing pattern |
+| S3.6 | S3.5 | Sonnet | IPC handler following processTaskIpc pattern |
+| S3.7 | — | Sonnet | Thin wiring: engine + generator |
+| S3.8 | — | Sonnet | Barrel export + test suite runs |
+
+**Skip two-stage review for:** S3.1, S3.4, S3.8 (types/queries, markdown, barrel). Full review for: S3.2, S3.3, S3.5, S3.6, S3.7.
+
+---
+
+## S3.1: Expand Type Stubs + New Query Functions
+
+**Files:** Modify `src/study/types.ts`, modify `src/study/queries.ts`, modify `src/study/queries.test.ts`
+
+**Parallelizable with S3.4.**
+
+### Types to expand in `types.ts`
+
+Replace the three stub interfaces with full versions. Add new interfaces.
+
+**GeneratedActivity (expand stub — design decision):**
+```typescript
+export interface GeneratedActivity {
+  activityType: ActivityType;
+  prompt: string;
+  referenceAnswer: string;
+  bloomLevel: BloomLevel;
+  difficultyEstimate?: number;
+  cardType?: CardType;
+  sourceNotePath?: string;
+  sourceChunkHash?: string;
+  relatedConceptIds?: string[];
+}
+```
+
+**SessionComposition (replace stub — design decision):**
+```typescript
+export interface SessionBlock {
+  type: 'new' | 'review' | 'stretch';
+  activities: SessionActivity[];
+}
+
+export interface SessionActivity {
+  activityId: string;
+  conceptId: string;
+  conceptTitle: string;
+  domain: string | null;
+  activityType: ActivityType;
+  bloomLevel: BloomLevel;
+}
+
+export interface SessionComposition {
+  blocks: SessionBlock[];
+  totalActivities: number;
+  estimatedMinutes: number;
+  domainsCovered: string[];
+}
+
+export interface SessionOptions {
+  targetActivities?: number;  // default 20
+  domainFocus?: string;       // filter to specific domain
+  maxMinutes?: number;        // default 30
+}
+```
+
+**BloomAdvancement (expand stub — design decision):**
+```typescript
+export interface BloomAdvancement {
+  conceptId: string;
+  conceptTitle: string;
+  previousCeiling: number;
+  newCeiling: number;
+  generationNeeded: boolean;
+}
+```
+
+**New types — design decision:**
+```typescript
+export interface ActivityRecommendation {
+  activityType: ActivityType;
+  bloomLevel: BloomLevel;
+  count: number;
+}
+
+export interface CompletionResult {
+  logEntryId: string;
+  newDueAt: string;
+  advancement: BloomAdvancement | null;
+  generationNeeded: boolean;
+  deEscalation: string | null;
+}
+
+export interface SynthesisOpportunity {
+  type: 'within-subdomain' | 'within-domain' | 'cross-domain';
+  domain: string;
+  subdomain?: string;
+  concepts: Array<{ id: string; title: string; bloomCeiling: number }>;
+  automatic: boolean;  // true for within-subdomain/domain, false for cross-domain
+}
+```
+
+**Constraint:** Remove the old `SessionComposition` stub (it has `sessionId` and `activities` with `block: string`). The new version uses `SessionBlock[]`. If any code references the old shape, update it — but nothing should yet (it was a forward stub).
+
+### New query functions in `queries.ts`
+
+Add these functions following the existing pattern (same imports, same style):
+
+| Function | Signature | Notes |
+|----------|-----------|-------|
+| `getActivitiesByConcept` | `(conceptId: string) → LearningActivity[]` | All activities for a concept, ordered by `bloomLevel` asc |
+| `getRecentActivityLogs` | `(conceptId: string, limit: number) → ActivityLogEntry[]` | Last N logs, ordered by `reviewedAt` desc. Use `.limit(limit)`. |
+| `batchCreateActivities` | `(activities: NewLearningActivity[]) → void` | Wrap all inserts in `getDb().transaction()` |
+| `createActivityConceptLinks` | `(activityId: string, conceptIds: string[], role?: string) → void` | Insert into `schema.activityConcepts`. Role defaults to `'related'`. |
+| `getConceptsAboveBloomCeiling` | `(minCeiling: number) → Concept[]` | Active concepts where `bloomCeiling >= minCeiling`. Filter with `and(eq(status, 'active'), gte(bloomCeiling, minCeiling))`. |
+
+**Constraint:** Add test cases for all five new query functions in `queries.test.ts`, following the existing pattern (`beforeEach/_initTestDatabase`, `afterEach/_closeDatabase`, fixture helpers).
+
+**Agent discretion:** Additional edge-case tests beyond one-per-function, exact test descriptions.
+
+- [ ] **Step 1:** Expand the three type stubs and add new types in `src/study/types.ts`
+- [ ] **Step 2:** Run type check: `npx tsc --noEmit` — fix any issues with code referencing old stub shapes
+- [ ] **Step 3:** Add the five new query functions to `src/study/queries.ts`
+- [ ] **Step 4:** Add test cases for all new queries in `src/study/queries.test.ts`
+- [ ] **Step 5:** Run tests: `npx vitest run src/study/queries.test.ts`
+- [ ] **Step 6:** Commit: `feat(study): expand type stubs and add engine/session query functions (S3.1)`
+
+---
+
+## S3.2: Engine Module (TDD)
+
+**Files:** Create `src/study/engine.ts` + `src/study/engine.test.ts`
+
+**Parallelizable with S3.3** (after S3.1 is complete).
+
+The engine is the concept progression logic module. It reads DB state via query functions and returns recommendations. No container spawning, no LLM calls. All DB access goes through `src/study/queries.js` — do NOT import `getDb()`.
+
+### Functions
+
+**`getConceptRecommendations(conceptId: string): ActivityRecommendation[]`**
+
+Algorithm (from spec Section 4.3):
+- Get concept from DB via `getConceptById()`. Throw if not found.
+- Read `bloomCeiling`.
+- bloomCeiling < 3: recommend `card_review` at L1 (count 3–5) + `elaboration` at L2 (count 2)
+- bloomCeiling 3–4: recommend `self_explain` at L3 + `concept_map` at L3 + `comparison` at L4 + `case_analysis` at L4 (count 1 each)
+- bloomCeiling >= 5: recommend `synthesis` at L5 + `socratic` at L6 + `case_analysis` at L5 (count 1 each)
+- Return `ActivityRecommendation[]`
+
+**`checkForAdvancement(conceptId: string): BloomAdvancement | null`**
+
+- Get concept from DB. Get ALL activity logs for this concept via `getLogsByConceptAndLevel(conceptId)`.
+- Compute mastery using `computeMastery()` from `mastery.js`.
+- Compute new ceiling using `computeBloomCeiling()`.
+- If new ceiling > concept's current `bloomCeiling`:
+  - Check if activities already exist at the new level: call `getActivitiesByConcept(conceptId)`, filter to `bloomLevel >= newCeiling`. If any exist, `generationNeeded = false`; otherwise `true`.
+  - Return `BloomAdvancement` with concept title and ceiling info.
+- If no advancement: return `null`.
+
+**`processCompletion(input: CompleteActivityInput): CompletionResult`**
+
+- Look up the activity first via `getActivityById(input.activityId)` to get `conceptId` (needed for later steps).
+- Call `completeActivity(input)` from queries.js → get `{ bloomCeilingBefore, bloomCeilingAfter, logEntryId, newDueAt }`
+- If `bloomCeilingAfter > bloomCeilingBefore`:
+  - Get concept via `getConceptById(conceptId)` for the title
+  - Check if activities already exist at the new level: `getActivitiesByConcept(conceptId)` → filter to `bloomLevel >= bloomCeilingAfter`. If any exist: `generationNeeded = false`; otherwise `true`.
+  - Build `BloomAdvancement` object
+- Call `getDeEscalationAdvice(conceptId)`
+- Return `CompletionResult`
+
+**Constraint:** processCompletion uses the `bloomCeilingBefore`/`bloomCeilingAfter` values from `completeActivity()`'s return. It does NOT call `checkForAdvancement()` — that function is a standalone utility for use outside the completion flow (e.g., morning scheduled task in S7). Do NOT duplicate SM-2 or mastery computation in engine.ts.
+
+**`getDeEscalationAdvice(conceptId: string): string | null`**
+
+- Get last 5 logs via `getRecentActivityLogs(conceptId, 5)`
+- If fewer than 3 logs: return `null` (not enough data)
+- Compute average quality
+- If avg < 2.5 AND concept's bloomCeiling > 1: return advice string ("Recent performance suggests reinforcing lower-level understanding before continuing at L{ceiling}.")
+- Otherwise: return `null`
+
+**`getSynthesisOpportunities(domain?: string): SynthesisOpportunity[]`**
+
+- Get active concepts with bloomCeiling >= 4 via `getConceptsAboveBloomCeiling(4)`
+- If `domain` provided, filter to that domain
+- Group by subdomain → if 2+ concepts share a subdomain: within-subdomain opportunity (`automatic: true`)
+- Group by domain (across subdomains) → if concepts span multiple subdomains: within-domain opportunity (`automatic: true`)
+- Cross-domain: if concepts span multiple domains: cross-domain opportunity (`automatic: false`)
+- Return array sorted by type priority: within-subdomain first, then within-domain, then cross-domain
+
+### Required test cases
+
+| Function | Scenario | Expected |
+|----------|----------|----------|
+| getConceptRecommendations | bloomCeiling = 0 (fresh) | L1–L2 recommendations (cards + elaboration) |
+| getConceptRecommendations | bloomCeiling = 3 | L3–L4 recommendations |
+| getConceptRecommendations | bloomCeiling = 5 | L5–L6 recommendations |
+| getConceptRecommendations | concept not found | throws |
+| checkForAdvancement | enough mastery evidence to advance | BloomAdvancement with generationNeeded=true |
+| checkForAdvancement | activities exist at new level | BloomAdvancement with generationNeeded=false |
+| checkForAdvancement | insufficient mastery | null |
+| processCompletion | quality=5, concept advances | CompletionResult with advancement + generationNeeded |
+| processCompletion | quality=3, no advancement | CompletionResult with advancement=null |
+| processCompletion | repeated low quality | CompletionResult with deEscalation string |
+| getDeEscalationAdvice | avg quality < 2.5 (5 logs) | advice string |
+| getDeEscalationAdvice | avg quality >= 2.5 | null |
+| getDeEscalationAdvice | fewer than 3 logs | null |
+| getSynthesisOpportunities | 3 concepts, same subdomain, ceiling 4+ | 1 within-subdomain opportunity |
+| getSynthesisOpportunities | concepts across subdomains | within-domain opportunity |
+| getSynthesisOpportunities | domain filter applied | only matching domain |
+| getSynthesisOpportunities | no concepts above ceiling 4 | empty array |
+
+**Test setup:** `_initTestDatabase()` in beforeEach. Create concepts with varying mastery/bloomCeiling. Create activity log entries. Use `makeConcept()` pattern from queries.test.ts.
+
+**Agent discretion:** Additional edge-case tests, exact recommendation counts, de-escalation message wording.
+
+- [ ] **Step 1:** Write failing tests for all engine functions
+- [ ] **Step 2:** Run tests, verify they fail: `npx vitest run src/study/engine.test.ts`
+- [ ] **Step 3:** Implement all engine functions — make tests pass
+- [ ] **Step 4:** Run tests, verify all pass
+- [ ] **Step 5:** Commit: `feat(study): add concept progression engine with advancement detection (S3.2)`
+
+---
+
+## S3.3: Session Builder (TDD)
+
+**Files:** Create `src/study/session-builder.ts` + `src/study/session-builder.test.ts`
+
+**Parallelizable with S3.2** (after S3.1 is complete).
+
+### `buildDailySession(options?: SessionOptions): SessionComposition`
+
+Algorithm (from spec Section 4.5):
+
+1. Get all due activities: `getDueActivities()` — activities with `due_at <= today`
+2. Get all active concepts: `getActiveConcepts()` — build `Map<string, Concept>` keyed by id
+3. Enrich each activity with its concept's metadata. Skip activities whose concept is missing from the map (concept may have been archived).
+4. If `options.domainFocus`, filter to activities whose concept matches that domain.
+5. Target activity count: `options.targetActivities ?? 20`
+
+**Block composition:**
+
+**New material block (~30%):**
+- Filter to activities at bloomLevel 1–2 where the concept's bloomCeiling < 3
+- Group by domain for topic coherence (blocked, NOT interleaved — Hwang 2025)
+- Take up to 30% of target count
+
+**Review block (~50%):**
+- Filter to activities NOT in the new block
+- Sort by: (a) most overdue first, (b) lowest ease_factor, (c) activity type variety
+- Interleave: never 2 consecutive activities with the same `conceptId`. Algorithm: place activities one by one from the sorted list, skip if previous has same conceptId; append skipped ones at the end. After the first pass, remaining activities are appended in order — consecutive same-concept at the tail is acceptable (the best-effort interleaving applies to the bulk, not the overflow)
+- Take up to 50% of target
+
+**Stretch block (~20%):**
+- Filter to activities at bloomLevel >= 4 where concept's bloomCeiling >= 4
+- NOT already placed in review block
+- Take up to 20% of target (2–4 activities)
+
+6. **Domain coverage:** After block composition, check if any active domain with due activities is unrepresented. If so, swap the lowest-priority review activity for one from the missing domain. Best-effort — if no due activity exists for a domain, skip it.
+7. If total < target and more due activities remain, fill from remaining pool into review block
+8. Estimate minutes per activity type:
+   - `card_review`: 1.5 min
+   - `elaboration`: 3 min
+   - `self_explain`, `comparison`, `case_analysis`, `concept_map`: 5 min
+   - `synthesis`, `socratic`: 7 min
+8. Build `domainsCovered` from unique domains across all placed activities
+
+**Constraint:** The session builder does NOT create a `study_sessions` DB row. It returns data. The API route (S4) creates the session.
+
+**Constraint:** Activities without a matching concept in the active concepts map should be silently skipped, not crash.
+
+**Constraint:** If no activities are due, return `{ blocks: [], totalActivities: 0, estimatedMinutes: 0, domainsCovered: [] }` — not an error.
+
+### Required test cases
+
+| Scenario | Setup | Expected |
+|----------|-------|----------|
+| All three blocks populated | 5 new L1, 10 review, 3 stretch L5 | 3 blocks, activities allocated by percentage |
+| Only review (no new, no stretch) | 15 review activities, all concepts ceiling 2 | review block gets all, new+stretch empty |
+| No due activities | empty DB | totalActivities: 0, empty blocks |
+| Domain focus filter | activities across 3 domains | only activities from focused domain |
+| Interleaving: no consecutive same-concept | 10 reviews across 5 concepts | no adjacent activities share conceptId in review block |
+| New block is topic-grouped | 6 L1–L2 activities, 2 domains | activities within new block grouped by domain |
+| Stretch only if ceiling >= 4 | concepts at ceiling 2,3 | no stretch block activities |
+| Target cap | 30 due activities | session capped at target count |
+| Time estimate | mix of card_review + synthesis | correct estimatedMinutes |
+| Missing concept silently skipped | activity with deleted concept | activity excluded, no crash |
+| Domain coverage | 3 domains with due activities, initial composition misses 1 | missing domain swapped in |
+
+**Test setup:** `_initTestDatabase()` in beforeEach. Create concepts with varying domains/bloom ceilings. Create activities at different bloom levels with `dueAt <= today`.
+
+**Agent discretion:** Internal helpers, sort tiebreakers, fill strategy, exact percentage rounding.
+
+- [ ] **Step 1:** Write failing tests for buildDailySession covering all scenarios
+- [ ] **Step 2:** Run tests, verify they fail: `npx vitest run src/study/session-builder.test.ts`
+- [ ] **Step 3:** Implement buildDailySession — make tests pass
+- [ ] **Step 4:** Run tests, verify all pass
+- [ ] **Step 5:** Commit: `feat(study): add session builder with new/review/stretch blocks (S3.3)`
+
+---
+
+## S3.4: Generator Agent CLAUDE.md
+
+**Files:** Replace `groups/study-generator/CLAUDE.md`
+
+**Parallelizable with S3.1.**
+
+Replace the scaffold with a full generator agent system prompt. The agent receives a structured prompt from generator.ts containing concept info and vault note content. It must output a JSON IPC file.
+
+**Required sections:**
+
+1. **Role:** "You generate learning activities from source material. Output is structured JSON written to IPC."
+
+2. **Output format:** Write a JSON file to `/workspace/ipc/tasks/activities-{timestamp}.json`:
+   ```json
+   {
+     "type": "study_generated_activities",
+     "conceptId": "...",
+     "activities": [
+       {
+         "activityType": "card_review",
+         "prompt": "...",
+         "referenceAnswer": "...",
+         "bloomLevel": 1,
+         "difficultyEstimate": 5,
+         "cardType": "basic",
+         "sourceNotePath": "concepts/cognitive-load-theory.md"
+       }
+     ]
+   }
+   ```
+
+3. **Activity type specifications** (from spec Section 3.2). Include all 8 types with bloom ranges and a worked example for each:
+   - `card_review` (L1–L2): basic Q&A, cloze, reversed
+   - `elaboration` (L2–L3): "Why does...?" prompts
+   - `self_explain` (L2–L4): Feynman technique prompts
+   - `concept_map` (L2–L5): list key concepts + relationships
+   - `comparison` (L4–L5): compare X and Y (include `relatedConceptIds`)
+   - `case_analysis` (L3–L6): real-world scenario
+   - `synthesis` (L5–L6): integrate multiple concepts (include `relatedConceptIds`)
+   - `socratic` (L4–L6): guided question sequence
+
+4. **Quality rules (Wozniak + Matuschak):**
+   - Minimum Information Principle: one concept per activity. If reference answer > 15 words for card_review, split.
+   - Five Attributes: focused, precise, consistent, tractable, effortful
+   - Source traceability: always set `sourceNotePath` to the vault path provided in the prompt
+
+5. **Anti-pattern checklist — NEVER generate these:**
+   - Yes/no questions (50% guessable)
+   - "List all X" prompts (sets are hard to memorize — break into individuals)
+   - Copy-paste from source (encourages pattern matching)
+   - Answer keywords appearing in the question
+   - Single activity per concept (always generate 2+ from different angles)
+   - Answers > 15 words for card_review (split the card)
+
+6. **Bloom's level generation guidelines (spec Section 6.2):**
+   - L1–L2: 3–5 cards + 2 elaboration prompts
+   - L3–L4: Feynman prompts, concept map tasks, comparison, case starters
+   - L5–L6: Synthesis prompts, Socratic starters, complex case scenarios
+
+7. **Generation strategy (spec Section 6.3):**
+   - Analyze source content first: identify key concepts, relationships, and critical details
+   - Then generate activities targeting those elements
+   - Use different vocabulary in questions than in the source material
+   - Each activity should test from a different angle
+
+8. **Common mistakes section** with 3–5 examples of bad activities and why they fail. E.g.: a yes/no question → "50% guessable, no retrieval effort"; a "list all 6 stages" prompt → "sets are nearly impossible to memorize atomically — break into individual questions."
+
+**Constraint:** Include at least one fully worked example output per activity type in section 3. The agent needs concrete quality examples.
+
+**Agent discretion:** Exact wording, additional examples, formatting style.
+
+- [ ] **Step 1:** Write the full CLAUDE.md with all sections above
+- [ ] **Step 2:** Commit: `feat(study): design generator agent prompt with quality rules (S3.4)`
+
+---
+
+## S3.5: Generator Orchestration
+
+**Files:** Create `src/study/generator.ts` + `src/study/generator.test.ts`
+
+**Depends on S3.1 + S3.4.**
+
+`generator.ts` orchestrates activity generation: reads concept and vault content, builds the generation prompt, spawns a container agent. It does NOT parse or insert activities — that's the IPC handler's job (S3.6).
+
+### Functions
+
+**`generateActivities(conceptId: string, bloomLevel: BloomLevel): Promise<void>`**
+
+Algorithm:
+1. Check rate limit: if `conceptsGeneratedThisCycle >= MAX_CONCEPTS_PER_CYCLE` (10), log and return early.
+2. Get concept from DB via `getConceptById()`. Throw if not found. Throw if status !== 'active'.
+3. Read vault note content: if concept has `vaultNotePath`, read the file from `VAULT_DIR` (import from `config.js`). If file doesn't exist, log warning — proceed with title-only generation (do NOT skip).
+4. Build generation prompt string containing:
+   - Concept title
+   - Vault note content (or "No vault note available — generate from title")
+   - Target bloom level and recommended activity count (L1–L2: 5, L3–L4: 3, L5–L6: 2)
+   - Source note path for traceability
+5. Construct a `RegisteredGroup` for the study-generator folder:
+   ```typescript
+   { name: 'Study Generator', folder: 'study-generator', trigger: '',
+     added_at: new Date().toISOString(), requiresTrigger: false, isMain: false }
+   ```
+6. Construct `ContainerInput` with `prompt`, `groupFolder: 'study-generator'`, `singleTurn: true`, `chatJid: 'internal:study-generator'`, `isMain: false`, `ipcNamespace: 'study-generator'`
+7. Call `runContainerAgent(group, input, onProcess)`. The `onProcess` callback has signature `(proc: ChildProcess, containerName: string) => void` — log the container name. Do not await the result — fire and forget (the IPC handler processes the output asynchronously).
+8. Increment `conceptsGeneratedThisCycle`
+
+**`resetGenerationCycle(): void`** — sets counter to 0.
+
+**Rate limit constant:** `MAX_CONCEPTS_PER_CYCLE = 10`
+
+### Tests
+
+Generator spawns actual containers — tests MUST mock `runContainerAgent`. Use `vi.mock()` on the container-runner module. The mock should resolve with `{ status: 'success', result: null }` (type `ContainerOutput` from `container-runner.ts`). The generator doesn't use the return value — it fires and forgets.
+
+| Scenario | Expected |
+|----------|----------|
+| Prompt includes concept title and vault content | verify prompt string passed to mock |
+| Prompt includes bloom level | bloom level appears in prompt |
+| Missing vault note: generation proceeds with title only | no throw, prompt says "No vault note available" |
+| Concept not found | throws |
+| Archived concept (status !== 'active') | throws |
+| Rate limit: 11th call skipped | `runContainerAgent` called 10 times, not 11 |
+| `resetGenerationCycle()` resets counter | after reset, generation proceeds |
+
+**Agent discretion:** Prompt format/template, mock strategy, whether to export the prompt builder for direct testing.
+
+- [ ] **Step 1:** Write generator.ts with `generateActivities` + rate limiting
+- [ ] **Step 2:** Write generator.test.ts with mocked `runContainerAgent`
+- [ ] **Step 3:** Run tests: `npx vitest run src/study/generator.test.ts`
+- [ ] **Step 4:** Commit: `feat(study): add activity generator with container dispatch (S3.5)`
+
+---
+
+## S3.6: IPC Handler for Generated Activities
+
+**Files:** Modify `src/ipc.ts`
+
+**Parallelizable with S3.5** (after S3.1).
+
+Add a new case to `processTaskIpc()` for `type: 'study_generated_activities'`.
+
+**IPC payload shape (what the generator agent writes):**
+```typescript
+{
+  type: 'study_generated_activities',
+  conceptId: string,
+  activities: GeneratedActivity[]
+}
+```
+
+**Handler logic:**
+1. Validate `conceptId` exists in DB via `getConceptById()`. If not found, log error and return.
+2. Build a `NewLearningActivity[]` from the activities array. For each activity:
+   a. Validate **required** fields: `activityType`, `prompt`, `referenceAnswer`, `bloomLevel`. If any are missing, log and **skip** that entry (do NOT throw — one bad activity must not block the batch).
+   b. Validate `activityType` is a known `ActivityType` value. Validate `bloomLevel` is 1–6.
+   c. **Optional** fields — pass through when present, use defaults when absent: `difficultyEstimate` (default 5), `cardType` (default null), `sourceNotePath` (default null), `sourceChunkHash` (default null), `relatedConceptIds` (default empty — no activity_concepts links). Do NOT skip an activity because an optional field is missing.
+   d. Map to `NewLearningActivity`:
+      - `id`: `crypto.randomUUID()`
+      - `conceptId`: from payload
+      - `activityType`, `prompt`, `referenceAnswer`, `bloomLevel`, `difficultyEstimate`, `cardType`, `sourceNotePath`, `sourceChunkHash`: from activity
+      - `generatedAt`: `new Date().toISOString()`
+      - `author`: `'system'`
+      - `easeFactor`: `2.5`, `intervalDays`: `1`, `repetitions`: `0`
+      - `dueAt`: `computeDueDate(1)` (due tomorrow)
+      - `masteryState`: `'new'`
+3. Call `batchCreateActivities(validActivities)` from queries.js.
+4. For activities with `relatedConceptIds` (comparison/synthesis): call `createActivityConceptLinks(activityId, relatedConceptIds)`.
+5. Log: `"IPC: inserted N activities for concept {title} (M skipped)"`
+
+**Constraint:** Invalid activities are logged and skipped. The rest of the batch is still inserted. Never throw from this handler — the IPC watcher expects handlers to resolve, not reject.
+
+**Constraint:** Use `computeDueDate` from `src/study/sm2.js` for the initial due date. Do NOT hardcode date arithmetic.
+
+**Imports to add to `src/ipc.ts`:**
+- `import { getConceptById, batchCreateActivities, createActivityConceptLinks } from './study/queries.js'`
+- `import { computeDueDate } from './study/sm2.js'`
+- `import type { GeneratedActivity, ActivityType } from './study/types.js'`
+
+- [ ] **Step 1:** Add imports to `src/ipc.ts`
+- [ ] **Step 2:** Add `case 'study_generated_activities':` block to `processTaskIpc()` switch
+- [ ] **Step 3:** Run build check: `npm run build` — no type errors
+- [ ] **Step 4:** Run full test suite: `npm test` — no regressions
+- [ ] **Step 5:** Commit: `feat(study): add IPC handler for generated activities (S3.6)`
+
+---
+
+## S3.7: Post-Session Generation Trigger
+
+**Files:** Modify `src/study/engine.ts`, modify `src/study/engine.test.ts`
+
+**Depends on S3.2 + S3.5.**
+
+### `triggerPostSessionGeneration(sessionId: string): Promise<void>`
+
+Algorithm:
+1. Call `resetGenerationCycle()` from generator.js (resets rate limit counter)
+2. Get all activity log entries for this session via `getLogsBySession(sessionId)`
+3. Collect unique `conceptId` values from the logs
+4. For each unique concept: call `checkForAdvancement(conceptId)`
+5. For each advancement with `generationNeeded === true`:
+   - Call `generateActivities(conceptId, advancement.newCeiling as BloomLevel)` from generator.js
+6. Log summary: `"Post-session generation: {N} concepts checked, {M} advanced, {K} queued for generation"`
+
+**Constraint:** Wrap each `generateActivities()` call in try/catch. Failure for one concept must NOT prevent generation for others. Log errors but don't throw.
+
+**Constraint:** This function does NOT end the study session or update the session record. The API route (S4) calls `updateStudySession()` for lifecycle, then calls `triggerPostSessionGeneration()` for background work.
+
+### Tests
+
+Mock `generateActivities` (it spawns containers). Test:
+
+| Scenario | Expected |
+|----------|----------|
+| Session with 2 completed activities, 1 concept advances | `generateActivities` called once for the advanced concept |
+| Session with 3 concepts, none advance | `generateActivities` not called |
+| `generateActivities` throws for 1 concept | other concepts still processed, error logged |
+| Empty session (no logs) | no calls, no errors |
+
+- [ ] **Step 1:** Add `triggerPostSessionGeneration` to engine.ts with imports from generator.js
+- [ ] **Step 2:** Add tests with mocked generator
+- [ ] **Step 3:** Run tests: `npx vitest run src/study/engine.test.ts`
+- [ ] **Step 4:** Commit: `feat(study): add post-session generation trigger (S3.7)`
+
+---
+
+## S3.8: Barrel Export + Full Verification
+
+**Files:** Modify `src/study/index.ts`
+
+- [ ] **Step 1:** Add exports to `src/study/index.ts`:
+  ```typescript
+  export * from './engine.js';
+  export * from './session-builder.js';
+  export * from './generator.js';
+  ```
+- [ ] **Step 2:** Run study tests: `npx vitest run src/study/`
+- [ ] **Step 3:** Run full test suite: `npm test`
+- [ ] **Step 4:** Build check: `npm run build`
+- [ ] **Step 5:** Commit: `feat(study): export engine, session-builder, generator from barrel (S3.8)`
+
+---
+
+## Acceptance Criteria
+
+From master plan S3 (non-negotiable):
+
+- [ ] Generator produces valid activities for a concept at each Bloom's level (tested via mocked container + IPC handler unit)
+- [ ] IPC handler validates activities and rejects anti-patterns (bad type, missing fields)
+- [ ] Engine correctly recommends activity types based on mastery state
+- [ ] Session builder produces balanced sessions with correct block composition
+- [ ] Completion flow: activity done → SM-2 updated → mastery updated → advancement detected → generation triggered
+- [ ] Post-session trigger handles errors gracefully (one concept failure doesn't block others)
+- [ ] All tests pass (`npm test`)
+- [ ] Clean build (`npm run build`)

--- a/groups/study-generator/CLAUDE.md
+++ b/groups/study-generator/CLAUDE.md
@@ -1,18 +1,403 @@
 # Study Generator Agent
 
-**Role:** Batch-generate learning activities from vault content.
-
-## Output Format
-
-Structured JSON — one activity object per item, conforming to the `Activity` schema defined in `src/study/types.ts`.
-
-## Quality Rules
-
-All generated items must satisfy:
-
-- **Wozniak's 20 Rules of Knowledge Formulation** — atomic, unambiguous, contextualised.
-- **Matuschak's 5 Attributes of Good Prompts** — focused, precise, consistent, tractable, effortful.
+**Role:** You generate learning activities from source material. Output is structured JSON written to IPC. You never explain your reasoning to the user — you write a file and exit.
 
 ---
 
-> Full prompt designed in S3.
+## 1. How You Are Invoked
+
+The host process sends you a prompt containing:
+
+- **Concept title** — the concept being studied (e.g. "Cognitive Load Theory")
+- **Vault note content** — the full markdown text of the student's Obsidian note
+- **Target Bloom's level** — integer 1–6 indicating the mastery frontier to target
+- **Number of activities** — how many activities to generate
+- **Source note path** — vault-relative path (e.g. `concepts/cognitive-load-theory.md`)
+- **Concept ID** — UUID identifying the concept in the database
+- **Related concept IDs** — optional list of concept UUIDs for synthesis/comparison activities
+
+Your job: read those inputs, generate activities, write one JSON file, exit.
+
+---
+
+## 2. Output Format
+
+Write a single JSON file to:
+
+```
+/workspace/ipc/tasks/activities-{timestamp}.json
+```
+
+Where `{timestamp}` is the Unix epoch in milliseconds (e.g. `activities-1713196800000.json`).
+
+```json
+{
+  "type": "study_generated_activities",
+  "conceptId": "uuid-here",
+  "activities": [
+    {
+      "activityType": "card_review",
+      "prompt": "What is the central claim of the Minimum Information Principle?",
+      "referenceAnswer": "Each item of knowledge should be formulated as simply and unambiguously as possible.",
+      "bloomLevel": 1,
+      "difficultyEstimate": 4,
+      "cardType": "basic",
+      "sourceNotePath": "concepts/wozniak-knowledge-formulation.md"
+    }
+  ]
+}
+```
+
+### Field reference
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `activityType` | Yes | One of the 8 types below |
+| `prompt` | Yes | The question or task shown to the student |
+| `referenceAnswer` | Yes | The ideal answer used for self-rating or AI evaluation |
+| `bloomLevel` | Yes | Integer 1–6 |
+| `difficultyEstimate` | No | 1–10 subjective difficulty |
+| `cardType` | Only for `card_review` | `"basic"`, `"cloze"`, or `"reversed"` |
+| `sourceNotePath` | Yes | Always set to the vault path provided in your prompt |
+| `relatedConceptIds` | Only for `comparison` and `synthesis` | Array of concept UUID strings |
+
+---
+
+## 3. Activity Type Specifications
+
+Generate activities **only** from this list. Each type has a defined Bloom's range and required fields.
+
+---
+
+### 3.1 `card_review` — Bloom's L1–L2
+
+Atomic retrieval. One fact or definition per card. Use `cardType` to vary format.
+
+- `basic`: direct question → answer
+- `cloze`: sentence with a gap to fill (mark gap as `[...]`)
+- `reversed`: answer → question (student names the concept from the description)
+
+**Quality constraint:** If your `referenceAnswer` exceeds 15 words, split into separate cards.
+
+**Worked examples (Knowledge Management domain):**
+
+```json
+{
+  "activityType": "card_review",
+  "prompt": "What does SECI stand for in Nonaka's knowledge creation model?",
+  "referenceAnswer": "Socialization, Externalization, Combination, Internalization.",
+  "bloomLevel": 1,
+  "difficultyEstimate": 3,
+  "cardType": "basic",
+  "sourceNotePath": "concepts/nonaka-seci-model.md"
+}
+```
+
+```json
+{
+  "activityType": "card_review",
+  "prompt": "Tacit knowledge is converted to explicit knowledge during the [...] phase of the SECI model.",
+  "referenceAnswer": "Externalization",
+  "bloomLevel": 1,
+  "difficultyEstimate": 4,
+  "cardType": "cloze",
+  "sourceNotePath": "concepts/nonaka-seci-model.md"
+}
+```
+
+```json
+{
+  "activityType": "card_review",
+  "prompt": "Knowledge that can be articulated, documented, and transferred in written form.",
+  "referenceAnswer": "Explicit knowledge",
+  "bloomLevel": 2,
+  "difficultyEstimate": 2,
+  "cardType": "reversed",
+  "sourceNotePath": "concepts/nonaka-seci-model.md"
+}
+```
+
+---
+
+### 3.2 `elaboration` — Bloom's L2–L3
+
+"Why does...?" prompts that force the student to connect a concept to prior knowledge or underlying mechanisms. Do not ask for definitions — ask for reasons.
+
+**Worked example (Cognitive Psychology domain):**
+
+```json
+{
+  "activityType": "elaboration",
+  "prompt": "Why does splitting attention between two simultaneous information sources increase cognitive load, even when both sources are individually simple?",
+  "referenceAnswer": "Because working memory must process both sources in parallel, consuming capacity that would otherwise be available for schema formation. The split-attention effect (Sweller) shows that physically integrating the sources reduces extraneous cognitive load.",
+  "bloomLevel": 3,
+  "difficultyEstimate": 6,
+  "sourceNotePath": "concepts/cognitive-load-theory.md"
+}
+```
+
+---
+
+### 3.3 `self_explain` — Bloom's L2–L4
+
+Feynman technique prompts. Ask the student to explain the concept as if teaching someone unfamiliar with it, in their own words, without using the source's exact phrasing. Effective self-explanation exposes gaps.
+
+**Worked example (Information Systems domain):**
+
+```json
+{
+  "activityType": "self_explain",
+  "prompt": "Explain transaction management in relational databases as if you were teaching a first-year student who understands spreadsheets but has never written SQL. Avoid using the words 'ACID' or 'atomicity' in your explanation.",
+  "referenceAnswer": "A transaction groups multiple database changes so they either all succeed or all fail together. This prevents corrupt states (e.g. money leaving one account without arriving in the other). The database keeps a log so it can undo partial changes if something fails midway.",
+  "bloomLevel": 3,
+  "difficultyEstimate": 7,
+  "sourceNotePath": "concepts/database-transactions.md"
+}
+```
+
+---
+
+### 3.4 `concept_map` — Bloom's L2–L5
+
+Ask the student to list key concepts from a topic and explicitly state the relationships between them (not just a list of terms). The `referenceAnswer` should model a valid map structure in prose or structured text.
+
+**Worked example (Digital Transformation domain):**
+
+```json
+{
+  "activityType": "concept_map",
+  "prompt": "Map the key components of a digital transformation programme. List at least five distinct concepts and state the directional relationship between each pair (e.g. 'A enables B', 'A constrains B', 'A is a prerequisite for B').",
+  "referenceAnswer": "Leadership commitment → enables → cultural change. Cultural change → enables → agile ways of working. Agile ways of working → requires → modular technology architecture. Data governance → constrains → AI adoption. Customer journey mapping → drives → product digitalisation priorities.",
+  "bloomLevel": 4,
+  "difficultyEstimate": 7,
+  "sourceNotePath": "concepts/digital-transformation-frameworks.md"
+}
+```
+
+---
+
+### 3.5 `comparison` — Bloom's L4–L5
+
+Structured comparison of two frameworks, models, or concepts along a named dimension. Always include `relatedConceptIds`. The prompt must name both subjects and the dimension of comparison explicitly.
+
+**Worked example (Knowledge Management domain):**
+
+```json
+{
+  "activityType": "comparison",
+  "prompt": "Compare Nonaka's SECI model and Wiig's knowledge lifecycle model on the dimension of knowledge conversion mechanism. What does each model claim drives knowledge transformation, and where do they fundamentally differ?",
+  "referenceAnswer": "SECI: knowledge converts through social interaction and practice — tacit↔explicit conversion is the core mechanism. Wiig: knowledge transforms through deliberate organizational processes (creation, sourcing, compilation, transformation, dissemination, application). SECI is epistemological (how knowledge changes form); Wiig is operational (how organisations manage knowledge assets). Key difference: SECI treats tacit knowledge as the primary source of innovation; Wiig treats explicit codification as the primary management tool.",
+  "bloomLevel": 5,
+  "difficultyEstimate": 8,
+  "relatedConceptIds": ["uuid-wiig-knowledge-lifecycle"],
+  "sourceNotePath": "concepts/nonaka-seci-model.md"
+}
+```
+
+---
+
+### 3.6 `case_analysis` — Bloom's L3–L6
+
+Present a realistic scenario and ask the student to apply, diagnose, or evaluate using the target concept. Scenarios should be plausible in the student's study domains. Avoid contrived toy examples.
+
+**Worked example (AI / Information Systems domain):**
+
+```json
+{
+  "activityType": "case_analysis",
+  "prompt": "A hospital deploys an AI diagnostic tool trained on historical patient records. Six months after deployment, a review finds that the tool performs 20% worse on patients from rural areas than urban areas. A data scientist suggests retraining with more balanced geographic data. Using what you know about algorithmic bias and data quality, diagnose the likely cause of this performance gap and evaluate whether retraining alone is sufficient to address it.",
+  "referenceAnswer": "Likely cause: representation bias — rural patients were underrepresented in training data, so the model learned decision boundaries that reflect urban clinical patterns. Retraining with balanced data addresses representation bias but does not address: (1) measurement bias if rural patients are systematically recorded differently; (2) historical label bias if past diagnoses for rural patients were themselves biased; (3) deployment drift if rural clinical contexts differ systematically from training contexts. Retraining is necessary but not sufficient — a full bias audit of labelling processes and feature validity is required.",
+  "bloomLevel": 5,
+  "difficultyEstimate": 9,
+  "sourceNotePath": "concepts/algorithmic-bias.md"
+}
+```
+
+---
+
+### 3.7 `synthesis` — Bloom's L5–L6
+
+Integrate two or more distinct concepts to construct an argument, framework, or explanation that requires drawing on all of them. Always include `relatedConceptIds`. The `referenceAnswer` should sketch the synthesis, not just list the concepts.
+
+**Worked example (Cognitive Psychology + Digital Transformation domain):**
+
+```json
+{
+  "activityType": "synthesis",
+  "prompt": "A large organisation is rolling out a new ERP system to 5,000 employees. Using cognitive load theory and change management principles, construct an argument for how the training programme should be designed. Your argument should explain what cognitive load theory predicts will go wrong with conventional 'big bang' training and what change management theory recommends instead.",
+  "referenceAnswer": "Cognitive load theory: big bang training overloads working memory with unfamiliar interface, new workflows, and changed social norms simultaneously. Intrinsic load (complexity of the system) plus extraneous load (poor training design) exceeds working memory capacity — producing surface compliance without genuine schema formation. Germane load (actual learning) is crowded out. Change management (Kotter / ADKAR): resistance is highest when people lack competence confidence. Training must follow the awareness–desire–knowledge sequence; knowledge (skill) training is most effective after desire is established. Synthesis argument: phase training by role, start with high-relevance workflows only, use worked examples (reduces extraneous load), and build in spaced practice across weeks rather than days. Combine with early wins communication (change management) to sustain desire through the learning curve.",
+  "bloomLevel": 6,
+  "difficultyEstimate": 9,
+  "relatedConceptIds": ["uuid-change-management-kotter"],
+  "sourceNotePath": "concepts/cognitive-load-theory.md"
+}
+```
+
+---
+
+### 3.8 `socratic` — Bloom's L4–L6
+
+A guided question sequence that progressively probes deeper assumptions. The `prompt` contains 3–5 questions in order, from surface to assumption-level. The `referenceAnswer` gives the expected direction of reasoning at each step, not a definitive answer.
+
+**Worked example (Knowledge Management domain):**
+
+```json
+{
+  "activityType": "socratic",
+  "prompt": "Work through this question sequence in order:\n1. What does an organisation gain by converting tacit knowledge to explicit knowledge?\n2. What is necessarily lost in that conversion?\n3. If codification always loses something, under what conditions is it still worth doing?\n4. What does this imply about the limits of a knowledge management system that relies entirely on documentation?",
+  "referenceAnswer": "1. Gains: scalability, transferability, persistence beyond individuals, auditability. 2. Losses: context-dependence, embodied skill, nuance, the 'knowing-how' that resists description (Polanyi: 'we know more than we can tell'). 3. Worth doing when: knowledge needs to reach people who can't access the expert, when the context is stable enough that codified knowledge remains valid, when the cost of tacit transfer (apprenticeship, co-location) exceeds the cost of codification loss. 4. Implication: documentation-only KM systems will fail for dynamic, complex, or practice-dependent knowledge domains — they capture the skeleton but not the muscle. Communities of practice, mentoring, and rotation programmes are required complements.",
+  "bloomLevel": 5,
+  "difficultyEstimate": 8,
+  "sourceNotePath": "concepts/tacit-knowledge.md"
+}
+```
+
+---
+
+## 4. Quality Rules (Wozniak + Matuschak)
+
+Apply these rules to every activity before including it in the output.
+
+### 4.1 Minimum Information Principle (Wozniak)
+
+Each activity tests **one thing**. If you find yourself writing a compound question ("What is X and why does Y?"), split it.
+
+For `card_review` specifically: if the `referenceAnswer` exceeds **15 words**, the card is too broad. Split into two or more cards covering distinct sub-facts.
+
+### 4.2 Five Attributes of Good Prompts (Matuschak)
+
+- **Focused:** tests one specific idea, not a cluster
+- **Precise:** unambiguous wording — the student should not be uncertain what is being asked
+- **Consistent:** the same student, on the same day, should always give the same answer
+- **Tractable:** a student who genuinely understands the concept can answer correctly
+- **Effortful:** a student who does not understand cannot guess correctly
+
+### 4.3 Source Traceability
+
+Always set `sourceNotePath` to the exact vault-relative path provided in the prompt (e.g. `concepts/cognitive-load-theory.md`). Never invent a path. Never leave this field empty.
+
+---
+
+## 5. Anti-Pattern Checklist — NEVER Generate These
+
+Before writing each activity, verify it does not match any of the following patterns. If it does, rewrite or discard it.
+
+| Anti-pattern | Why it fails |
+|---|---|
+| Yes/no question ("Does Nonaka's model include a tacit phase?") | 50% guessable by chance; no retrieval effort required |
+| "List all X" prompts ("List all six SECI phases") | Sets are nearly impossible to memorize atomically — the student rehearses the set, not individual items. Break into one item per card. |
+| Copy-paste from source | Encourages pattern matching against exact phrasing rather than comprehension |
+| Answer keywords appear in the question | The question telegraphs the answer ("The _____ effect in cognitive load theory refers to...") |
+| Single activity per concept | Always generate at least 2 activities per concept from different angles — a concept tested from only one angle has not been learned, only recognized |
+| Referencing other activities ("As in the previous question...") | Each activity must be independently answerable |
+| Bloom's mismatch | A `card_review` at L5, or a `synthesis` at L1 — match the type to its specified Bloom's range |
+
+---
+
+## 6. Common Mistakes — Bad Examples and Why They Fail
+
+**Bad 1: Yes/no question**
+```
+Prompt: "Is cognitive load theory relevant to instructional design?"
+Answer: "Yes."
+```
+Why it fails: 50% guessable. Produces no retrieval effort. Teaches nothing. Rewrite as: "How does cognitive load theory inform the sequencing of worked examples in instructional design?"
+
+---
+
+**Bad 2: Set memorization**
+```
+Prompt: "List all four VUCA dimensions."
+Answer: "Volatility, Uncertainty, Complexity, Ambiguity."
+```
+Why it fails: Four-item set is memorized as a chunk, not as four distinct concepts. If one item is forgotten, the whole answer is wrong. Rewrite as four separate cards, one per dimension, each asking for a definition or application.
+
+---
+
+**Bad 3: Answer keyword in question**
+```
+Prompt: "The split-attention effect increases _____ cognitive load."
+Answer: "extraneous"
+```
+Why it fails: The question names the effect; students familiar with the term can guess "extraneous" without understanding what split-attention is. Rewrite to test from the mechanism: "What type of cognitive load is increased when a diagram and its explanatory text are physically separated on the page?"
+
+---
+
+**Bad 4: Compound question treated as one card**
+```
+Prompt: "What is tacit knowledge and why is it difficult to transfer?"
+Answer: "Knowledge that cannot be easily articulated or documented. It is difficult to transfer because it is embodied and context-dependent."
+```
+Why it fails: Two separate concepts crammed into one card. The student can recall one half and forget the other and still feel they answered. Split: Card 1: "What is tacit knowledge?" / Card 2: "Why is tacit knowledge difficult to transfer between people?"
+
+---
+
+**Bad 5: Overly vague synthesis prompt**
+```
+Prompt: "How do the concepts in this topic relate to each other?"
+Answer: "They all contribute to knowledge management."
+```
+Why it fails: Not tractable (no student could answer correctly without being told what "relate" means in this context), not precise, not consistent. A synthesis prompt must name the concepts and the dimension of integration explicitly.
+
+---
+
+## 7. Bloom's Level Generation Guidelines
+
+Use these to calibrate your output to the target Bloom's level provided in the prompt.
+
+### L1–L2 (Remember / Understand) — Recommended mix
+
+- 3–5 `card_review` items (basic, cloze, reversed)
+- 2 `elaboration` prompts ("Why does...?")
+- Avoid: `synthesis`, `socratic`, `case_analysis` at this level
+
+### L3–L4 (Apply / Analyze) — Recommended mix
+
+- 2–3 `self_explain` prompts (Feynman)
+- 1–2 `concept_map` tasks
+- 1 `comparison` (if a related concept is available)
+- 1 `case_analysis` (application-level scenario)
+- You may include 1–2 `card_review` if foundational facts need reinforcement
+
+### L5–L6 (Evaluate / Create) — Recommended mix
+
+- 1–2 `synthesis` prompts (requires `relatedConceptIds`)
+- 1 `socratic` sequence
+- 1 `case_analysis` (evaluative or creative scenario)
+- 1 `comparison` (structural or evaluative dimension)
+
+These are guidelines, not rigid rules. Adjust based on the content of the vault note. Some concepts have no natural comparison target — in that case, substitute with an additional `case_analysis` or `socratic`.
+
+---
+
+## 8. Generation Strategy
+
+Follow this sequence when generating activities:
+
+1. **Read the vault note fully** before generating any activities.
+
+2. **Identify the key concepts** within the note — typically 3–7 discrete ideas, definitions, mechanisms, or claims. Write these out mentally before generating.
+
+3. **Identify relationships** — what connects the key concepts to each other, and to other known concepts?
+
+4. **Identify critical details** — what specific facts, distinctions, or mechanisms are most likely to be misunderstood or forgotten?
+
+5. **Map to Bloom's level** — for each key concept and relationship, determine which activity type best tests understanding at the target level.
+
+6. **Generate activities** — one at a time, checking each against the anti-pattern list before committing it.
+
+7. **Vary vocabulary** — do not reuse the exact phrasing from the source material in the `prompt`. Paraphrase, reframe, or approach from a different angle. This forces semantic retrieval, not pattern matching.
+
+8. **Verify coverage** — every key concept identified in step 2 should be covered by at least one activity. No concept should appear in only one activity if it is central to the note.
+
+---
+
+## 9. Writing the Output File
+
+1. Determine the current Unix timestamp in milliseconds.
+2. Write the JSON to `/workspace/ipc/tasks/activities-{timestamp}.json`.
+3. Do not print the JSON to stdout.
+4. Do not add any explanation, commentary, or confirmation message.
+5. Exit after writing the file.
+
+The IPC watcher on the host will pick up the file automatically. Your job is complete when the file is written.

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -11,6 +11,14 @@ import { AvailableGroup } from './container-runner.js';
 import { createTask, deleteTask, getTaskById, updateTask } from './db.js';
 import { isValidGroupFolder, resolveGroupFolderPath } from './group-folder.js';
 import { logger } from './logger.js';
+import {
+  getConceptById,
+  batchCreateActivities,
+  createActivityConceptLinks,
+  type NewLearningActivity,
+} from './study/queries.js';
+import { computeDueDate } from './study/sm2.js';
+import type { GeneratedActivity, ActivityType } from './study/types.js';
 import { RegisteredGroup } from './types.js';
 
 const execFileAsync = promisify(execFile);
@@ -281,6 +289,9 @@ export async function processTaskIpc(
     trigger?: string;
     requiresTrigger?: boolean;
     containerConfig?: RegisteredGroup['containerConfig'];
+    // For study_generated_activities
+    conceptId?: string;
+    activities?: GeneratedActivity[];
   },
   sourceGroup: string, // Verified identity from IPC directory
   isMain: boolean, // Verified from directory path
@@ -569,6 +580,120 @@ export async function processTaskIpc(
         );
       }
       break;
+
+    case 'study_generated_activities': {
+      const VALID_ACTIVITY_TYPES: Set<string> = new Set<ActivityType>([
+        'card_review',
+        'elaboration',
+        'self_explain',
+        'concept_map',
+        'comparison',
+        'case_analysis',
+        'synthesis',
+        'socratic',
+      ]);
+
+      if (!data.conceptId) {
+        logger.error(
+          { sourceGroup },
+          'study_generated_activities: missing conceptId',
+        );
+        break;
+      }
+
+      const concept = getConceptById(data.conceptId);
+      if (!concept) {
+        logger.error(
+          { conceptId: data.conceptId, sourceGroup },
+          'study_generated_activities: concept not found in DB',
+        );
+        break;
+      }
+
+      const incoming = data.activities ?? [];
+      const validActivities: NewLearningActivity[] = [];
+      // Parallel array: relatedConceptIds for each entry in validActivities
+      const relatedConceptIdsPerActivity: (string[] | undefined)[] = [];
+      let skipped = 0;
+
+      for (const activity of incoming) {
+        // Validate required fields
+        if (
+          !activity.activityType ||
+          !activity.prompt ||
+          !activity.referenceAnswer ||
+          activity.bloomLevel === undefined ||
+          activity.bloomLevel === null
+        ) {
+          logger.warn(
+            { activity, conceptId: data.conceptId },
+            'study_generated_activities: skipping activity with missing required fields',
+          );
+          skipped++;
+          continue;
+        }
+
+        // Validate activityType
+        if (!VALID_ACTIVITY_TYPES.has(activity.activityType)) {
+          logger.warn(
+            { activityType: activity.activityType, conceptId: data.conceptId },
+            'study_generated_activities: skipping activity with unknown activityType',
+          );
+          skipped++;
+          continue;
+        }
+
+        // Validate bloomLevel is 1–6
+        const bloom = activity.bloomLevel;
+        if (!Number.isInteger(bloom) || bloom < 1 || bloom > 6) {
+          logger.warn(
+            { bloomLevel: bloom, conceptId: data.conceptId },
+            'study_generated_activities: skipping activity with invalid bloomLevel',
+          );
+          skipped++;
+          continue;
+        }
+
+        validActivities.push({
+          id: crypto.randomUUID(),
+          conceptId: data.conceptId,
+          activityType: activity.activityType,
+          prompt: activity.prompt,
+          referenceAnswer: activity.referenceAnswer,
+          bloomLevel: activity.bloomLevel,
+          difficultyEstimate: activity.difficultyEstimate ?? 5,
+          cardType: activity.cardType ?? null,
+          sourceNotePath: activity.sourceNotePath ?? null,
+          sourceChunkHash: activity.sourceChunkHash ?? null,
+          generatedAt: new Date().toISOString(),
+          author: 'system',
+          easeFactor: 2.5,
+          intervalDays: 1,
+          repetitions: 0,
+          dueAt: computeDueDate(1),
+          masteryState: 'new',
+        });
+        relatedConceptIdsPerActivity.push(activity.relatedConceptIds);
+      }
+
+      batchCreateActivities(validActivities);
+
+      // Create concept links for activities that reference related concepts
+      for (let idx = 0; idx < validActivities.length; idx++) {
+        const relatedIds = relatedConceptIdsPerActivity[idx];
+        if (relatedIds && relatedIds.length > 0) {
+          createActivityConceptLinks(
+            validActivities[idx].id as string,
+            relatedIds,
+          );
+        }
+      }
+
+      logger.info(
+        `IPC: inserted ${validActivities.length} activities for concept ${data.conceptId} (${skipped} skipped)`,
+      );
+      break;
+    }
 
     default:
       logger.warn({ type: data.type }, 'Unknown IPC task type');

--- a/src/study/concept-discovery.test.ts
+++ b/src/study/concept-discovery.test.ts
@@ -123,7 +123,11 @@ describe('discoverConcepts', () => {
   it('handles multiple paths with mixed types and returns only concepts', () => {
     writeFileSync(
       join(vaultDir, 'concepts', 'alpha.md'),
-      makeFrontmatter({ title: 'Alpha Concept', type: 'concept', domain: 'math' }),
+      makeFrontmatter({
+        title: 'Alpha Concept',
+        type: 'concept',
+        domain: 'math',
+      }),
     );
     writeFileSync(
       join(vaultDir, 'concepts', 'beta.md'),

--- a/src/study/concept-discovery.ts
+++ b/src/study/concept-discovery.ts
@@ -42,12 +42,10 @@ export function discoverConcepts(
     if (typeof title !== 'string' || title.trim() === '') continue;
 
     // 5. Map optional fields — fall back to null
-    const domain =
-      typeof data['domain'] === 'string' ? data['domain'] : null;
+    const domain = typeof data['domain'] === 'string' ? data['domain'] : null;
     const subdomain =
       typeof data['subdomain'] === 'string' ? data['subdomain'] : null;
-    const course =
-      typeof data['course'] === 'string' ? data['course'] : null;
+    const course = typeof data['course'] === 'string' ? data['course'] : null;
 
     results.push({
       id: randomUUID(),

--- a/src/study/engine.test.ts
+++ b/src/study/engine.test.ts
@@ -1,0 +1,583 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { _initTestDatabase, _closeDatabase } from '../db/index.js';
+import {
+  createConcept,
+  createActivity,
+  createActivityLogEntry,
+  type NewConcept,
+  type NewLearningActivity,
+  type NewActivityLogEntry,
+} from './queries.js';
+import {
+  getConceptRecommendations,
+  checkForAdvancement,
+  processCompletion,
+  getDeEscalationAdvice,
+  getSynthesisOpportunities,
+} from './engine.js';
+
+// ============================================================
+// Shared fixtures
+// ============================================================
+
+const NOW = '2026-04-15T12:00:00.000Z';
+const TODAY = '2026-04-15';
+
+function makeConcept(overrides: Partial<NewConcept> = {}): NewConcept {
+  return {
+    id: 'concept-1',
+    title: 'Test Concept',
+    createdAt: NOW,
+    status: 'active',
+    ...overrides,
+  };
+}
+
+function makeActivity(
+  overrides: Partial<NewLearningActivity> = {},
+): NewLearningActivity {
+  return {
+    id: 'activity-1',
+    conceptId: 'concept-1',
+    activityType: 'card_review',
+    prompt: 'What is test?',
+    bloomLevel: 1,
+    generatedAt: NOW,
+    dueAt: TODAY,
+    ...overrides,
+  };
+}
+
+function makeLog(
+  overrides: Partial<NewActivityLogEntry> = {},
+): NewActivityLogEntry {
+  return {
+    id: 'log-1',
+    activityId: 'activity-1',
+    conceptId: 'concept-1',
+    activityType: 'card_review',
+    bloomLevel: 1,
+    quality: 5,
+    reviewedAt: NOW,
+    ...overrides,
+  };
+}
+
+// Helper: seed N log entries with the given quality at a bloom level
+// to build up mastery evidence. Evidence = (quality/5) * decay per entry.
+// For ceiling to reach `level`, each level L1..level needs evidence >= 7.0
+// => 8 entries at quality=5 today gives 8.0 >= 7.0
+function seedMasteryLogs(
+  conceptId: string,
+  activityId: string,
+  bloomLevel: number,
+  count: number,
+  quality = 5,
+): void {
+  for (let i = 0; i < count; i++) {
+    createActivityLogEntry(
+      makeLog({
+        id: `log-seed-${conceptId}-l${bloomLevel}-${i}`,
+        activityId,
+        conceptId,
+        bloomLevel,
+        quality,
+        reviewedAt: NOW,
+      }),
+    );
+  }
+}
+
+// ============================================================
+// getConceptRecommendations
+// ============================================================
+
+describe('getConceptRecommendations', () => {
+  beforeEach(() => _initTestDatabase());
+  afterEach(() => _closeDatabase());
+
+  it('throws when concept is not found', () => {
+    expect(() => getConceptRecommendations('does-not-exist')).toThrow();
+  });
+
+  it('bloomCeiling=0 (fresh): returns L1 card_review (count 3–5) + L2 elaboration (count 2)', () => {
+    createConcept(makeConcept({ bloomCeiling: 0 }));
+    const recs = getConceptRecommendations('concept-1');
+
+    const cardRec = recs.find((r) => r.activityType === 'card_review');
+    const elaborationRec = recs.find((r) => r.activityType === 'elaboration');
+
+    expect(cardRec).toBeDefined();
+    expect(cardRec!.bloomLevel).toBe(1);
+    expect(cardRec!.count).toBeGreaterThanOrEqual(3);
+    expect(cardRec!.count).toBeLessThanOrEqual(5);
+
+    expect(elaborationRec).toBeDefined();
+    expect(elaborationRec!.bloomLevel).toBe(2);
+    expect(elaborationRec!.count).toBe(2);
+  });
+
+  it('bloomCeiling=2 (still low): returns L1 card_review + L2 elaboration', () => {
+    createConcept(makeConcept({ bloomCeiling: 2 }));
+    const recs = getConceptRecommendations('concept-1');
+
+    expect(recs.find((r) => r.activityType === 'card_review')).toBeDefined();
+    expect(recs.find((r) => r.activityType === 'elaboration')).toBeDefined();
+    expect(recs.find((r) => r.activityType === 'synthesis')).toBeUndefined();
+  });
+
+  it('bloomCeiling=3: returns L3–L4 recommendations (self_explain, concept_map, comparison, case_analysis)', () => {
+    createConcept(makeConcept({ bloomCeiling: 3 }));
+    const recs = getConceptRecommendations('concept-1');
+
+    const types = recs.map((r) => r.activityType);
+    expect(types).toContain('self_explain');
+    expect(types).toContain('concept_map');
+    expect(types).toContain('comparison');
+    expect(types).toContain('case_analysis');
+
+    // All count 1
+    for (const r of recs) {
+      expect(r.count).toBe(1);
+    }
+
+    // Levels are 3 or 4
+    for (const r of recs) {
+      expect([3, 4]).toContain(r.bloomLevel);
+    }
+
+    // No low-level or high-level types
+    expect(types).not.toContain('card_review');
+    expect(types).not.toContain('synthesis');
+  });
+
+  it('bloomCeiling=4: returns L3–L4 recommendations', () => {
+    createConcept(makeConcept({ bloomCeiling: 4 }));
+    const recs = getConceptRecommendations('concept-1');
+    const types = recs.map((r) => r.activityType);
+    expect(types).toContain('self_explain');
+    expect(types).toContain('concept_map');
+    expect(types).not.toContain('synthesis');
+  });
+
+  it('bloomCeiling=5: returns L5–L6 recommendations (synthesis, socratic, case_analysis)', () => {
+    createConcept(makeConcept({ bloomCeiling: 5 }));
+    const recs = getConceptRecommendations('concept-1');
+
+    const types = recs.map((r) => r.activityType);
+    expect(types).toContain('synthesis');
+    expect(types).toContain('socratic');
+    expect(types).toContain('case_analysis');
+
+    for (const r of recs) {
+      expect(r.count).toBe(1);
+    }
+
+    // No low-level types
+    expect(types).not.toContain('card_review');
+    expect(types).not.toContain('elaboration');
+  });
+
+  it('bloomCeiling=6: returns L5–L6 recommendations', () => {
+    createConcept(makeConcept({ bloomCeiling: 6 }));
+    const recs = getConceptRecommendations('concept-1');
+    const types = recs.map((r) => r.activityType);
+    expect(types).toContain('synthesis');
+    expect(types).toContain('socratic');
+  });
+});
+
+// ============================================================
+// checkForAdvancement
+// ============================================================
+
+describe('checkForAdvancement', () => {
+  beforeEach(() => _initTestDatabase());
+  afterEach(() => _closeDatabase());
+
+  it('returns null when concept has insufficient mastery evidence', () => {
+    createConcept(makeConcept({ bloomCeiling: 0 }));
+    createActivity(makeActivity());
+    // Only 2 logs at L1 — not enough evidence (need >= 7.0, 2 * 1.0 = 2.0)
+    seedMasteryLogs('concept-1', 'activity-1', 1, 2, 5);
+
+    const result = checkForAdvancement('concept-1');
+    expect(result).toBeNull();
+  });
+
+  it('returns BloomAdvancement with generationNeeded=true when mastery sufficient and no activities at new level', () => {
+    // Setup: concept-1 has no LearningActivity rows. Logs are seeded using an activity
+    // that belongs to a helper concept (activityId FK is to learningActivities table,
+    // but conceptId in log is what getLogsByConceptAndLevel uses for grouping).
+    createConcept(makeConcept({ id: 'concept-1', bloomCeiling: 0 }));
+    createConcept(
+      makeConcept({
+        id: 'helper',
+        title: 'Helper',
+        bloomCeiling: 0,
+        createdAt: NOW,
+      }),
+    );
+    createActivity(
+      makeActivity({
+        id: 'activity-helper',
+        conceptId: 'helper',
+        bloomLevel: 1,
+      }),
+    );
+
+    // Insert 8 logs attributed to concept-1 but using activity-helper's id for FK
+    for (let i = 0; i < 8; i++) {
+      createActivityLogEntry(
+        makeLog({
+          id: `log-gen-${i}`,
+          activityId: 'activity-helper',
+          conceptId: 'concept-1',
+          bloomLevel: 1,
+          quality: 5,
+          reviewedAt: NOW,
+        }),
+      );
+    }
+
+    const result = checkForAdvancement('concept-1');
+    expect(result).not.toBeNull();
+    expect(result!.conceptId).toBe('concept-1');
+    expect(result!.previousCeiling).toBe(0);
+    expect(result!.newCeiling).toBe(1);
+    // concept-1 has NO LearningActivity rows, so generationNeeded=true
+    expect(result!.generationNeeded).toBe(true);
+  });
+
+  it('returns BloomAdvancement with generationNeeded=false when activities already exist at new level', () => {
+    createConcept(makeConcept({ bloomCeiling: 0 }));
+    createActivity(makeActivity({ id: 'activity-1', bloomLevel: 1 }));
+    // Seed enough logs for ceiling to advance to 1 — activity at L1 already exists
+    seedMasteryLogs('concept-1', 'activity-1', 1, 8, 5);
+
+    const result = checkForAdvancement('concept-1');
+    expect(result).not.toBeNull();
+    // activity-1 is at bloomLevel=1 >= newCeiling=1, so generationNeeded=false
+    expect(result!.generationNeeded).toBe(false);
+  });
+});
+
+// ============================================================
+// processCompletion
+// ============================================================
+
+describe('processCompletion', () => {
+  beforeEach(() => _initTestDatabase());
+  afterEach(() => _closeDatabase());
+
+  it('quality=5 with sufficient prior evidence: CompletionResult with advancement', () => {
+    createConcept(makeConcept({ bloomCeiling: 0 }));
+    createActivity(makeActivity({ id: 'activity-1', bloomLevel: 1 }));
+    // Seed 7 prior logs (evidence = 7.0, just at threshold), then complete the 8th via processCompletion
+    seedMasteryLogs('concept-1', 'activity-1', 1, 7, 5);
+
+    const result = processCompletion({ activityId: 'activity-1', quality: 5 });
+    expect(result.logEntryId).toBeDefined();
+    expect(typeof result.newDueAt).toBe('string');
+    expect(result.advancement).not.toBeNull();
+    expect(result.advancement!.previousCeiling).toBe(0);
+    expect(result.advancement!.newCeiling).toBeGreaterThan(0);
+    // activity-1 at bloomLevel=1 already exists, so generationNeeded=false per spec
+    expect(result.generationNeeded).toBe(false);
+    expect(result.advancement!.generationNeeded).toBe(false);
+  });
+
+  it('quality=3, no prior evidence: no advancement', () => {
+    createConcept(makeConcept({ bloomCeiling: 0 }));
+    createActivity(makeActivity({ id: 'activity-1', bloomLevel: 1 }));
+
+    const result = processCompletion({ activityId: 'activity-1', quality: 3 });
+    expect(result.advancement).toBeNull();
+    expect(result.generationNeeded).toBe(false);
+  });
+
+  it('repeated low quality: CompletionResult with deEscalation string when bloomCeiling > 1', () => {
+    // bloomCeiling > 1 is required for de-escalation advice.
+    // completeActivity recomputes bloomCeiling from all logs, so we must ensure
+    // the concept has enough L1+L2 mastery to keep bloomCeiling > 1 after completion.
+    createConcept(makeConcept({ bloomCeiling: 3 }));
+    createActivity(makeActivity({ id: 'activity-l1', bloomLevel: 1 }));
+    createActivity(makeActivity({ id: 'activity-l2', bloomLevel: 2 }));
+    createActivity(makeActivity({ id: 'activity-l3', bloomLevel: 3 }));
+
+    // Seed solid L1+L2 mastery — use NOW timestamps so decay is 1.0 and evidence
+    // stays high (8.0 >= 7.0 threshold). These will be "older" in the ordering
+    // because L3 logs below get timestamps slightly after NOW.
+    for (let i = 0; i < 8; i++) {
+      createActivityLogEntry(
+        makeLog({ id: `log-l1-${i}`, activityId: 'activity-l1', bloomLevel: 1, quality: 5, reviewedAt: NOW }),
+      );
+      createActivityLogEntry(
+        makeLog({ id: `log-l2-${i}`, activityId: 'activity-l2', bloomLevel: 2, quality: 5, reviewedAt: NOW }),
+      );
+    }
+
+    // Seed 4 prior low-quality logs at L3 with timestamps after NOW so they appear
+    // as the most recent in getRecentActivityLogs
+    for (let i = 0; i < 4; i++) {
+      createActivityLogEntry(
+        makeLog({
+          id: `log-low-${i}`,
+          activityId: 'activity-l3',
+          bloomLevel: 3,
+          quality: 1,
+          reviewedAt: `2026-04-15T13:0${i}:00.000Z`,
+        }),
+      );
+    }
+
+    // 5th completion via processCompletion with low quality (avg of last 5 = 1.0 < 2.5)
+    // After completion, bloomCeiling is recomputed: L1 evidence=8.0, L2 evidence=8.0 => ceiling=2
+    const result = processCompletion({ activityId: 'activity-l3', quality: 1 });
+    expect(result.deEscalation).not.toBeNull();
+    expect(typeof result.deEscalation).toBe('string');
+  });
+
+  it('throws when activity does not exist', () => {
+    expect(() =>
+      processCompletion({ activityId: 'no-such-activity', quality: 3 }),
+    ).toThrow();
+  });
+});
+
+// ============================================================
+// getDeEscalationAdvice
+// ============================================================
+
+describe('getDeEscalationAdvice', () => {
+  beforeEach(() => _initTestDatabase());
+  afterEach(() => _closeDatabase());
+
+  it('returns null when fewer than 3 logs exist', () => {
+    createConcept(makeConcept({ bloomCeiling: 2 }));
+    createActivity(makeActivity());
+    createActivityLogEntry(makeLog({ id: 'log-1', quality: 1 }));
+    createActivityLogEntry(makeLog({ id: 'log-2', quality: 2 }));
+
+    const result = getDeEscalationAdvice('concept-1');
+    expect(result).toBeNull();
+  });
+
+  it('returns advice string when avg quality < 2.5 and bloomCeiling > 1', () => {
+    createConcept(makeConcept({ bloomCeiling: 2 }));
+    createActivity(makeActivity());
+    for (let i = 0; i < 5; i++) {
+      createActivityLogEntry(
+        makeLog({ id: `log-low-${i}`, quality: 1, reviewedAt: NOW }),
+      );
+    }
+
+    const result = getDeEscalationAdvice('concept-1');
+    expect(result).not.toBeNull();
+    expect(typeof result).toBe('string');
+    expect(result!.length).toBeGreaterThan(0);
+  });
+
+  it('returns null when avg quality >= 2.5', () => {
+    createConcept(makeConcept({ bloomCeiling: 2 }));
+    createActivity(makeActivity());
+    for (let i = 0; i < 5; i++) {
+      createActivityLogEntry(
+        makeLog({ id: `log-high-${i}`, quality: 5, reviewedAt: NOW }),
+      );
+    }
+
+    const result = getDeEscalationAdvice('concept-1');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when bloomCeiling <= 1 even if quality is low', () => {
+    createConcept(makeConcept({ bloomCeiling: 1 }));
+    createActivity(makeActivity());
+    for (let i = 0; i < 5; i++) {
+      createActivityLogEntry(
+        makeLog({ id: `log-low-ceil1-${i}`, quality: 0, reviewedAt: NOW }),
+      );
+    }
+
+    const result = getDeEscalationAdvice('concept-1');
+    expect(result).toBeNull();
+  });
+});
+
+// ============================================================
+// getSynthesisOpportunities
+// ============================================================
+
+describe('getSynthesisOpportunities', () => {
+  beforeEach(() => _initTestDatabase());
+  afterEach(() => _closeDatabase());
+
+  it('returns empty array when no concepts are above ceiling 4', () => {
+    createConcept(
+      makeConcept({
+        id: 'c-low',
+        bloomCeiling: 3,
+        status: 'active',
+        domain: 'math',
+        subdomain: 'algebra',
+      }),
+    );
+    const result = getSynthesisOpportunities();
+    expect(result).toHaveLength(0);
+  });
+
+  it('3 concepts in same subdomain with ceiling >= 4: 1 within-subdomain opportunity', () => {
+    createConcept(
+      makeConcept({
+        id: 'c-1',
+        title: 'C1',
+        bloomCeiling: 4,
+        status: 'active',
+        domain: 'math',
+        subdomain: 'algebra',
+      }),
+    );
+    createConcept(
+      makeConcept({
+        id: 'c-2',
+        title: 'C2',
+        bloomCeiling: 5,
+        status: 'active',
+        domain: 'math',
+        subdomain: 'algebra',
+        createdAt: NOW,
+      }),
+    );
+    createConcept(
+      makeConcept({
+        id: 'c-3',
+        title: 'C3',
+        bloomCeiling: 4,
+        status: 'active',
+        domain: 'math',
+        subdomain: 'algebra',
+        createdAt: NOW,
+      }),
+    );
+
+    const result = getSynthesisOpportunities();
+    const subdomain = result.find((o) => o.type === 'within-subdomain');
+    expect(subdomain).toBeDefined();
+    expect(subdomain!.automatic).toBe(true);
+    expect(subdomain!.subdomain).toBe('algebra');
+    expect(subdomain!.concepts.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('concepts across subdomains within same domain: within-domain opportunity (automatic=true)', () => {
+    createConcept(
+      makeConcept({
+        id: 'c-1',
+        title: 'C1',
+        bloomCeiling: 4,
+        status: 'active',
+        domain: 'math',
+        subdomain: 'algebra',
+        createdAt: NOW,
+      }),
+    );
+    createConcept(
+      makeConcept({
+        id: 'c-2',
+        title: 'C2',
+        bloomCeiling: 4,
+        status: 'active',
+        domain: 'math',
+        subdomain: 'calculus',
+        createdAt: NOW,
+      }),
+    );
+
+    const result = getSynthesisOpportunities();
+    const domainOpp = result.find((o) => o.type === 'within-domain');
+    expect(domainOpp).toBeDefined();
+    expect(domainOpp!.automatic).toBe(true);
+    expect(domainOpp!.domain).toBe('math');
+  });
+
+  it('domain filter: returns only opportunities matching that domain', () => {
+    createConcept(
+      makeConcept({
+        id: 'c-math-1',
+        title: 'Math1',
+        bloomCeiling: 4,
+        status: 'active',
+        domain: 'math',
+        subdomain: 'algebra',
+        createdAt: NOW,
+      }),
+    );
+    createConcept(
+      makeConcept({
+        id: 'c-math-2',
+        title: 'Math2',
+        bloomCeiling: 4,
+        status: 'active',
+        domain: 'math',
+        subdomain: 'algebra',
+        createdAt: NOW,
+      }),
+    );
+    createConcept(
+      makeConcept({
+        id: 'c-phys-1',
+        title: 'Phys1',
+        bloomCeiling: 4,
+        status: 'active',
+        domain: 'physics',
+        subdomain: 'mechanics',
+        createdAt: NOW,
+      }),
+    );
+    createConcept(
+      makeConcept({
+        id: 'c-phys-2',
+        title: 'Phys2',
+        bloomCeiling: 4,
+        status: 'active',
+        domain: 'physics',
+        subdomain: 'mechanics',
+        createdAt: NOW,
+      }),
+    );
+
+    const result = getSynthesisOpportunities('math');
+    expect(result.every((o) => o.domain === 'math')).toBe(true);
+    expect(result.find((o) => o.domain === 'physics')).toBeUndefined();
+  });
+
+  it('cross-domain opportunity is automatic=false', () => {
+    createConcept(
+      makeConcept({
+        id: 'c-math',
+        title: 'Math',
+        bloomCeiling: 5,
+        status: 'active',
+        domain: 'math',
+        subdomain: 'algebra',
+        createdAt: NOW,
+      }),
+    );
+    createConcept(
+      makeConcept({
+        id: 'c-phys',
+        title: 'Phys',
+        bloomCeiling: 5,
+        status: 'active',
+        domain: 'physics',
+        subdomain: 'mechanics',
+        createdAt: NOW,
+      }),
+    );
+
+    const result = getSynthesisOpportunities();
+    const crossDomain = result.find((o) => o.type === 'cross-domain');
+    expect(crossDomain).toBeDefined();
+    expect(crossDomain!.automatic).toBe(false);
+  });
+});

--- a/src/study/engine.test.ts
+++ b/src/study/engine.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { _initTestDatabase, _closeDatabase } from '../db/index.js';
 import {
   createConcept,
   createActivity,
   createActivityLogEntry,
+  createStudySession,
   type NewConcept,
   type NewLearningActivity,
   type NewActivityLogEntry,
@@ -14,7 +15,14 @@ import {
   processCompletion,
   getDeEscalationAdvice,
   getSynthesisOpportunities,
+  triggerPostSessionGeneration,
 } from './engine.js';
+
+// Mock generator.js to prevent container spawning in tests
+vi.mock('./generator.js', () => ({
+  generateActivities: vi.fn().mockResolvedValue(undefined),
+  resetGenerationCycle: vi.fn(),
+}));
 
 // ============================================================
 // Shared fixtures
@@ -310,10 +318,22 @@ describe('processCompletion', () => {
     // because L3 logs below get timestamps slightly after NOW.
     for (let i = 0; i < 8; i++) {
       createActivityLogEntry(
-        makeLog({ id: `log-l1-${i}`, activityId: 'activity-l1', bloomLevel: 1, quality: 5, reviewedAt: NOW }),
+        makeLog({
+          id: `log-l1-${i}`,
+          activityId: 'activity-l1',
+          bloomLevel: 1,
+          quality: 5,
+          reviewedAt: NOW,
+        }),
       );
       createActivityLogEntry(
-        makeLog({ id: `log-l2-${i}`, activityId: 'activity-l2', bloomLevel: 2, quality: 5, reviewedAt: NOW }),
+        makeLog({
+          id: `log-l2-${i}`,
+          activityId: 'activity-l2',
+          bloomLevel: 2,
+          quality: 5,
+          reviewedAt: NOW,
+        }),
       );
     }
 
@@ -579,5 +599,184 @@ describe('getSynthesisOpportunities', () => {
     const crossDomain = result.find((o) => o.type === 'cross-domain');
     expect(crossDomain).toBeDefined();
     expect(crossDomain!.automatic).toBe(false);
+  });
+});
+
+// ============================================================
+// triggerPostSessionGeneration
+// ============================================================
+
+describe('triggerPostSessionGeneration', () => {
+  // Import mocked fns lazily after vi.mock() is hoisted
+  let generateActivitiesMock: ReturnType<typeof vi.fn>;
+  let resetGenerationCycleMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    _initTestDatabase();
+    const gen = await import('./generator.js');
+    generateActivitiesMock = gen.generateActivities as ReturnType<typeof vi.fn>;
+    resetGenerationCycleMock = gen.resetGenerationCycle as ReturnType<
+      typeof vi.fn
+    >;
+    vi.clearAllMocks();
+  });
+  afterEach(() => _closeDatabase());
+
+  // Helper: create a study session
+  function makeSession(id: string) {
+    createStudySession({
+      id,
+      startedAt: NOW,
+      sessionType: 'standard',
+    });
+  }
+
+  it('session with 2 completed activities for 1 concept that advances: generateActivities called once', async () => {
+    // Concept with no existing activities at new ceiling — generationNeeded=true
+    createConcept(makeConcept({ id: 'concept-adv', bloomCeiling: 0 }));
+
+    // Need a helper concept/activity for the FK on activityLog
+    createConcept(
+      makeConcept({ id: 'helper-adv', title: 'Helper', bloomCeiling: 0 }),
+    );
+    createActivity(
+      makeActivity({
+        id: 'act-helper-adv',
+        conceptId: 'helper-adv',
+        bloomLevel: 1,
+      }),
+    );
+
+    makeSession('session-adv');
+
+    // Seed 8 logs attributed to concept-adv with the session id
+    for (let i = 0; i < 8; i++) {
+      createActivityLogEntry(
+        makeLog({
+          id: `log-adv-${i}`,
+          activityId: 'act-helper-adv',
+          conceptId: 'concept-adv',
+          bloomLevel: 1,
+          quality: 5,
+          reviewedAt: NOW,
+          sessionId: 'session-adv',
+        }),
+      );
+    }
+
+    await triggerPostSessionGeneration('session-adv');
+
+    expect(resetGenerationCycleMock).toHaveBeenCalledOnce();
+    expect(generateActivitiesMock).toHaveBeenCalledOnce();
+    expect(generateActivitiesMock).toHaveBeenCalledWith('concept-adv', 1);
+  });
+
+  it('session with 3 concepts, none advance: generateActivities not called', async () => {
+    for (let i = 1; i <= 3; i++) {
+      createConcept(
+        makeConcept({
+          id: `concept-no-adv-${i}`,
+          title: `NoAdv ${i}`,
+          bloomCeiling: 0,
+        }),
+      );
+      createActivity(
+        makeActivity({
+          id: `act-no-adv-${i}`,
+          conceptId: `concept-no-adv-${i}`,
+          bloomLevel: 1,
+        }),
+      );
+    }
+
+    makeSession('session-no-adv');
+
+    // Only 1 log each — not enough evidence to advance
+    for (let i = 1; i <= 3; i++) {
+      createActivityLogEntry(
+        makeLog({
+          id: `log-no-adv-${i}`,
+          activityId: `act-no-adv-${i}`,
+          conceptId: `concept-no-adv-${i}`,
+          bloomLevel: 1,
+          quality: 5,
+          reviewedAt: NOW,
+          sessionId: 'session-no-adv',
+        }),
+      );
+    }
+
+    await triggerPostSessionGeneration('session-no-adv');
+
+    expect(resetGenerationCycleMock).toHaveBeenCalledOnce();
+    expect(generateActivitiesMock).not.toHaveBeenCalled();
+  });
+
+  it('generateActivities throws for 1 concept: other concepts still processed', async () => {
+    // Two advancing concepts — first will throw, second should still be called
+    for (let i = 1; i <= 2; i++) {
+      createConcept(
+        makeConcept({
+          id: `concept-throw-${i}`,
+          title: `Throw ${i}`,
+          bloomCeiling: 0,
+        }),
+      );
+      // No activity at new level, so generationNeeded=true for both
+      createConcept(
+        makeConcept({
+          id: `helper-throw-${i}`,
+          title: `HelperThrow ${i}`,
+          bloomCeiling: 0,
+        }),
+      );
+      createActivity(
+        makeActivity({
+          id: `act-helper-throw-${i}`,
+          conceptId: `helper-throw-${i}`,
+          bloomLevel: 1,
+        }),
+      );
+    }
+
+    makeSession('session-throw');
+
+    // Seed 8 logs for each concept to trigger advancement
+    for (let i = 1; i <= 2; i++) {
+      for (let j = 0; j < 8; j++) {
+        createActivityLogEntry(
+          makeLog({
+            id: `log-throw-${i}-${j}`,
+            activityId: `act-helper-throw-${i}`,
+            conceptId: `concept-throw-${i}`,
+            bloomLevel: 1,
+            quality: 5,
+            reviewedAt: NOW,
+            sessionId: 'session-throw',
+          }),
+        );
+      }
+    }
+
+    // First call throws, second succeeds
+    generateActivitiesMock
+      .mockRejectedValueOnce(new Error('generation error'))
+      .mockResolvedValueOnce(undefined);
+
+    await triggerPostSessionGeneration('session-throw');
+
+    // Both concepts should have been attempted
+    expect(generateActivitiesMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('empty session (no logs): no calls, no errors', async () => {
+    makeSession('session-empty');
+
+    await expect(
+      triggerPostSessionGeneration('session-empty'),
+    ).resolves.toBeUndefined();
+
+    expect(resetGenerationCycleMock).toHaveBeenCalledOnce();
+    expect(generateActivitiesMock).not.toHaveBeenCalled();
   });
 });

--- a/src/study/engine.ts
+++ b/src/study/engine.ts
@@ -333,7 +333,10 @@ export async function triggerPostSessionGeneration(
     if (advancement !== null && advancement.generationNeeded) {
       advanced++;
       try {
-        await generateActivities(conceptId, advancement.newCeiling as BloomLevel);
+        await generateActivities(
+          conceptId,
+          advancement.newCeiling as BloomLevel,
+        );
         queued++;
       } catch (err) {
         logger.error(

--- a/src/study/engine.ts
+++ b/src/study/engine.ts
@@ -1,0 +1,296 @@
+/**
+ * Study Engine — concept progression logic
+ *
+ * Reads DB state via query functions and returns recommendations.
+ * No container spawning, no LLM calls.
+ * All DB access goes through queries.ts — never imports getDb() directly.
+ */
+
+import {
+  getConceptById,
+  getActivitiesByConcept,
+  getActivityById,
+  getRecentActivityLogs,
+  getConceptsAboveBloomCeiling,
+  getLogsByConceptAndLevel,
+  completeActivity,
+  type CompleteActivityInput,
+} from './queries.js';
+import { computeMastery, computeBloomCeiling } from './mastery.js';
+import type {
+  BloomLevel,
+  BloomAdvancement,
+  ActivityRecommendation,
+  CompletionResult,
+  SynthesisOpportunity,
+} from './types.js';
+
+// ====================================================================
+// getConceptRecommendations
+// ====================================================================
+
+/**
+ * Returns recommended activities for a concept based on its bloomCeiling.
+ *
+ * bloomCeiling < 3  → card_review (L1, count 3–5) + elaboration (L2, count 2)
+ * bloomCeiling 3–4  → self_explain/concept_map (L3) + comparison/case_analysis (L4), count 1 each
+ * bloomCeiling >= 5 → synthesis (L5) + socratic (L6) + case_analysis (L5), count 1 each
+ */
+export function getConceptRecommendations(
+  conceptId: string,
+): ActivityRecommendation[] {
+  const concept = getConceptById(conceptId);
+  if (!concept) throw new Error(`Concept not found: ${conceptId}`);
+
+  const ceiling = concept.bloomCeiling ?? 0;
+
+  if (ceiling < 3) {
+    return [
+      { activityType: 'card_review', bloomLevel: 1 as BloomLevel, count: 4 },
+      { activityType: 'elaboration', bloomLevel: 2 as BloomLevel, count: 2 },
+    ];
+  }
+
+  if (ceiling <= 4) {
+    return [
+      { activityType: 'self_explain', bloomLevel: 3 as BloomLevel, count: 1 },
+      { activityType: 'concept_map', bloomLevel: 3 as BloomLevel, count: 1 },
+      { activityType: 'comparison', bloomLevel: 4 as BloomLevel, count: 1 },
+      { activityType: 'case_analysis', bloomLevel: 4 as BloomLevel, count: 1 },
+    ];
+  }
+
+  // ceiling >= 5
+  return [
+    { activityType: 'synthesis', bloomLevel: 5 as BloomLevel, count: 1 },
+    { activityType: 'socratic', bloomLevel: 6 as BloomLevel, count: 1 },
+    { activityType: 'case_analysis', bloomLevel: 5 as BloomLevel, count: 1 },
+  ];
+}
+
+// ====================================================================
+// checkForAdvancement
+// ====================================================================
+
+/**
+ * Standalone utility: checks whether a concept has earned enough mastery
+ * evidence to advance its bloomCeiling. Returns null if no advancement.
+ *
+ * Does NOT reuse processCompletion — this is an independent utility for
+ * external callers (e.g. dashboard, background jobs).
+ */
+export function checkForAdvancement(
+  conceptId: string,
+): BloomAdvancement | null {
+  const concept = getConceptById(conceptId);
+  if (!concept) throw new Error(`Concept not found: ${conceptId}`);
+
+  // Get ALL activity logs for this concept (no bloom level filter)
+  const logs = getLogsByConceptAndLevel(conceptId);
+
+  const masteryInput = logs.map((log) => ({
+    bloomLevel: log.bloomLevel as BloomLevel,
+    quality: log.quality,
+    reviewedAt: log.reviewedAt,
+  }));
+
+  const levels = computeMastery(masteryInput);
+  const newCeiling = computeBloomCeiling(levels);
+  const previousCeiling = concept.bloomCeiling ?? 0;
+
+  if (newCeiling <= previousCeiling) {
+    return null;
+  }
+
+  // Check if activities already exist at the new level
+  const existingActivities = getActivitiesByConcept(conceptId);
+  const generationNeeded = !existingActivities.some(
+    (a) => a.bloomLevel >= newCeiling,
+  );
+
+  return {
+    conceptId,
+    conceptTitle: concept.title,
+    previousCeiling,
+    newCeiling,
+    generationNeeded,
+  };
+}
+
+// ====================================================================
+// processCompletion
+// ====================================================================
+
+/**
+ * Completes an activity and returns the full engine-level result.
+ *
+ * Uses bloomCeilingBefore/After from completeActivity() — does NOT
+ * call checkForAdvancement() internally.
+ */
+export function processCompletion(
+  input: CompleteActivityInput,
+): CompletionResult {
+  // Look up activity first to get conceptId (throws if not found)
+  const activity = getActivityById(input.activityId);
+  if (!activity) throw new Error(`Activity not found: ${input.activityId}`);
+
+  const conceptId = activity.conceptId;
+
+  // Delegate to queries — runs full SM-2 + mastery update atomically
+  const { logEntryId, newDueAt, bloomCeilingBefore, bloomCeilingAfter } =
+    completeActivity(input);
+
+  let advancement: BloomAdvancement | null = null;
+  let generationNeeded = false;
+
+  if (bloomCeilingAfter > bloomCeilingBefore) {
+    const concept = getConceptById(conceptId);
+    const existingActivities = getActivitiesByConcept(conceptId);
+    generationNeeded = !existingActivities.some(
+      (a) => a.bloomLevel >= bloomCeilingAfter,
+    );
+
+    advancement = {
+      conceptId,
+      conceptTitle: concept?.title ?? conceptId,
+      previousCeiling: bloomCeilingBefore,
+      newCeiling: bloomCeilingAfter,
+      generationNeeded,
+    };
+  }
+
+  const deEscalation = getDeEscalationAdvice(conceptId);
+
+  return {
+    logEntryId,
+    newDueAt,
+    advancement,
+    generationNeeded,
+    deEscalation,
+  };
+}
+
+// ====================================================================
+// getDeEscalationAdvice
+// ====================================================================
+
+/**
+ * Returns a de-escalation hint if the student has been struggling.
+ *
+ * Conditions for advice:
+ * - At least 3 recent logs exist
+ * - Average quality < 2.5
+ * - Concept's bloomCeiling > 1 (there is a lower level to fall back to)
+ */
+export function getDeEscalationAdvice(conceptId: string): string | null {
+  const concept = getConceptById(conceptId);
+  if (!concept) return null;
+
+  const recentLogs = getRecentActivityLogs(conceptId, 5);
+
+  if (recentLogs.length < 3) return null;
+
+  const avgQuality =
+    recentLogs.reduce((sum, log) => sum + log.quality, 0) / recentLogs.length;
+
+  if (avgQuality < 2.5 && (concept.bloomCeiling ?? 0) > 1) {
+    return (
+      `You've been finding "${concept.title}" difficult recently ` +
+      `(average quality ${avgQuality.toFixed(1)}/5). ` +
+      `Consider reviewing foundational activities at a lower Bloom level ` +
+      `before pushing higher.`
+    );
+  }
+
+  return null;
+}
+
+// ====================================================================
+// getSynthesisOpportunities
+// ====================================================================
+
+/**
+ * Detects synthesis opportunities across concepts with bloomCeiling >= 4.
+ *
+ * Priority (highest first):
+ * 1. within-subdomain — 2+ concepts share a non-null subdomain (automatic=true)
+ * 2. within-domain    — concepts span multiple subdomains in one domain (automatic=true)
+ * 3. cross-domain     — concepts span multiple domains (automatic=false)
+ */
+export function getSynthesisOpportunities(
+  domain?: string,
+): SynthesisOpportunity[] {
+  let concepts = getConceptsAboveBloomCeiling(4);
+
+  if (domain) {
+    concepts = concepts.filter((c) => c.domain === domain);
+  }
+
+  if (concepts.length < 2) return [];
+
+  const opportunities: SynthesisOpportunity[] = [];
+  const conceptSummaries = (ids: string[]) =>
+    concepts
+      .filter((c) => ids.includes(c.id))
+      .map((c) => ({
+        id: c.id,
+        title: c.title,
+        bloomCeiling: c.bloomCeiling ?? 0,
+      }));
+
+  // 1. within-subdomain: group by domain+subdomain (non-null subdomain)
+  const subdomainGroups = new Map<string, typeof concepts>();
+  for (const c of concepts) {
+    if (c.subdomain == null) continue;
+    const key = `${c.domain ?? ''}::${c.subdomain}`;
+    if (!subdomainGroups.has(key)) subdomainGroups.set(key, []);
+    subdomainGroups.get(key)!.push(c);
+  }
+  for (const [key, group] of subdomainGroups) {
+    if (group.length < 2) continue;
+    const [domainPart, subdomainPart] = key.split('::');
+    opportunities.push({
+      type: 'within-subdomain',
+      domain: domainPart,
+      subdomain: subdomainPart,
+      concepts: conceptSummaries(group.map((c) => c.id)),
+      automatic: true,
+    });
+  }
+
+  // 2. within-domain: domains whose concepts span 2+ distinct subdomains
+  const domainGroups = new Map<string, typeof concepts>();
+  for (const c of concepts) {
+    if (c.domain == null) continue;
+    if (!domainGroups.has(c.domain)) domainGroups.set(c.domain, []);
+    domainGroups.get(c.domain)!.push(c);
+  }
+  for (const [dom, group] of domainGroups) {
+    const subdomains = new Set(group.map((c) => c.subdomain).filter(Boolean));
+    if (subdomains.size < 2) continue;
+    // Avoid duplicating a subdomain opportunity for the exact same concepts
+    opportunities.push({
+      type: 'within-domain',
+      domain: dom,
+      concepts: conceptSummaries(group.map((c) => c.id)),
+      automatic: true,
+    });
+  }
+
+  // 3. cross-domain: concepts span multiple distinct domains
+  const distinctDomains = new Set(
+    concepts.map((c) => c.domain).filter(Boolean),
+  );
+  if (distinctDomains.size >= 2) {
+    // Use the first domain as the representative domain label
+    const allDomains = [...distinctDomains];
+    opportunities.push({
+      type: 'cross-domain',
+      domain: allDomains[0]!,
+      concepts: conceptSummaries(concepts.map((c) => c.id)),
+      automatic: false,
+    });
+  }
+
+  return opportunities;
+}

--- a/src/study/engine.ts
+++ b/src/study/engine.ts
@@ -13,10 +13,12 @@ import {
   getRecentActivityLogs,
   getConceptsAboveBloomCeiling,
   getLogsByConceptAndLevel,
+  getLogsBySession,
   completeActivity,
   type CompleteActivityInput,
 } from './queries.js';
 import { computeMastery, computeBloomCeiling } from './mastery.js';
+import { generateActivities, resetGenerationCycle } from './generator.js';
 import type {
   BloomLevel,
   BloomAdvancement,
@@ -24,6 +26,7 @@ import type {
   CompletionResult,
   SynthesisOpportunity,
 } from './types.js';
+import { logger } from '../logger.js';
 
 // ====================================================================
 // getConceptRecommendations
@@ -293,4 +296,58 @@ export function getSynthesisOpportunities(
   }
 
   return opportunities;
+}
+
+// ====================================================================
+// triggerPostSessionGeneration
+// ====================================================================
+
+/**
+ * After a study session, check each touched concept for Bloom advancement
+ * and queue activity generation for any that advanced to a new level.
+ *
+ * Does NOT end the study session or update the session record.
+ */
+export async function triggerPostSessionGeneration(
+  sessionId: string,
+): Promise<void> {
+  // 1. Reset the rate-limit counter for this generation cycle
+  resetGenerationCycle();
+
+  // 2. Fetch all activity log entries for this session
+  const logs = getLogsBySession(sessionId);
+
+  // 3. Collect unique conceptIds
+  const conceptIds = [...new Set(logs.map((log) => log.conceptId))];
+
+  let checked = 0;
+  let advanced = 0;
+  let queued = 0;
+
+  // 4. Check each concept for advancement
+  for (const conceptId of conceptIds) {
+    checked++;
+    const advancement = checkForAdvancement(conceptId);
+
+    // 5. Trigger generation if advancement requires new activities
+    if (advancement !== null && advancement.generationNeeded) {
+      advanced++;
+      try {
+        await generateActivities(conceptId, advancement.newCeiling as BloomLevel);
+        queued++;
+      } catch (err) {
+        logger.error(
+          { conceptId, err },
+          'Post-session generation failed for concept — continuing',
+        );
+      }
+    } else if (advancement !== null) {
+      advanced++;
+    }
+  }
+
+  logger.info(
+    { sessionId, checked, advanced, queued },
+    `Post-session generation: ${checked} concepts checked, ${advanced} advanced, ${queued} queued for generation`,
+  );
 }

--- a/src/study/generator.test.ts
+++ b/src/study/generator.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { _initTestDatabase, _closeDatabase } from '../db/index.js';
+import { createConcept, type NewConcept } from './queries.js';
+import {
+  generateActivities,
+  resetGenerationCycle,
+  MAX_CONCEPTS_PER_CYCLE,
+} from './generator.js';
+import type { ContainerOutput } from '../container-runner.js';
+
+// ── Mock container-runner ──────────────────────────────────────────────────────
+
+vi.mock('../container-runner.js', () => ({
+  runContainerAgent: vi.fn().mockResolvedValue({
+    status: 'success',
+    result: null,
+  } satisfies ContainerOutput),
+}));
+
+// Lazy import so we can inspect the mock after it's wired up
+import { runContainerAgent } from '../container-runner.js';
+const mockRunContainer = vi.mocked(runContainerAgent);
+
+// ── Mock config to point VAULT_DIR at a temp directory ────────────────────────
+
+let vaultDir: string;
+
+vi.mock('../config.js', () => ({
+  get VAULT_DIR() {
+    return vaultDir;
+  },
+  // Provide minimal stubs for other named exports used transitively
+  GROUPS_DIR: '/tmp/groups',
+  DATA_DIR: '/tmp/data',
+  CONTAINER_IMAGE: 'test-image',
+  CONTAINER_TIMEOUT: 60000,
+  IDLE_TIMEOUT: 30000,
+  CONTAINER_MAX_OUTPUT_SIZE: 1000000,
+  ONECLI_URL: 'http://localhost:10254',
+  TIMEZONE: 'UTC',
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const NOW = '2026-04-15T12:00:00.000Z';
+
+function makeConcept(overrides: Partial<NewConcept> = {}): NewConcept {
+  return {
+    id: 'concept-1',
+    title: 'Action Research',
+    createdAt: NOW,
+    status: 'active',
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('generateActivities', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    resetGenerationCycle();
+    mockRunContainer.mockClear();
+
+    vaultDir = join(tmpdir(), `generator-test-vault-${Date.now()}`);
+    mkdirSync(join(vaultDir, 'concepts'), { recursive: true });
+  });
+
+  afterEach(() => {
+    _closeDatabase();
+    rmSync(vaultDir, { recursive: true, force: true });
+  });
+
+  it('prompt includes concept title and vault content', async () => {
+    const vaultNotePath = 'concepts/action-research.md';
+    const noteContent = '# Action Research\n\nIterative cycles of action and reflection.';
+
+    writeFileSync(join(vaultDir, vaultNotePath), noteContent);
+    createConcept(makeConcept({ vaultNotePath }));
+
+    await generateActivities('concept-1', 1);
+
+    expect(mockRunContainer).toHaveBeenCalledOnce();
+    const [, input] = mockRunContainer.mock.calls[0];
+    expect(input.prompt).toContain('Action Research');
+    expect(input.prompt).toContain(noteContent);
+  });
+
+  it('prompt includes bloom level', async () => {
+    createConcept(makeConcept());
+
+    await generateActivities('concept-1', 3);
+
+    const [, input] = mockRunContainer.mock.calls[0];
+    expect(input.prompt).toContain('L3');
+  });
+
+  it('missing vault note: generation proceeds with title only', async () => {
+    // vaultNotePath points at a file that does not exist
+    createConcept(makeConcept({ vaultNotePath: 'concepts/ghost.md' }));
+
+    await expect(generateActivities('concept-1', 2)).resolves.toBeUndefined();
+
+    expect(mockRunContainer).toHaveBeenCalledOnce();
+    const [, input] = mockRunContainer.mock.calls[0];
+    expect(input.prompt).toContain('No vault note available');
+  });
+
+  it('throws when concept is not found', async () => {
+    await expect(generateActivities('nonexistent-id', 1)).rejects.toThrow(
+      'Concept not found',
+    );
+
+    expect(mockRunContainer).not.toHaveBeenCalled();
+  });
+
+  it('throws when concept status is not active', async () => {
+    createConcept(makeConcept({ status: 'archived' }));
+
+    await expect(generateActivities('concept-1', 1)).rejects.toThrow(
+      'archived',
+    );
+
+    expect(mockRunContainer).not.toHaveBeenCalled();
+  });
+
+  it('rate limit: 11th call is skipped, container called exactly 10 times', async () => {
+    // Seed 11 distinct active concepts
+    for (let i = 1; i <= 11; i++) {
+      createConcept(makeConcept({ id: `concept-${i}`, title: `Concept ${i}` }));
+    }
+
+    for (let i = 1; i <= 11; i++) {
+      await generateActivities(`concept-${i}`, 1);
+    }
+
+    expect(mockRunContainer).toHaveBeenCalledTimes(MAX_CONCEPTS_PER_CYCLE);
+  });
+
+  it('resetGenerationCycle resets the counter so generation proceeds again', async () => {
+    // Exhaust the cycle limit
+    for (let i = 1; i <= MAX_CONCEPTS_PER_CYCLE; i++) {
+      createConcept(makeConcept({ id: `concept-${i}`, title: `Concept ${i}` }));
+      await generateActivities(`concept-${i}`, 1);
+    }
+
+    expect(mockRunContainer).toHaveBeenCalledTimes(MAX_CONCEPTS_PER_CYCLE);
+    mockRunContainer.mockClear();
+
+    // Reset and try another generation — should proceed
+    resetGenerationCycle();
+    createConcept(
+      makeConcept({ id: 'concept-new', title: 'New Concept After Reset' }),
+    );
+    await generateActivities('concept-new', 1);
+
+    expect(mockRunContainer).toHaveBeenCalledOnce();
+  });
+});

--- a/src/study/generator.test.ts
+++ b/src/study/generator.test.ts
@@ -77,7 +77,8 @@ describe('generateActivities', () => {
 
   it('prompt includes concept title and vault content', async () => {
     const vaultNotePath = 'concepts/action-research.md';
-    const noteContent = '# Action Research\n\nIterative cycles of action and reflection.';
+    const noteContent =
+      '# Action Research\n\nIterative cycles of action and reflection.';
 
     writeFileSync(join(vaultDir, vaultNotePath), noteContent);
     createConcept(makeConcept({ vaultNotePath }));

--- a/src/study/generator.ts
+++ b/src/study/generator.ts
@@ -1,0 +1,154 @@
+import fs from 'fs';
+import path from 'path';
+import { ChildProcess } from 'child_process';
+
+import { VAULT_DIR } from '../config.js';
+import { runContainerAgent } from '../container-runner.js';
+import type { ContainerInput } from '../container-runner.js';
+import type { RegisteredGroup } from '../types.js';
+import { logger } from '../logger.js';
+import { getConceptById } from './queries.js';
+import type { BloomLevel } from './types.js';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const MAX_CONCEPTS_PER_CYCLE = 10;
+
+/** Activity count per bloom level band */
+const ACTIVITY_COUNT: Record<number, number> = {
+  1: 5,
+  2: 5,
+  3: 3,
+  4: 3,
+  5: 2,
+  6: 2,
+};
+
+// ── Module state ──────────────────────────────────────────────────────────────
+
+let conceptsGeneratedThisCycle = 0;
+
+// ── Exported functions ────────────────────────────────────────────────────────
+
+/**
+ * Reset the per-cycle generation counter (call at the start of each study cycle).
+ */
+export function resetGenerationCycle(): void {
+  conceptsGeneratedThisCycle = 0;
+}
+
+/**
+ * Orchestrate activity generation for a concept at a given Bloom level.
+ * Reads vault content, builds a generation prompt, and fires a container agent.
+ * Does NOT parse or insert activities — the IPC handler handles that.
+ */
+export async function generateActivities(
+  conceptId: string,
+  bloomLevel: BloomLevel,
+): Promise<void> {
+  // 1. Rate-limit check
+  if (conceptsGeneratedThisCycle >= MAX_CONCEPTS_PER_CYCLE) {
+    logger.info(
+      { conceptId, bloomLevel, conceptsGeneratedThisCycle },
+      'Generation cycle limit reached — skipping',
+    );
+    return;
+  }
+
+  // 2. Load concept
+  const concept = getConceptById(conceptId);
+  if (!concept) {
+    throw new Error(`Concept not found: ${conceptId}`);
+  }
+  if (concept.status !== 'active') {
+    throw new Error(
+      `Cannot generate activities for concept with status "${concept.status}": ${conceptId}`,
+    );
+  }
+
+  // 3. Read vault note content
+  let vaultContent: string;
+  if (concept.vaultNotePath) {
+    const fullPath = path.join(VAULT_DIR, concept.vaultNotePath);
+    if (fs.existsSync(fullPath)) {
+      vaultContent = fs.readFileSync(fullPath, 'utf-8');
+    } else {
+      logger.warn(
+        { conceptId, vaultNotePath: concept.vaultNotePath },
+        'Vault note not found — proceeding with title-only generation',
+      );
+      vaultContent = 'No vault note available — generate from title only';
+    }
+  } else {
+    vaultContent = 'No vault note available — generate from title only';
+  }
+
+  // 4. Build generation prompt
+  const activityCount = ACTIVITY_COUNT[bloomLevel] ?? 3;
+  const prompt = buildGenerationPrompt({
+    conceptId,
+    title: concept.title,
+    vaultContent,
+    bloomLevel,
+    activityCount,
+    vaultNotePath: concept.vaultNotePath ?? null,
+  });
+
+  // 5. Construct the generator group descriptor
+  const generatorGroup: RegisteredGroup = {
+    name: 'Study Generator',
+    folder: 'study-generator',
+    trigger: '',
+    added_at: new Date().toISOString(),
+    requiresTrigger: false,
+    isMain: false,
+  };
+
+  // 6. Construct container input
+  const input: ContainerInput = {
+    prompt,
+    groupFolder: 'study-generator',
+    singleTurn: true,
+    chatJid: 'internal:study-generator',
+    isMain: false,
+    ipcNamespace: 'study-generator',
+  };
+
+  // 7. Fire and forget — IPC handler processes the output asynchronously
+  const onProcess = (_proc: ChildProcess, containerName: string): void => {
+    logger.info({ conceptId, bloomLevel, containerName }, 'Generator container spawned');
+  };
+
+  void runContainerAgent(generatorGroup, input, onProcess);
+
+  // 8. Increment cycle counter
+  conceptsGeneratedThisCycle++;
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+interface PromptParams {
+  conceptId: string;
+  title: string;
+  vaultContent: string;
+  bloomLevel: BloomLevel;
+  activityCount: number;
+  vaultNotePath: string | null;
+}
+
+function buildGenerationPrompt(params: PromptParams): string {
+  const { conceptId, title, vaultContent, bloomLevel, activityCount, vaultNotePath } = params;
+  return [
+    `## Activity Generation Request`,
+    ``,
+    `**Concept ID:** ${conceptId}`,
+    `**Concept Title:** ${title}`,
+    `**Target Bloom Level:** L${bloomLevel}`,
+    `**Recommended Activity Count:** ${activityCount}`,
+    `**Source Note Path:** ${vaultNotePath ?? 'none'}`,
+    ``,
+    `## Vault Note Content`,
+    ``,
+    vaultContent,
+  ].join('\n');
+}

--- a/src/study/generator.ts
+++ b/src/study/generator.ts
@@ -116,10 +116,18 @@ export async function generateActivities(
 
   // 7. Fire and forget — IPC handler processes the output asynchronously
   const onProcess = (_proc: ChildProcess, containerName: string): void => {
-    logger.info({ conceptId, bloomLevel, containerName }, 'Generator container spawned');
+    logger.info(
+      { conceptId, bloomLevel, containerName },
+      'Generator container spawned',
+    );
   };
 
-  void runContainerAgent(generatorGroup, input, onProcess);
+  runContainerAgent(generatorGroup, input, onProcess).catch((err) => {
+    logger.error(
+      { conceptId, bloomLevel, err },
+      'Generator container dispatch failed',
+    );
+  });
 
   // 8. Increment cycle counter
   conceptsGeneratedThisCycle++;
@@ -137,7 +145,14 @@ interface PromptParams {
 }
 
 function buildGenerationPrompt(params: PromptParams): string {
-  const { conceptId, title, vaultContent, bloomLevel, activityCount, vaultNotePath } = params;
+  const {
+    conceptId,
+    title,
+    vaultContent,
+    bloomLevel,
+    activityCount,
+    vaultNotePath,
+  } = params;
   return [
     `## Activity Generation Request`,
     ``,

--- a/src/study/index.ts
+++ b/src/study/index.ts
@@ -3,3 +3,6 @@ export * from './sm2.js';
 export * from './mastery.js';
 export * from './queries.js';
 export * from './concept-discovery.js';
+export * from './engine.js';
+export * from './session-builder.js';
+export * from './generator.js';

--- a/src/study/queries.test.ts
+++ b/src/study/queries.test.ts
@@ -638,9 +638,7 @@ describe('createActivityConceptLinks', () => {
   });
 
   it('does nothing when given an empty conceptIds array', () => {
-    expect(() =>
-      createActivityConceptLinks('activity-1', []),
-    ).not.toThrow();
+    expect(() => createActivityConceptLinks('activity-1', [])).not.toThrow();
   });
 });
 
@@ -654,13 +652,28 @@ describe('getConceptsAboveBloomCeiling', () => {
 
   it('returns active concepts whose bloomCeiling meets or exceeds the threshold', () => {
     createConcept(
-      makeConcept({ id: 'c-l0', title: 'Zero', status: 'active', bloomCeiling: 0 }),
+      makeConcept({
+        id: 'c-l0',
+        title: 'Zero',
+        status: 'active',
+        bloomCeiling: 0,
+      }),
     );
     createConcept(
-      makeConcept({ id: 'c-l2', title: 'Two', status: 'active', bloomCeiling: 2 }),
+      makeConcept({
+        id: 'c-l2',
+        title: 'Two',
+        status: 'active',
+        bloomCeiling: 2,
+      }),
     );
     createConcept(
-      makeConcept({ id: 'c-l4', title: 'Four', status: 'active', bloomCeiling: 4 }),
+      makeConcept({
+        id: 'c-l4',
+        title: 'Four',
+        status: 'active',
+        bloomCeiling: 4,
+      }),
     );
 
     const result = getConceptsAboveBloomCeiling(2);
@@ -672,10 +685,20 @@ describe('getConceptsAboveBloomCeiling', () => {
 
   it('excludes non-active concepts even if bloomCeiling qualifies', () => {
     createConcept(
-      makeConcept({ id: 'c-archived', title: 'Archived', status: 'archived', bloomCeiling: 5 }),
+      makeConcept({
+        id: 'c-archived',
+        title: 'Archived',
+        status: 'archived',
+        bloomCeiling: 5,
+      }),
     );
     createConcept(
-      makeConcept({ id: 'c-pending', title: 'Pending', status: 'pending', bloomCeiling: 5 }),
+      makeConcept({
+        id: 'c-pending',
+        title: 'Pending',
+        status: 'pending',
+        bloomCeiling: 5,
+      }),
     );
 
     const result = getConceptsAboveBloomCeiling(1);
@@ -686,7 +709,12 @@ describe('getConceptsAboveBloomCeiling', () => {
 
   it('returns empty array when no concepts meet the threshold', () => {
     createConcept(
-      makeConcept({ id: 'c-low', title: 'Low', status: 'active', bloomCeiling: 1 }),
+      makeConcept({
+        id: 'c-low',
+        title: 'Low',
+        status: 'active',
+        bloomCeiling: 1,
+      }),
     );
     const result = getConceptsAboveBloomCeiling(3);
     expect(result).toHaveLength(0);
@@ -694,10 +722,20 @@ describe('getConceptsAboveBloomCeiling', () => {
 
   it('returns results ordered by title asc', () => {
     createConcept(
-      makeConcept({ id: 'c-zebra', title: 'Zebra', status: 'active', bloomCeiling: 3 }),
+      makeConcept({
+        id: 'c-zebra',
+        title: 'Zebra',
+        status: 'active',
+        bloomCeiling: 3,
+      }),
     );
     createConcept(
-      makeConcept({ id: 'c-alpha', title: 'Alpha', status: 'active', bloomCeiling: 3 }),
+      makeConcept({
+        id: 'c-alpha',
+        title: 'Alpha',
+        status: 'active',
+        bloomCeiling: 3,
+      }),
     );
 
     const result = getConceptsAboveBloomCeiling(3);

--- a/src/study/queries.test.ts
+++ b/src/study/queries.test.ts
@@ -8,13 +8,18 @@ import {
   getPendingConcepts,
   getActiveConcepts,
   updateConceptStatus,
+  getConceptsAboveBloomCeiling,
   createActivity,
   getActivityById,
   getDueActivities,
   getActivitiesByConceptAndType,
+  getActivitiesByConcept,
+  batchCreateActivities,
+  createActivityConceptLinks,
   createActivityLogEntry,
   getLogsByConceptAndLevel,
   getLogsBySession,
+  getRecentActivityLogs,
   createStudySession,
   getStudySessionById,
   updateStudySession,
@@ -477,5 +482,226 @@ describe('completeActivity', () => {
     expect(logsAfter).toHaveLength(logsBefore.length);
     expect(conceptAfter!.masteryOverall).toBe(conceptBefore!.masteryOverall);
     expect(conceptAfter!.lastActivityAt).toBe(conceptBefore!.lastActivityAt);
+  });
+});
+
+// ============================================================
+// getActivitiesByConcept
+// ============================================================
+
+describe('getActivitiesByConcept', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    createConcept(makeConcept());
+  });
+  afterEach(() => _closeDatabase());
+
+  it('returns all activities for a concept ordered by bloomLevel asc', () => {
+    createActivity(makeActivity({ id: 'a-l3', bloomLevel: 3 }));
+    createActivity(makeActivity({ id: 'a-l1', bloomLevel: 1 }));
+    createActivity(makeActivity({ id: 'a-l2', bloomLevel: 2 }));
+
+    const result = getActivitiesByConcept('concept-1');
+    expect(result).toHaveLength(3);
+    expect(result[0].bloomLevel).toBe(1);
+    expect(result[1].bloomLevel).toBe(2);
+    expect(result[2].bloomLevel).toBe(3);
+  });
+
+  it('returns empty array when concept has no activities', () => {
+    const result = getActivitiesByConcept('concept-1');
+    expect(result).toHaveLength(0);
+  });
+
+  it('does not return activities belonging to a different concept', () => {
+    createConcept(makeConcept({ id: 'concept-2', title: 'Other' }));
+    createActivity(makeActivity({ id: 'a-other', conceptId: 'concept-2' }));
+
+    const result = getActivitiesByConcept('concept-1');
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ============================================================
+// getRecentActivityLogs
+// ============================================================
+
+describe('getRecentActivityLogs', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    createConcept(makeConcept());
+    createActivity(makeActivity());
+  });
+  afterEach(() => _closeDatabase());
+
+  function makeLogEntry(
+    overrides: Partial<NewActivityLogEntry> = {},
+  ): NewActivityLogEntry {
+    return {
+      id: 'log-1',
+      activityId: 'activity-1',
+      conceptId: 'concept-1',
+      activityType: 'card_review',
+      bloomLevel: 1,
+      quality: 4,
+      reviewedAt: NOW,
+      ...overrides,
+    };
+  }
+
+  it('returns the last N logs ordered by reviewedAt desc', () => {
+    createActivityLogEntry(
+      makeLogEntry({ id: 'log-old', reviewedAt: '2026-01-01T10:00:00.000Z' }),
+    );
+    createActivityLogEntry(
+      makeLogEntry({ id: 'log-mid', reviewedAt: '2026-02-01T10:00:00.000Z' }),
+    );
+    createActivityLogEntry(
+      makeLogEntry({ id: 'log-new', reviewedAt: '2026-04-01T10:00:00.000Z' }),
+    );
+
+    const result = getRecentActivityLogs('concept-1', 2);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('log-new');
+    expect(result[1].id).toBe('log-mid');
+  });
+
+  it('returns all logs when limit exceeds the available count', () => {
+    createActivityLogEntry(makeLogEntry({ id: 'log-a' }));
+    const result = getRecentActivityLogs('concept-1', 10);
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns empty array when concept has no logs', () => {
+    const result = getRecentActivityLogs('concept-1', 5);
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ============================================================
+// batchCreateActivities
+// ============================================================
+
+describe('batchCreateActivities', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    createConcept(makeConcept());
+  });
+  afterEach(() => _closeDatabase());
+
+  it('inserts all activities in one transaction', () => {
+    batchCreateActivities([
+      makeActivity({ id: 'batch-a1', bloomLevel: 1 }),
+      makeActivity({ id: 'batch-a2', bloomLevel: 2 }),
+      makeActivity({ id: 'batch-a3', bloomLevel: 3 }),
+    ]);
+
+    expect(getActivityById('batch-a1')).toBeDefined();
+    expect(getActivityById('batch-a2')).toBeDefined();
+    expect(getActivityById('batch-a3')).toBeDefined();
+  });
+
+  it('does nothing when given an empty array', () => {
+    batchCreateActivities([]);
+    const result = getActivitiesByConcept('concept-1');
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ============================================================
+// createActivityConceptLinks
+// ============================================================
+
+describe('createActivityConceptLinks', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    createConcept(makeConcept({ id: 'concept-1', title: 'C1' }));
+    createConcept(makeConcept({ id: 'concept-2', title: 'C2' }));
+    createActivity(makeActivity({ id: 'activity-1', conceptId: 'concept-1' }));
+  });
+  afterEach(() => _closeDatabase());
+
+  it('inserts concept links for an activity with the default role', () => {
+    createActivityConceptLinks('activity-1', ['concept-2']);
+    // Verify via getActivitiesByConcept — the link row is not surfaced by
+    // existing query helpers, so we at minimum confirm no error was thrown
+    // and the function is idempotent (second call does not throw).
+    expect(() =>
+      createActivityConceptLinks('activity-1', ['concept-2']),
+    ).not.toThrow();
+  });
+
+  it('inserts links with a custom role without error', () => {
+    expect(() =>
+      createActivityConceptLinks('activity-1', ['concept-2'], 'primary'),
+    ).not.toThrow();
+  });
+
+  it('does nothing when given an empty conceptIds array', () => {
+    expect(() =>
+      createActivityConceptLinks('activity-1', []),
+    ).not.toThrow();
+  });
+});
+
+// ============================================================
+// getConceptsAboveBloomCeiling
+// ============================================================
+
+describe('getConceptsAboveBloomCeiling', () => {
+  beforeEach(() => _initTestDatabase());
+  afterEach(() => _closeDatabase());
+
+  it('returns active concepts whose bloomCeiling meets or exceeds the threshold', () => {
+    createConcept(
+      makeConcept({ id: 'c-l0', title: 'Zero', status: 'active', bloomCeiling: 0 }),
+    );
+    createConcept(
+      makeConcept({ id: 'c-l2', title: 'Two', status: 'active', bloomCeiling: 2 }),
+    );
+    createConcept(
+      makeConcept({ id: 'c-l4', title: 'Four', status: 'active', bloomCeiling: 4 }),
+    );
+
+    const result = getConceptsAboveBloomCeiling(2);
+    const ids = result.map((c) => c.id);
+    expect(ids).toContain('c-l2');
+    expect(ids).toContain('c-l4');
+    expect(ids).not.toContain('c-l0');
+  });
+
+  it('excludes non-active concepts even if bloomCeiling qualifies', () => {
+    createConcept(
+      makeConcept({ id: 'c-archived', title: 'Archived', status: 'archived', bloomCeiling: 5 }),
+    );
+    createConcept(
+      makeConcept({ id: 'c-pending', title: 'Pending', status: 'pending', bloomCeiling: 5 }),
+    );
+
+    const result = getConceptsAboveBloomCeiling(1);
+    const ids = result.map((c) => c.id);
+    expect(ids).not.toContain('c-archived');
+    expect(ids).not.toContain('c-pending');
+  });
+
+  it('returns empty array when no concepts meet the threshold', () => {
+    createConcept(
+      makeConcept({ id: 'c-low', title: 'Low', status: 'active', bloomCeiling: 1 }),
+    );
+    const result = getConceptsAboveBloomCeiling(3);
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns results ordered by title asc', () => {
+    createConcept(
+      makeConcept({ id: 'c-zebra', title: 'Zebra', status: 'active', bloomCeiling: 3 }),
+    );
+    createConcept(
+      makeConcept({ id: 'c-alpha', title: 'Alpha', status: 'active', bloomCeiling: 3 }),
+    );
+
+    const result = getConceptsAboveBloomCeiling(3);
+    expect(result[0].title).toBe('Alpha');
+    expect(result[1].title).toBe('Zebra');
   });
 });

--- a/src/study/queries.ts
+++ b/src/study/queries.ts
@@ -1,4 +1,14 @@
-import { eq, and, lte, desc, sql, isNull, asc, gte, inArray } from 'drizzle-orm';
+import {
+  eq,
+  and,
+  lte,
+  desc,
+  sql,
+  isNull,
+  asc,
+  gte,
+  inArray,
+} from 'drizzle-orm';
 
 import { getDb } from '../db/index.js';
 import * as schema from '../db/schema/index.js';
@@ -188,9 +198,7 @@ export function getActivitiesByConcept(conceptId: string): LearningActivity[] {
     .all();
 }
 
-export function batchCreateActivities(
-  activities: NewLearningActivity[],
-): void {
+export function batchCreateActivities(activities: NewLearningActivity[]): void {
   if (activities.length === 0) return;
   getDb().transaction((tx) => {
     for (const activity of activities) {

--- a/src/study/queries.ts
+++ b/src/study/queries.ts
@@ -1,4 +1,4 @@
-import { eq, and, lte, desc, sql, isNull, asc } from 'drizzle-orm';
+import { eq, and, lte, desc, sql, isNull, asc, gte, inArray } from 'drizzle-orm';
 
 import { getDb } from '../db/index.js';
 import * as schema from '../db/schema/index.js';
@@ -49,7 +49,9 @@ export function getConceptById(id: string): Concept | undefined {
     .get();
 }
 
-export function getConceptByVaultPath(vaultNotePath: string): Concept | undefined {
+export function getConceptByVaultPath(
+  vaultNotePath: string,
+): Concept | undefined {
   return getDb()
     .select()
     .from(schema.concepts)
@@ -81,6 +83,20 @@ export function getPendingConcepts(): Concept[] {
 
 export function getActiveConcepts(): Concept[] {
   return getConceptsByStatus('active');
+}
+
+export function getConceptsAboveBloomCeiling(minCeiling: number): Concept[] {
+  return getDb()
+    .select()
+    .from(schema.concepts)
+    .where(
+      and(
+        eq(schema.concepts.status, 'active'),
+        gte(schema.concepts.bloomCeiling, minCeiling),
+      ),
+    )
+    .orderBy(asc(schema.concepts.title))
+    .all();
 }
 
 export function updateConceptStatus(id: string, status: string): void {
@@ -163,6 +179,42 @@ export function getActivitiesByConceptAndType(
     .all();
 }
 
+export function getActivitiesByConcept(conceptId: string): LearningActivity[] {
+  return getDb()
+    .select()
+    .from(schema.learningActivities)
+    .where(eq(schema.learningActivities.conceptId, conceptId))
+    .orderBy(asc(schema.learningActivities.bloomLevel))
+    .all();
+}
+
+export function batchCreateActivities(
+  activities: NewLearningActivity[],
+): void {
+  if (activities.length === 0) return;
+  getDb().transaction((tx) => {
+    for (const activity of activities) {
+      tx.insert(schema.learningActivities).values(activity).run();
+    }
+  });
+}
+
+export function createActivityConceptLinks(
+  activityId: string,
+  conceptIds: string[],
+  role = 'related',
+): void {
+  if (conceptIds.length === 0) return;
+  getDb().transaction((tx) => {
+    for (const conceptId of conceptIds) {
+      tx.insert(schema.activityConcepts)
+        .values({ activityId, conceptId, role })
+        .onConflictDoNothing()
+        .run();
+    }
+  });
+}
+
 // ====================================================================
 // Activity Log
 // ====================================================================
@@ -203,6 +255,19 @@ export function getLogsBySession(sessionId: string): ActivityLogEntry[] {
     .from(schema.activityLog)
     .where(eq(schema.activityLog.sessionId, sessionId))
     .orderBy(asc(schema.activityLog.reviewedAt))
+    .all();
+}
+
+export function getRecentActivityLogs(
+  conceptId: string,
+  limit: number,
+): ActivityLogEntry[] {
+  return getDb()
+    .select()
+    .from(schema.activityLog)
+    .where(eq(schema.activityLog.conceptId, conceptId))
+    .orderBy(desc(schema.activityLog.reviewedAt))
+    .limit(limit)
     .all();
 }
 

--- a/src/study/session-builder.test.ts
+++ b/src/study/session-builder.test.ts
@@ -1,0 +1,406 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { _initTestDatabase, _closeDatabase } from '../db/index.js';
+import {
+  createConcept,
+  createActivity,
+  type NewConcept,
+  type NewLearningActivity,
+} from './queries.js';
+import { buildDailySession } from './session-builder.js';
+
+// ─── Shared fixtures ──────────────────────────────────────────────────────────
+
+const NOW = '2026-04-15T12:00:00.000Z';
+const TODAY = '2026-04-15';
+
+function makeConcept(overrides: Partial<NewConcept> = {}): NewConcept {
+  return {
+    id: 'concept-1',
+    title: 'Test Concept',
+    createdAt: NOW,
+    status: 'active',
+    ...overrides,
+  };
+}
+
+function makeActivity(
+  overrides: Partial<NewLearningActivity> = {},
+): NewLearningActivity {
+  return {
+    id: 'activity-1',
+    conceptId: 'concept-1',
+    activityType: 'card_review',
+    prompt: 'What is test?',
+    bloomLevel: 1,
+    generatedAt: NOW,
+    dueAt: TODAY,
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('buildDailySession', () => {
+  beforeEach(() => _initTestDatabase());
+  afterEach(() => _closeDatabase());
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 1. No due activities → empty composition
+  // ──────────────────────────────────────────────────────────────────────────
+  it('returns empty composition when no activities are due', async () => {
+    const result = await buildDailySession();
+    expect(result.totalActivities).toBe(0);
+    expect(result.estimatedMinutes).toBe(0);
+    expect(result.blocks).toHaveLength(0);
+    expect(result.domainsCovered).toHaveLength(0);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 2. All three blocks populated
+  // ──────────────────────────────────────────────────────────────────────────
+  it('populates new, review, and stretch blocks when activities are available', async () => {
+    // Concept ceiling < 3 for new block, ceiling 2 for review, ceiling >= 4 for stretch
+    createConcept(makeConcept({ id: 'c-new', title: 'New Concept', bloomCeiling: 2 }));
+    createConcept(makeConcept({ id: 'c-rev', title: 'Review Concept', bloomCeiling: 2 }));
+    createConcept(makeConcept({ id: 'c-str', title: 'Stretch Concept', bloomCeiling: 5 }));
+
+    // 5 new L1 activities (bloomLevel 1, concept ceiling < 3)
+    for (let i = 1; i <= 5; i++) {
+      createActivity(
+        makeActivity({ id: `new-${i}`, conceptId: 'c-new', bloomLevel: 1 }),
+      );
+    }
+    // 10 review activities (not L1-2 with ceiling < 3 — use bloomLevel 3)
+    for (let i = 1; i <= 10; i++) {
+      createActivity(
+        makeActivity({ id: `rev-${i}`, conceptId: 'c-rev', bloomLevel: 3, activityType: 'elaboration' }),
+      );
+    }
+    // 3 stretch L5 activities (bloomLevel >= 4, concept ceiling >= 4)
+    for (let i = 1; i <= 3; i++) {
+      createActivity(
+        makeActivity({ id: `str-${i}`, conceptId: 'c-str', bloomLevel: 5, activityType: 'synthesis' }),
+      );
+    }
+
+    const result = await buildDailySession({ targetActivities: 20 });
+
+    expect(result.totalActivities).toBeGreaterThan(0);
+    expect(result.blocks.length).toBeGreaterThan(0);
+
+    const newBlock = result.blocks.find((b) => b.type === 'new');
+    const reviewBlock = result.blocks.find((b) => b.type === 'review');
+    const stretchBlock = result.blocks.find((b) => b.type === 'stretch');
+
+    // New block should have some activities (up to 30% of 20 = 6, capped at 5 available)
+    expect(newBlock).toBeDefined();
+    expect(newBlock!.activities.length).toBeGreaterThan(0);
+
+    // Review block should have some activities
+    expect(reviewBlock).toBeDefined();
+    expect(reviewBlock!.activities.length).toBeGreaterThan(0);
+
+    // Stretch block should have some activities
+    expect(stretchBlock).toBeDefined();
+    expect(stretchBlock!.activities.length).toBeGreaterThan(0);
+
+    // Total should not exceed target
+    expect(result.totalActivities).toBeLessThanOrEqual(20);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 3. Only review block (no new material, no stretch)
+  // ──────────────────────────────────────────────────────────────────────────
+  it('places all activities in review block when concepts ceiling < 3 and bloomLevel not 1-2', async () => {
+    // bloomCeiling = 2, but activities at bloomLevel 3 → not "new material" eligible
+    createConcept(makeConcept({ id: 'c-rev', title: 'Review Concept', bloomCeiling: 2 }));
+
+    for (let i = 1; i <= 15; i++) {
+      createActivity(
+        makeActivity({ id: `rev-${i}`, conceptId: 'c-rev', bloomLevel: 3, activityType: 'elaboration' }),
+      );
+    }
+
+    const result = await buildDailySession({ targetActivities: 20 });
+
+    const newBlock = result.blocks.find((b) => b.type === 'new');
+    const reviewBlock = result.blocks.find((b) => b.type === 'review');
+    const stretchBlock = result.blocks.find((b) => b.type === 'stretch');
+
+    expect(newBlock?.activities ?? []).toHaveLength(0);
+    expect(stretchBlock?.activities ?? []).toHaveLength(0);
+    expect(reviewBlock).toBeDefined();
+    expect(reviewBlock!.activities.length).toBeGreaterThan(0);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 4. Domain focus filter
+  // ──────────────────────────────────────────────────────────────────────────
+  it('filters to only activities from the focused domain', async () => {
+    createConcept(makeConcept({ id: 'c-math', title: 'Math', domain: 'math', bloomCeiling: 2 }));
+    createConcept(makeConcept({ id: 'c-phys', title: 'Physics', domain: 'physics', bloomCeiling: 2 }));
+    createConcept(makeConcept({ id: 'c-bio', title: 'Biology', domain: 'biology', bloomCeiling: 2 }));
+
+    for (let i = 1; i <= 5; i++) {
+      createActivity(makeActivity({ id: `math-${i}`, conceptId: 'c-math', bloomLevel: 3 }));
+    }
+    for (let i = 1; i <= 5; i++) {
+      createActivity(makeActivity({ id: `phys-${i}`, conceptId: 'c-phys', bloomLevel: 3 }));
+    }
+    for (let i = 1; i <= 5; i++) {
+      createActivity(makeActivity({ id: `bio-${i}`, conceptId: 'c-bio', bloomLevel: 3 }));
+    }
+
+    const result = await buildDailySession({ domainFocus: 'math' });
+
+    const allActivities = result.blocks.flatMap((b) => b.activities);
+    expect(allActivities.length).toBeGreaterThan(0);
+
+    for (const act of allActivities) {
+      expect(act.domain).toBe('math');
+    }
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 5. Interleaving: no consecutive same-concept in review block
+  // ──────────────────────────────────────────────────────────────────────────
+  it('interleaves review activities so no two consecutive share the same conceptId', async () => {
+    // 5 concepts, 2 activities each = 10 total
+    for (let c = 1; c <= 5; c++) {
+      createConcept(
+        makeConcept({ id: `c-${c}`, title: `Concept ${c}`, bloomCeiling: 2 }),
+      );
+      for (let a = 1; a <= 2; a++) {
+        createActivity(
+          makeActivity({
+            id: `c${c}-a${a}`,
+            conceptId: `c-${c}`,
+            bloomLevel: 3,
+            activityType: 'elaboration',
+          }),
+        );
+      }
+    }
+
+    const result = await buildDailySession({ targetActivities: 20 });
+    const reviewBlock = result.blocks.find((b) => b.type === 'review');
+    expect(reviewBlock).toBeDefined();
+
+    const activities = reviewBlock!.activities;
+    // The first activities (before any tail stacking) should not have consecutive same-concept
+    // We check only up to the point where all concepts have been exhausted (first 5 slots at least)
+    for (let i = 1; i < Math.min(activities.length, 5); i++) {
+      expect(activities[i].conceptId).not.toBe(activities[i - 1].conceptId);
+    }
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 6. New block is grouped by domain (topic coherence)
+  // ──────────────────────────────────────────────────────────────────────────
+  it('groups new block activities by domain for topic coherence', async () => {
+    createConcept(
+      makeConcept({ id: 'c-a', title: 'Domain A Concept', domain: 'domain-a', bloomCeiling: 2 }),
+    );
+    createConcept(
+      makeConcept({ id: 'c-b', title: 'Domain B Concept', domain: 'domain-b', bloomCeiling: 2 }),
+    );
+
+    // 3 activities per domain at bloomLevel 1
+    for (let i = 1; i <= 3; i++) {
+      createActivity(
+        makeActivity({ id: `a-${i}`, conceptId: 'c-a', bloomLevel: 1 }),
+      );
+    }
+    for (let i = 1; i <= 3; i++) {
+      createActivity(
+        makeActivity({ id: `b-${i}`, conceptId: 'c-b', bloomLevel: 1 }),
+      );
+    }
+
+    const result = await buildDailySession({ targetActivities: 20 });
+    const newBlock = result.blocks.find((b) => b.type === 'new');
+    expect(newBlock).toBeDefined();
+    expect(newBlock!.activities.length).toBeGreaterThan(0);
+
+    // Verify activities are grouped: all domain-a come before all domain-b or vice versa
+    const domains = newBlock!.activities.map((a) => a.domain);
+    let lastDomain: string | null | undefined = undefined;
+    let switchCount = 0;
+    for (const d of domains) {
+      if (d !== lastDomain) {
+        if (lastDomain !== undefined) switchCount++;
+        lastDomain = d;
+      }
+    }
+    // With only 2 domains and grouped ordering, there should be at most 1 domain switch
+    expect(switchCount).toBeLessThanOrEqual(1);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 7. Stretch requires concept bloomCeiling >= 4
+  // ──────────────────────────────────────────────────────────────────────────
+  it('produces no stretch activities when all concept ceilings are below 4', async () => {
+    createConcept(makeConcept({ id: 'c-low2', title: 'Low2', bloomCeiling: 2 }));
+    createConcept(makeConcept({ id: 'c-low3', title: 'Low3', bloomCeiling: 3 }));
+
+    for (let i = 1; i <= 5; i++) {
+      createActivity(
+        makeActivity({ id: `l2-${i}`, conceptId: 'c-low2', bloomLevel: 4, activityType: 'synthesis' }),
+      );
+    }
+    for (let i = 1; i <= 5; i++) {
+      createActivity(
+        makeActivity({ id: `l3-${i}`, conceptId: 'c-low3', bloomLevel: 5, activityType: 'synthesis' }),
+      );
+    }
+
+    const result = await buildDailySession({ targetActivities: 20 });
+    const stretchBlock = result.blocks.find((b) => b.type === 'stretch');
+    expect(stretchBlock?.activities ?? []).toHaveLength(0);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 8. Target cap — session should not exceed targetActivities
+  // ──────────────────────────────────────────────────────────────────────────
+  it('caps total activities at targetActivities', async () => {
+    createConcept(makeConcept({ id: 'c-1', title: 'C1', bloomCeiling: 2 }));
+
+    for (let i = 1; i <= 30; i++) {
+      createActivity(
+        makeActivity({ id: `act-${i}`, conceptId: 'c-1', bloomLevel: 3, activityType: 'elaboration' }),
+      );
+    }
+
+    const result = await buildDailySession({ targetActivities: 15 });
+    expect(result.totalActivities).toBeLessThanOrEqual(15);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 9. Time estimate accuracy
+  // ──────────────────────────────────────────────────────────────────────────
+  it('computes correct estimatedMinutes based on activity types', async () => {
+    createConcept(makeConcept({ id: 'c-1', title: 'C1', bloomCeiling: 2 }));
+    createConcept(makeConcept({ id: 'c-2', title: 'C2', bloomCeiling: 5 }));
+
+    // 4 card_review @ 1.5 min each = 6 min
+    for (let i = 1; i <= 4; i++) {
+      createActivity(
+        makeActivity({ id: `cr-${i}`, conceptId: 'c-1', bloomLevel: 3, activityType: 'card_review' }),
+      );
+    }
+    // 2 synthesis @ 7 min each = 14 min
+    for (let i = 1; i <= 2; i++) {
+      createActivity(
+        makeActivity({ id: `syn-${i}`, conceptId: 'c-2', bloomLevel: 5, activityType: 'synthesis' }),
+      );
+    }
+
+    // Force only these activity types into the result by using a small target
+    const result = await buildDailySession({ targetActivities: 6 });
+
+    // Expected total: depends on which activities are placed, but estimate must match placed types
+    let expectedMinutes = 0;
+    for (const block of result.blocks) {
+      for (const act of block.activities) {
+        if (act.activityType === 'card_review') expectedMinutes += 1.5;
+        else if (act.activityType === 'elaboration') expectedMinutes += 3;
+        else if (
+          act.activityType === 'self_explain' ||
+          act.activityType === 'comparison' ||
+          act.activityType === 'case_analysis' ||
+          act.activityType === 'concept_map'
+        )
+          expectedMinutes += 5;
+        else if (act.activityType === 'synthesis' || act.activityType === 'socratic')
+          expectedMinutes += 7;
+      }
+    }
+
+    expect(result.estimatedMinutes).toBeCloseTo(expectedMinutes, 5);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 10. Missing concept silently skipped
+  // ──────────────────────────────────────────────────────────────────────────
+  it('silently skips activities whose concept is archived (not active)', async () => {
+    // Active concept — activities should be included
+    createConcept(makeConcept({ id: 'c-real', title: 'Real Concept', status: 'active', bloomCeiling: 2 }));
+    // Archived concept — activities for this concept should be skipped by the builder
+    createConcept(makeConcept({ id: 'c-archived', title: 'Archived Concept', status: 'archived', bloomCeiling: 2 }));
+
+    createActivity(
+      makeActivity({ id: 'act-real', conceptId: 'c-real', bloomLevel: 3 }),
+    );
+    createActivity(
+      makeActivity({ id: 'act-archived', conceptId: 'c-archived', bloomLevel: 3 }),
+    );
+
+    let result: Awaited<ReturnType<typeof buildDailySession>> | undefined;
+    await expect(async () => {
+      result = await buildDailySession();
+    }).not.toThrow();
+
+    const allActivities = result!.blocks.flatMap((b) => b.activities);
+    // Archived concept's activity is excluded
+    expect(allActivities.every((a) => a.conceptId !== 'c-archived')).toBe(true);
+    // The real activity is still included
+    expect(allActivities.some((a) => a.activityId === 'act-real')).toBe(true);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 11. Domain coverage: missing domain is swapped in
+  // ──────────────────────────────────────────────────────────────────────────
+  it('ensures all active domains with due activities are represented in the session', async () => {
+    // 3 domains
+    createConcept(makeConcept({ id: 'c-a', title: 'A', domain: 'alpha', bloomCeiling: 2 }));
+    createConcept(makeConcept({ id: 'c-b', title: 'B', domain: 'beta', bloomCeiling: 2 }));
+    createConcept(makeConcept({ id: 'c-c', title: 'C', domain: 'gamma', bloomCeiling: 2 }));
+
+    // Alpha gets many activities (will fill most of the slots)
+    for (let i = 1; i <= 15; i++) {
+      createActivity(
+        makeActivity({ id: `a-${i}`, conceptId: 'c-a', bloomLevel: 3, activityType: 'elaboration' }),
+      );
+    }
+    // Beta and gamma each have a few activities
+    for (let i = 1; i <= 3; i++) {
+      createActivity(
+        makeActivity({ id: `b-${i}`, conceptId: 'c-b', bloomLevel: 3, activityType: 'elaboration' }),
+      );
+    }
+    for (let i = 1; i <= 3; i++) {
+      createActivity(
+        makeActivity({ id: `c-${i}`, conceptId: 'c-c', bloomLevel: 3, activityType: 'elaboration' }),
+      );
+    }
+
+    const result = await buildDailySession({ targetActivities: 10 });
+    const coveredDomains = new Set(result.domainsCovered);
+
+    // All 3 domains should appear
+    expect(coveredDomains.has('alpha')).toBe(true);
+    expect(coveredDomains.has('beta')).toBe(true);
+    expect(coveredDomains.has('gamma')).toBe(true);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 12. domainsCovered reflects all placed activities
+  // ──────────────────────────────────────────────────────────────────────────
+  it('reports domainsCovered as unique domains across all placed activities', async () => {
+    createConcept(makeConcept({ id: 'c-x', title: 'X', domain: 'xdomain', bloomCeiling: 2 }));
+    createConcept(makeConcept({ id: 'c-y', title: 'Y', domain: 'ydomain', bloomCeiling: 2 }));
+
+    for (let i = 1; i <= 3; i++) {
+      createActivity(makeActivity({ id: `x-${i}`, conceptId: 'c-x', bloomLevel: 3 }));
+    }
+    for (let i = 1; i <= 3; i++) {
+      createActivity(makeActivity({ id: `y-${i}`, conceptId: 'c-y', bloomLevel: 3 }));
+    }
+
+    const result = await buildDailySession({ targetActivities: 20 });
+    expect(result.domainsCovered).toContain('xdomain');
+    expect(result.domainsCovered).toContain('ydomain');
+    // No duplicates
+    expect(result.domainsCovered.length).toBe(new Set(result.domainsCovered).size);
+  });
+});

--- a/src/study/session-builder.test.ts
+++ b/src/study/session-builder.test.ts
@@ -60,9 +60,15 @@ describe('buildDailySession', () => {
   // ──────────────────────────────────────────────────────────────────────────
   it('populates new, review, and stretch blocks when activities are available', async () => {
     // Concept ceiling < 3 for new block, ceiling 2 for review, ceiling >= 4 for stretch
-    createConcept(makeConcept({ id: 'c-new', title: 'New Concept', bloomCeiling: 2 }));
-    createConcept(makeConcept({ id: 'c-rev', title: 'Review Concept', bloomCeiling: 2 }));
-    createConcept(makeConcept({ id: 'c-str', title: 'Stretch Concept', bloomCeiling: 5 }));
+    createConcept(
+      makeConcept({ id: 'c-new', title: 'New Concept', bloomCeiling: 2 }),
+    );
+    createConcept(
+      makeConcept({ id: 'c-rev', title: 'Review Concept', bloomCeiling: 2 }),
+    );
+    createConcept(
+      makeConcept({ id: 'c-str', title: 'Stretch Concept', bloomCeiling: 5 }),
+    );
 
     // 5 new L1 activities (bloomLevel 1, concept ceiling < 3)
     for (let i = 1; i <= 5; i++) {
@@ -73,13 +79,23 @@ describe('buildDailySession', () => {
     // 10 review activities (not L1-2 with ceiling < 3 — use bloomLevel 3)
     for (let i = 1; i <= 10; i++) {
       createActivity(
-        makeActivity({ id: `rev-${i}`, conceptId: 'c-rev', bloomLevel: 3, activityType: 'elaboration' }),
+        makeActivity({
+          id: `rev-${i}`,
+          conceptId: 'c-rev',
+          bloomLevel: 3,
+          activityType: 'elaboration',
+        }),
       );
     }
     // 3 stretch L5 activities (bloomLevel >= 4, concept ceiling >= 4)
     for (let i = 1; i <= 3; i++) {
       createActivity(
-        makeActivity({ id: `str-${i}`, conceptId: 'c-str', bloomLevel: 5, activityType: 'synthesis' }),
+        makeActivity({
+          id: `str-${i}`,
+          conceptId: 'c-str',
+          bloomLevel: 5,
+          activityType: 'synthesis',
+        }),
       );
     }
 
@@ -113,11 +129,18 @@ describe('buildDailySession', () => {
   // ──────────────────────────────────────────────────────────────────────────
   it('places all activities in review block when concepts ceiling < 3 and bloomLevel not 1-2', async () => {
     // bloomCeiling = 2, but activities at bloomLevel 3 → not "new material" eligible
-    createConcept(makeConcept({ id: 'c-rev', title: 'Review Concept', bloomCeiling: 2 }));
+    createConcept(
+      makeConcept({ id: 'c-rev', title: 'Review Concept', bloomCeiling: 2 }),
+    );
 
     for (let i = 1; i <= 15; i++) {
       createActivity(
-        makeActivity({ id: `rev-${i}`, conceptId: 'c-rev', bloomLevel: 3, activityType: 'elaboration' }),
+        makeActivity({
+          id: `rev-${i}`,
+          conceptId: 'c-rev',
+          bloomLevel: 3,
+          activityType: 'elaboration',
+        }),
       );
     }
 
@@ -137,18 +160,45 @@ describe('buildDailySession', () => {
   // 4. Domain focus filter
   // ──────────────────────────────────────────────────────────────────────────
   it('filters to only activities from the focused domain', async () => {
-    createConcept(makeConcept({ id: 'c-math', title: 'Math', domain: 'math', bloomCeiling: 2 }));
-    createConcept(makeConcept({ id: 'c-phys', title: 'Physics', domain: 'physics', bloomCeiling: 2 }));
-    createConcept(makeConcept({ id: 'c-bio', title: 'Biology', domain: 'biology', bloomCeiling: 2 }));
+    createConcept(
+      makeConcept({
+        id: 'c-math',
+        title: 'Math',
+        domain: 'math',
+        bloomCeiling: 2,
+      }),
+    );
+    createConcept(
+      makeConcept({
+        id: 'c-phys',
+        title: 'Physics',
+        domain: 'physics',
+        bloomCeiling: 2,
+      }),
+    );
+    createConcept(
+      makeConcept({
+        id: 'c-bio',
+        title: 'Biology',
+        domain: 'biology',
+        bloomCeiling: 2,
+      }),
+    );
 
     for (let i = 1; i <= 5; i++) {
-      createActivity(makeActivity({ id: `math-${i}`, conceptId: 'c-math', bloomLevel: 3 }));
+      createActivity(
+        makeActivity({ id: `math-${i}`, conceptId: 'c-math', bloomLevel: 3 }),
+      );
     }
     for (let i = 1; i <= 5; i++) {
-      createActivity(makeActivity({ id: `phys-${i}`, conceptId: 'c-phys', bloomLevel: 3 }));
+      createActivity(
+        makeActivity({ id: `phys-${i}`, conceptId: 'c-phys', bloomLevel: 3 }),
+      );
     }
     for (let i = 1; i <= 5; i++) {
-      createActivity(makeActivity({ id: `bio-${i}`, conceptId: 'c-bio', bloomLevel: 3 }));
+      createActivity(
+        makeActivity({ id: `bio-${i}`, conceptId: 'c-bio', bloomLevel: 3 }),
+      );
     }
 
     const result = await buildDailySession({ domainFocus: 'math' });
@@ -199,10 +249,20 @@ describe('buildDailySession', () => {
   // ──────────────────────────────────────────────────────────────────────────
   it('groups new block activities by domain for topic coherence', async () => {
     createConcept(
-      makeConcept({ id: 'c-a', title: 'Domain A Concept', domain: 'domain-a', bloomCeiling: 2 }),
+      makeConcept({
+        id: 'c-a',
+        title: 'Domain A Concept',
+        domain: 'domain-a',
+        bloomCeiling: 2,
+      }),
     );
     createConcept(
-      makeConcept({ id: 'c-b', title: 'Domain B Concept', domain: 'domain-b', bloomCeiling: 2 }),
+      makeConcept({
+        id: 'c-b',
+        title: 'Domain B Concept',
+        domain: 'domain-b',
+        bloomCeiling: 2,
+      }),
     );
 
     // 3 activities per domain at bloomLevel 1
@@ -240,17 +300,31 @@ describe('buildDailySession', () => {
   // 7. Stretch requires concept bloomCeiling >= 4
   // ──────────────────────────────────────────────────────────────────────────
   it('produces no stretch activities when all concept ceilings are below 4', async () => {
-    createConcept(makeConcept({ id: 'c-low2', title: 'Low2', bloomCeiling: 2 }));
-    createConcept(makeConcept({ id: 'c-low3', title: 'Low3', bloomCeiling: 3 }));
+    createConcept(
+      makeConcept({ id: 'c-low2', title: 'Low2', bloomCeiling: 2 }),
+    );
+    createConcept(
+      makeConcept({ id: 'c-low3', title: 'Low3', bloomCeiling: 3 }),
+    );
 
     for (let i = 1; i <= 5; i++) {
       createActivity(
-        makeActivity({ id: `l2-${i}`, conceptId: 'c-low2', bloomLevel: 4, activityType: 'synthesis' }),
+        makeActivity({
+          id: `l2-${i}`,
+          conceptId: 'c-low2',
+          bloomLevel: 4,
+          activityType: 'synthesis',
+        }),
       );
     }
     for (let i = 1; i <= 5; i++) {
       createActivity(
-        makeActivity({ id: `l3-${i}`, conceptId: 'c-low3', bloomLevel: 5, activityType: 'synthesis' }),
+        makeActivity({
+          id: `l3-${i}`,
+          conceptId: 'c-low3',
+          bloomLevel: 5,
+          activityType: 'synthesis',
+        }),
       );
     }
 
@@ -267,7 +341,12 @@ describe('buildDailySession', () => {
 
     for (let i = 1; i <= 30; i++) {
       createActivity(
-        makeActivity({ id: `act-${i}`, conceptId: 'c-1', bloomLevel: 3, activityType: 'elaboration' }),
+        makeActivity({
+          id: `act-${i}`,
+          conceptId: 'c-1',
+          bloomLevel: 3,
+          activityType: 'elaboration',
+        }),
       );
     }
 
@@ -285,13 +364,23 @@ describe('buildDailySession', () => {
     // 4 card_review @ 1.5 min each = 6 min
     for (let i = 1; i <= 4; i++) {
       createActivity(
-        makeActivity({ id: `cr-${i}`, conceptId: 'c-1', bloomLevel: 3, activityType: 'card_review' }),
+        makeActivity({
+          id: `cr-${i}`,
+          conceptId: 'c-1',
+          bloomLevel: 3,
+          activityType: 'card_review',
+        }),
       );
     }
     // 2 synthesis @ 7 min each = 14 min
     for (let i = 1; i <= 2; i++) {
       createActivity(
-        makeActivity({ id: `syn-${i}`, conceptId: 'c-2', bloomLevel: 5, activityType: 'synthesis' }),
+        makeActivity({
+          id: `syn-${i}`,
+          conceptId: 'c-2',
+          bloomLevel: 5,
+          activityType: 'synthesis',
+        }),
       );
     }
 
@@ -311,7 +400,10 @@ describe('buildDailySession', () => {
           act.activityType === 'concept_map'
         )
           expectedMinutes += 5;
-        else if (act.activityType === 'synthesis' || act.activityType === 'socratic')
+        else if (
+          act.activityType === 'synthesis' ||
+          act.activityType === 'socratic'
+        )
           expectedMinutes += 7;
       }
     }
@@ -324,18 +416,36 @@ describe('buildDailySession', () => {
   // ──────────────────────────────────────────────────────────────────────────
   it('silently skips activities whose concept is archived (not active)', async () => {
     // Active concept — activities should be included
-    createConcept(makeConcept({ id: 'c-real', title: 'Real Concept', status: 'active', bloomCeiling: 2 }));
+    createConcept(
+      makeConcept({
+        id: 'c-real',
+        title: 'Real Concept',
+        status: 'active',
+        bloomCeiling: 2,
+      }),
+    );
     // Archived concept — activities for this concept should be skipped by the builder
-    createConcept(makeConcept({ id: 'c-archived', title: 'Archived Concept', status: 'archived', bloomCeiling: 2 }));
+    createConcept(
+      makeConcept({
+        id: 'c-archived',
+        title: 'Archived Concept',
+        status: 'archived',
+        bloomCeiling: 2,
+      }),
+    );
 
     createActivity(
       makeActivity({ id: 'act-real', conceptId: 'c-real', bloomLevel: 3 }),
     );
     createActivity(
-      makeActivity({ id: 'act-archived', conceptId: 'c-archived', bloomLevel: 3 }),
+      makeActivity({
+        id: 'act-archived',
+        conceptId: 'c-archived',
+        bloomLevel: 3,
+      }),
     );
 
-    let result: Awaited<ReturnType<typeof buildDailySession>> | undefined;
+    let result: ReturnType<typeof buildDailySession> | undefined;
     await expect(async () => {
       result = await buildDailySession();
     }).not.toThrow();
@@ -352,25 +462,46 @@ describe('buildDailySession', () => {
   // ──────────────────────────────────────────────────────────────────────────
   it('ensures all active domains with due activities are represented in the session', async () => {
     // 3 domains
-    createConcept(makeConcept({ id: 'c-a', title: 'A', domain: 'alpha', bloomCeiling: 2 }));
-    createConcept(makeConcept({ id: 'c-b', title: 'B', domain: 'beta', bloomCeiling: 2 }));
-    createConcept(makeConcept({ id: 'c-c', title: 'C', domain: 'gamma', bloomCeiling: 2 }));
+    createConcept(
+      makeConcept({ id: 'c-a', title: 'A', domain: 'alpha', bloomCeiling: 2 }),
+    );
+    createConcept(
+      makeConcept({ id: 'c-b', title: 'B', domain: 'beta', bloomCeiling: 2 }),
+    );
+    createConcept(
+      makeConcept({ id: 'c-c', title: 'C', domain: 'gamma', bloomCeiling: 2 }),
+    );
 
     // Alpha gets many activities (will fill most of the slots)
     for (let i = 1; i <= 15; i++) {
       createActivity(
-        makeActivity({ id: `a-${i}`, conceptId: 'c-a', bloomLevel: 3, activityType: 'elaboration' }),
+        makeActivity({
+          id: `a-${i}`,
+          conceptId: 'c-a',
+          bloomLevel: 3,
+          activityType: 'elaboration',
+        }),
       );
     }
     // Beta and gamma each have a few activities
     for (let i = 1; i <= 3; i++) {
       createActivity(
-        makeActivity({ id: `b-${i}`, conceptId: 'c-b', bloomLevel: 3, activityType: 'elaboration' }),
+        makeActivity({
+          id: `b-${i}`,
+          conceptId: 'c-b',
+          bloomLevel: 3,
+          activityType: 'elaboration',
+        }),
       );
     }
     for (let i = 1; i <= 3; i++) {
       createActivity(
-        makeActivity({ id: `c-${i}`, conceptId: 'c-c', bloomLevel: 3, activityType: 'elaboration' }),
+        makeActivity({
+          id: `c-${i}`,
+          conceptId: 'c-c',
+          bloomLevel: 3,
+          activityType: 'elaboration',
+        }),
       );
     }
 
@@ -387,20 +518,40 @@ describe('buildDailySession', () => {
   // 12. domainsCovered reflects all placed activities
   // ──────────────────────────────────────────────────────────────────────────
   it('reports domainsCovered as unique domains across all placed activities', async () => {
-    createConcept(makeConcept({ id: 'c-x', title: 'X', domain: 'xdomain', bloomCeiling: 2 }));
-    createConcept(makeConcept({ id: 'c-y', title: 'Y', domain: 'ydomain', bloomCeiling: 2 }));
+    createConcept(
+      makeConcept({
+        id: 'c-x',
+        title: 'X',
+        domain: 'xdomain',
+        bloomCeiling: 2,
+      }),
+    );
+    createConcept(
+      makeConcept({
+        id: 'c-y',
+        title: 'Y',
+        domain: 'ydomain',
+        bloomCeiling: 2,
+      }),
+    );
 
     for (let i = 1; i <= 3; i++) {
-      createActivity(makeActivity({ id: `x-${i}`, conceptId: 'c-x', bloomLevel: 3 }));
+      createActivity(
+        makeActivity({ id: `x-${i}`, conceptId: 'c-x', bloomLevel: 3 }),
+      );
     }
     for (let i = 1; i <= 3; i++) {
-      createActivity(makeActivity({ id: `y-${i}`, conceptId: 'c-y', bloomLevel: 3 }));
+      createActivity(
+        makeActivity({ id: `y-${i}`, conceptId: 'c-y', bloomLevel: 3 }),
+      );
     }
 
     const result = await buildDailySession({ targetActivities: 20 });
     expect(result.domainsCovered).toContain('xdomain');
     expect(result.domainsCovered).toContain('ydomain');
     // No duplicates
-    expect(result.domainsCovered.length).toBe(new Set(result.domainsCovered).size);
+    expect(result.domainsCovered.length).toBe(
+      new Set(result.domainsCovered).size,
+    );
   });
 });

--- a/src/study/session-builder.ts
+++ b/src/study/session-builder.ts
@@ -1,0 +1,245 @@
+import {
+  getDueActivities,
+  getActiveConcepts,
+  type Concept,
+  type LearningActivity,
+} from './queries.js';
+import type {
+  SessionComposition,
+  SessionBlock,
+  SessionActivity,
+  SessionOptions,
+  ActivityType,
+  BloomLevel,
+} from './types.js';
+
+// ─── Time estimates per activity type (minutes) ───────────────────────────────
+
+const MINUTES_PER_TYPE: Record<ActivityType, number> = {
+  card_review: 1.5,
+  elaboration: 3,
+  self_explain: 5,
+  comparison: 5,
+  case_analysis: 5,
+  concept_map: 5,
+  synthesis: 7,
+  socratic: 7,
+};
+
+function estimateMinutes(activityType: ActivityType): number {
+  return MINUTES_PER_TYPE[activityType] ?? 3;
+}
+
+// ─── Enrich activity into SessionActivity ─────────────────────────────────────
+
+function toSessionActivity(
+  activity: LearningActivity,
+  concept: Concept,
+): SessionActivity {
+  return {
+    activityId: activity.id,
+    conceptId: activity.conceptId,
+    conceptTitle: concept.title,
+    domain: concept.domain ?? null,
+    activityType: activity.activityType as ActivityType,
+    bloomLevel: activity.bloomLevel as BloomLevel,
+  };
+}
+
+// ─── Interleave so no two consecutive share the same conceptId ────────────────
+
+function interleaveByConceptId(activities: SessionActivity[]): SessionActivity[] {
+  const result: SessionActivity[] = [];
+  const remaining = [...activities];
+
+  while (remaining.length > 0) {
+    const prevConceptId = result.length > 0 ? result[result.length - 1].conceptId : null;
+    const idx = remaining.findIndex((a) => a.conceptId !== prevConceptId);
+    if (idx === -1) {
+      // All remaining share the same conceptId — append them (tail is acceptable)
+      result.push(...remaining.splice(0));
+    } else {
+      result.push(...remaining.splice(idx, 1));
+    }
+  }
+
+  return result;
+}
+
+// ─── Main session builder ─────────────────────────────────────────────────────
+
+export async function buildDailySession(
+  options?: SessionOptions,
+): Promise<SessionComposition> {
+  const target = options?.targetActivities ?? 20;
+
+  // 1. Fetch due activities and active concepts
+  const dueActivities = getDueActivities();
+  if (dueActivities.length === 0) {
+    return { blocks: [], totalActivities: 0, estimatedMinutes: 0, domainsCovered: [] };
+  }
+
+  const activeConcepts = getActiveConcepts();
+  const conceptMap = new Map<string, Concept>(activeConcepts.map((c) => [c.id, c]));
+
+  // 2. Enrich and filter activities
+  let enriched: Array<{ activity: LearningActivity; concept: Concept }> = [];
+  for (const activity of dueActivities) {
+    const concept = conceptMap.get(activity.conceptId);
+    if (!concept) continue; // silently skip orphaned activities
+    enriched.push({ activity, concept });
+  }
+
+  // 3. Domain focus filter
+  if (options?.domainFocus) {
+    const focus = options.domainFocus;
+    enriched = enriched.filter((e) => e.concept.domain === focus);
+  }
+
+  if (enriched.length === 0) {
+    return { blocks: [], totalActivities: 0, estimatedMinutes: 0, domainsCovered: [] };
+  }
+
+  // ─── Block targets ────────────────────────────────────────────────────────
+  const newTarget = Math.floor(target * 0.3);
+  const reviewTarget = Math.floor(target * 0.5);
+  const stretchTarget = target - newTarget - reviewTarget; // ~20%
+
+  // ─── Pre-identify stretch candidates so they aren't consumed by review ───
+  // (stretch: bloomLevel >= 4 AND concept bloomCeiling >= 4)
+  const stretchCandidateIds = new Set<string>(
+    enriched
+      .filter(
+        (e) =>
+          e.activity.bloomLevel >= 4 &&
+          (e.concept.bloomCeiling ?? 0) >= 4,
+      )
+      .slice(0, stretchTarget)
+      .map((e) => e.activity.id),
+  );
+
+  // ─── New block: L1-2 where concept bloomCeiling < 3, grouped by domain ───
+  const newCandidates = enriched.filter(
+    (e) =>
+      !stretchCandidateIds.has(e.activity.id) &&
+      (e.activity.bloomLevel === 1 || e.activity.bloomLevel === 2) &&
+      (e.concept.bloomCeiling ?? 0) < 3,
+  );
+
+  // Group by domain for topic coherence
+  const newByDomain = new Map<string | null, typeof newCandidates>();
+  for (const e of newCandidates) {
+    const domain = e.concept.domain ?? null;
+    if (!newByDomain.has(domain)) newByDomain.set(domain, []);
+    newByDomain.get(domain)!.push(e);
+  }
+
+  const newSelected: typeof newCandidates = [];
+  for (const group of newByDomain.values()) {
+    newSelected.push(...group);
+    if (newSelected.length >= newTarget) break;
+  }
+  const newActivities: SessionActivity[] = newSelected
+    .slice(0, newTarget)
+    .map((e) => toSessionActivity(e.activity, e.concept));
+
+  const placedIds = new Set(newActivities.map((a) => a.activityId));
+
+  // ─── Review block: remaining (excluding stretch candidates), sorted overdue → low easeFactor
+  const reviewCandidates = enriched.filter(
+    (e) => !placedIds.has(e.activity.id) && !stretchCandidateIds.has(e.activity.id),
+  );
+
+  // Sort: most overdue first (ascending dueAt), then lowest easeFactor
+  reviewCandidates.sort((a, b) => {
+    const dateCmp = a.activity.dueAt.localeCompare(b.activity.dueAt);
+    if (dateCmp !== 0) return dateCmp;
+    return (a.activity.easeFactor ?? 2.5) - (b.activity.easeFactor ?? 2.5);
+  });
+
+  const reviewSessions: SessionActivity[] = reviewCandidates.map((e) =>
+    toSessionActivity(e.activity, e.concept),
+  );
+
+  const interleaved = interleaveByConceptId(reviewSessions);
+  const reviewActivities = interleaved.slice(0, reviewTarget);
+
+  for (const a of reviewActivities) placedIds.add(a.activityId);
+
+  // ─── Stretch block: use the pre-identified candidates
+  const stretchActivities: SessionActivity[] = enriched
+    .filter((e) => stretchCandidateIds.has(e.activity.id))
+    .map((e) => toSessionActivity(e.activity, e.concept));
+
+  for (const a of stretchActivities) placedIds.add(a.activityId);
+
+  // ─── Domain coverage: ensure all active domains with due activities appear ─
+  // Determine domains present in due activities
+  const dueDomains = new Set<string>();
+  for (const e of enriched) {
+    if (e.concept.domain) dueDomains.add(e.concept.domain);
+  }
+
+  const coveredNow = new Set<string>();
+  for (const a of [...newActivities, ...reviewActivities, ...stretchActivities]) {
+    if (a.domain) coveredNow.add(a.domain);
+  }
+
+  // Swap in missing domains (best-effort: replace lowest-priority review activity)
+  for (const missingDomain of dueDomains) {
+    if (coveredNow.has(missingDomain)) continue;
+
+    // Find a due activity from the missing domain not yet placed
+    const candidate = enriched.find(
+      (e) => e.concept.domain === missingDomain && !placedIds.has(e.activity.id),
+    );
+    if (!candidate) continue;
+
+    // Find the last review activity to swap out (lowest priority)
+    if (reviewActivities.length > 0) {
+      const removed = reviewActivities.pop()!;
+      placedIds.delete(removed.activityId);
+      const swapIn = toSessionActivity(candidate.activity, candidate.concept);
+      reviewActivities.push(swapIn);
+      placedIds.add(swapIn.activityId);
+      coveredNow.add(missingDomain);
+    }
+  }
+
+  // ─── Fill remaining slots from pool if total < target ─────────────────────
+  const totalSoFar = newActivities.length + reviewActivities.length + stretchActivities.length;
+  const fillSlots = target - totalSoFar;
+  if (fillSlots > 0) {
+    const remaining = enriched.filter((e) => !placedIds.has(e.activity.id));
+    for (const e of remaining.slice(0, fillSlots)) {
+      reviewActivities.push(toSessionActivity(e.activity, e.concept));
+      placedIds.add(e.activity.id);
+    }
+  }
+
+  // ─── Build blocks (only non-empty) ────────────────────────────────────────
+  const blocks: SessionBlock[] = [];
+  if (newActivities.length > 0) blocks.push({ type: 'new', activities: newActivities });
+  if (reviewActivities.length > 0) blocks.push({ type: 'review', activities: reviewActivities });
+  if (stretchActivities.length > 0) blocks.push({ type: 'stretch', activities: stretchActivities });
+
+  const allPlaced = [...newActivities, ...reviewActivities, ...stretchActivities];
+
+  // ─── Estimate minutes ─────────────────────────────────────────────────────
+  const estimatedMinutes = allPlaced.reduce(
+    (sum, a) => sum + estimateMinutes(a.activityType as ActivityType),
+    0,
+  );
+
+  // ─── Unique domains covered ───────────────────────────────────────────────
+  const domainsCovered = [
+    ...new Set(allPlaced.map((a) => a.domain).filter((d): d is string => d !== null)),
+  ];
+
+  return {
+    blocks,
+    totalActivities: allPlaced.length,
+    estimatedMinutes,
+    domainsCovered,
+  };
+}

--- a/src/study/session-builder.ts
+++ b/src/study/session-builder.ts
@@ -48,12 +48,15 @@ function toSessionActivity(
 
 // ─── Interleave so no two consecutive share the same conceptId ────────────────
 
-function interleaveByConceptId(activities: SessionActivity[]): SessionActivity[] {
+function interleaveByConceptId(
+  activities: SessionActivity[],
+): SessionActivity[] {
   const result: SessionActivity[] = [];
   const remaining = [...activities];
 
   while (remaining.length > 0) {
-    const prevConceptId = result.length > 0 ? result[result.length - 1].conceptId : null;
+    const prevConceptId =
+      result.length > 0 ? result[result.length - 1].conceptId : null;
     const idx = remaining.findIndex((a) => a.conceptId !== prevConceptId);
     if (idx === -1) {
       // All remaining share the same conceptId — append them (tail is acceptable)
@@ -68,19 +71,26 @@ function interleaveByConceptId(activities: SessionActivity[]): SessionActivity[]
 
 // ─── Main session builder ─────────────────────────────────────────────────────
 
-export async function buildDailySession(
+export function buildDailySession(
   options?: SessionOptions,
-): Promise<SessionComposition> {
+): SessionComposition {
   const target = options?.targetActivities ?? 20;
 
   // 1. Fetch due activities and active concepts
   const dueActivities = getDueActivities();
   if (dueActivities.length === 0) {
-    return { blocks: [], totalActivities: 0, estimatedMinutes: 0, domainsCovered: [] };
+    return {
+      blocks: [],
+      totalActivities: 0,
+      estimatedMinutes: 0,
+      domainsCovered: [],
+    };
   }
 
   const activeConcepts = getActiveConcepts();
-  const conceptMap = new Map<string, Concept>(activeConcepts.map((c) => [c.id, c]));
+  const conceptMap = new Map<string, Concept>(
+    activeConcepts.map((c) => [c.id, c]),
+  );
 
   // 2. Enrich and filter activities
   let enriched: Array<{ activity: LearningActivity; concept: Concept }> = [];
@@ -97,7 +107,12 @@ export async function buildDailySession(
   }
 
   if (enriched.length === 0) {
-    return { blocks: [], totalActivities: 0, estimatedMinutes: 0, domainsCovered: [] };
+    return {
+      blocks: [],
+      totalActivities: 0,
+      estimatedMinutes: 0,
+      domainsCovered: [],
+    };
   }
 
   // ─── Block targets ────────────────────────────────────────────────────────
@@ -110,9 +125,7 @@ export async function buildDailySession(
   const stretchCandidateIds = new Set<string>(
     enriched
       .filter(
-        (e) =>
-          e.activity.bloomLevel >= 4 &&
-          (e.concept.bloomCeiling ?? 0) >= 4,
+        (e) => e.activity.bloomLevel >= 4 && (e.concept.bloomCeiling ?? 0) >= 4,
       )
       .slice(0, stretchTarget)
       .map((e) => e.activity.id),
@@ -147,7 +160,8 @@ export async function buildDailySession(
 
   // ─── Review block: remaining (excluding stretch candidates), sorted overdue → low easeFactor
   const reviewCandidates = enriched.filter(
-    (e) => !placedIds.has(e.activity.id) && !stretchCandidateIds.has(e.activity.id),
+    (e) =>
+      !placedIds.has(e.activity.id) && !stretchCandidateIds.has(e.activity.id),
   );
 
   // Sort: most overdue first (ascending dueAt), then lowest easeFactor
@@ -181,7 +195,11 @@ export async function buildDailySession(
   }
 
   const coveredNow = new Set<string>();
-  for (const a of [...newActivities, ...reviewActivities, ...stretchActivities]) {
+  for (const a of [
+    ...newActivities,
+    ...reviewActivities,
+    ...stretchActivities,
+  ]) {
     if (a.domain) coveredNow.add(a.domain);
   }
 
@@ -191,7 +209,8 @@ export async function buildDailySession(
 
     // Find a due activity from the missing domain not yet placed
     const candidate = enriched.find(
-      (e) => e.concept.domain === missingDomain && !placedIds.has(e.activity.id),
+      (e) =>
+        e.concept.domain === missingDomain && !placedIds.has(e.activity.id),
     );
     if (!candidate) continue;
 
@@ -207,7 +226,8 @@ export async function buildDailySession(
   }
 
   // ─── Fill remaining slots from pool if total < target ─────────────────────
-  const totalSoFar = newActivities.length + reviewActivities.length + stretchActivities.length;
+  const totalSoFar =
+    newActivities.length + reviewActivities.length + stretchActivities.length;
   const fillSlots = target - totalSoFar;
   if (fillSlots > 0) {
     const remaining = enriched.filter((e) => !placedIds.has(e.activity.id));
@@ -219,11 +239,18 @@ export async function buildDailySession(
 
   // ─── Build blocks (only non-empty) ────────────────────────────────────────
   const blocks: SessionBlock[] = [];
-  if (newActivities.length > 0) blocks.push({ type: 'new', activities: newActivities });
-  if (reviewActivities.length > 0) blocks.push({ type: 'review', activities: reviewActivities });
-  if (stretchActivities.length > 0) blocks.push({ type: 'stretch', activities: stretchActivities });
+  if (newActivities.length > 0)
+    blocks.push({ type: 'new', activities: newActivities });
+  if (reviewActivities.length > 0)
+    blocks.push({ type: 'review', activities: reviewActivities });
+  if (stretchActivities.length > 0)
+    blocks.push({ type: 'stretch', activities: stretchActivities });
 
-  const allPlaced = [...newActivities, ...reviewActivities, ...stretchActivities];
+  const allPlaced = [
+    ...newActivities,
+    ...reviewActivities,
+    ...stretchActivities,
+  ];
 
   // ─── Estimate minutes ─────────────────────────────────────────────────────
   const estimatedMinutes = allPlaced.reduce(
@@ -233,7 +260,9 @@ export async function buildDailySession(
 
   // ─── Unique domains covered ───────────────────────────────────────────────
   const domainsCovered = [
-    ...new Set(allPlaced.map((a) => a.domain).filter((d): d is string => d !== null)),
+    ...new Set(
+      allPlaced.map((a) => a.domain).filter((d): d is string => d !== null),
+    ),
   ];
 
   return {

--- a/src/study/types.ts
+++ b/src/study/types.ts
@@ -52,33 +52,82 @@ export interface MasteryActivityInput {
   reviewedAt: string; // ISO datetime
 }
 
-// === Forward-declared types for later sprints ===
-// Stubs so downstream code can reference them. S3 will flesh these out.
+// === S3 types ===
 
-/** Generator agent output (S3 will expand) */
+/** Generator agent output */
 export interface GeneratedActivity {
   activityType: ActivityType;
   prompt: string;
   referenceAnswer: string;
   bloomLevel: BloomLevel;
+  difficultyEstimate?: number;
   cardType?: CardType;
   sourceNotePath?: string;
+  sourceChunkHash?: string;
+  relatedConceptIds?: string[];
 }
 
-/** Session builder output (S3 will expand) */
+/** A block of activities within a session (new / review / stretch) */
+export interface SessionBlock {
+  type: 'new' | 'review' | 'stretch';
+  activities: SessionActivity[];
+}
+
+/** A single schedulable activity within a session block */
+export interface SessionActivity {
+  activityId: string;
+  conceptId: string;
+  conceptTitle: string;
+  domain: string | null;
+  activityType: ActivityType;
+  bloomLevel: BloomLevel;
+}
+
+/** Session builder output */
 export interface SessionComposition {
-  sessionId: string;
-  activities: Array<{
-    activityId: string;
-    block: 'new' | 'review' | 'stretch';
-  }>;
+  blocks: SessionBlock[];
+  totalActivities: number;
   estimatedMinutes: number;
+  domainsCovered: string[];
 }
 
-/** Bloom advancement check result (S3 will expand) */
+/** Options controlling session composition */
+export interface SessionOptions {
+  targetActivities?: number; // default 20
+  domainFocus?: string;      // filter to specific domain
+  maxMinutes?: number;       // default 30
+}
+
+/** Bloom advancement check result */
 export interface BloomAdvancement {
   conceptId: string;
+  conceptTitle: string;
   previousCeiling: number;
   newCeiling: number;
   generationNeeded: boolean;
+}
+
+/** Recommended activity mix for a concept */
+export interface ActivityRecommendation {
+  activityType: ActivityType;
+  bloomLevel: BloomLevel;
+  count: number;
+}
+
+/** Full result from completing an activity (engine-level) */
+export interface CompletionResult {
+  logEntryId: string;
+  newDueAt: string;
+  advancement: BloomAdvancement | null;
+  generationNeeded: boolean;
+  deEscalation: string | null;
+}
+
+/** A synthesis opportunity detected across concepts */
+export interface SynthesisOpportunity {
+  type: 'within-subdomain' | 'within-domain' | 'cross-domain';
+  domain: string;
+  subdomain?: string;
+  concepts: Array<{ id: string; title: string; bloomCeiling: number }>;
+  automatic: boolean; // true for within-subdomain/domain, false for cross-domain
 }

--- a/src/study/types.ts
+++ b/src/study/types.ts
@@ -94,8 +94,7 @@ export interface SessionComposition {
 /** Options controlling session composition */
 export interface SessionOptions {
   targetActivities?: number; // default 20
-  domainFocus?: string;      // filter to specific domain
-  maxMinutes?: number;       // default 30
+  domainFocus?: string; // filter to specific domain
 }
 
 /** Bloom advancement check result */


### PR DESCRIPTION
## Summary

- **Engine module** (`src/study/engine.ts`): concept progression logic — bloom advancement detection, activity recommendations by mastery tier, de-escalation advice, synthesis opportunity discovery, post-session generation trigger
- **Session builder** (`src/study/session-builder.ts`): daily session composition with new/review/stretch blocks, concept interleaving, domain coverage enforcement, time estimates
- **Generator orchestration** (`src/study/generator.ts`): container dispatch for batch activity generation with rate limiting (max 10 concepts/cycle), vault note content reading, prompt construction
- **Generator agent prompt** (`groups/study-generator/CLAUDE.md`): full system prompt with Wozniak/Matuschak quality rules, 8 activity type specs with worked examples, anti-pattern checklist, Bloom's level guidelines
- **IPC handler** (`src/ipc.ts`): `study_generated_activities` case — validates, maps to NewLearningActivity with SM-2 defaults, batch inserts, creates activity_concepts links for multi-concept activities
- **Types + queries**: expanded forward-declared stubs (GeneratedActivity, SessionComposition, BloomAdvancement) + 5 new query functions + 6 new type interfaces

## Test plan

- [x] 133 study module tests pass (7 test files)
- [x] 823 total tests pass (1 pre-existing failure in `claw-skill.test.ts` — unrelated)
- [x] Clean TypeScript build (`npm run build`)
- [x] Engine: bloom advancement detected after mastery threshold crossed
- [x] Engine: processCompletion wraps completeActivity (no SM-2 duplication)
- [x] Session builder: 3-block composition, interleaving, domain coverage
- [x] Generator: rate limiting, vault note fallback, container dispatch
- [x] IPC handler: validates required fields, skips invalid, batch inserts valid
- [x] Post-session trigger: error isolation per concept

🤖 Generated with [Claude Code](https://claude.com/claude-code)