### PR TITLE
feat(study): S5 dashboard chat + deep methods

### DIFF
--- a/dashboard/src/app/api/study/chat/close/route.ts
+++ b/dashboard/src/app/api/study/chat/close/route.ts
@@ -1,0 +1,29 @@
+const WEB_CHANNEL_URL = process.env.WEB_CHANNEL_URL || 'http://127.0.0.1:3200';
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as { sessionId: string };
+    const { sessionId } = body;
+
+    if (!sessionId) {
+      return Response.json({ error: 'sessionId is required' }, { status: 400 });
+    }
+
+    const res = await fetch(`${WEB_CHANNEL_URL}/study-close/${sessionId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      return Response.json(
+        { error: `Web channel error: ${errorText}` },
+        { status: res.status },
+      );
+    }
+
+    return Response.json({ ok: true });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/study/chat/route.ts
+++ b/dashboard/src/app/api/study/chat/route.ts
@@ -1,0 +1,57 @@
+import { eq } from 'drizzle-orm';
+import { getDb } from '@/lib/db/index';
+import { concepts } from '@/lib/db/schema';
+
+const WEB_CHANNEL_URL = process.env.WEB_CHANNEL_URL || 'http://127.0.0.1:3200';
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as {
+      sessionId: string;
+      text: string;
+      conceptId?: string;
+      method?: string;
+      bloomLevel?: number;
+    };
+
+    const { sessionId, conceptId, method, bloomLevel } = body;
+    let { text } = body;
+
+    if (!sessionId || !text) {
+      return Response.json({ error: 'sessionId and text are required' }, { status: 400 });
+    }
+
+    // First-message injection: prepend context if conceptId and method are provided
+    if (conceptId && method) {
+      const concept = getDb()
+        .select()
+        .from(concepts)
+        .where(eq(concepts.id, conceptId))
+        .get();
+
+      const conceptTitle = concept?.title ?? conceptId;
+      const level = bloomLevel ?? 1;
+
+      text =
+        `[CONTEXT] Concept: ${conceptTitle} | Bloom's Level: L${level} | Method: ${method}\n\n${text}`;
+    }
+
+    const res = await fetch(`${WEB_CHANNEL_URL}/study-message`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId, text }),
+    });
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      return Response.json(
+        { error: `Web channel error: ${errorText}` },
+        { status: res.status },
+      );
+    }
+
+    return Response.json({ ok: true });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/study/chat/stream/[sessionId]/route.ts
+++ b/dashboard/src/app/api/study/chat/stream/[sessionId]/route.ts
@@ -1,0 +1,35 @@
+const WEB_CHANNEL_URL = process.env.WEB_CHANNEL_URL || 'http://127.0.0.1:3200';
+
+export async function GET(
+  _request: Request,
+  ctx: { params: Promise<{ sessionId: string }> },
+) {
+  try {
+    const { sessionId } = await ctx.params;
+
+    const upstream = await fetch(
+      `${WEB_CHANNEL_URL}/study-stream/${sessionId}`,
+    );
+
+    if (!upstream.ok || !upstream.body) {
+      return Response.json(
+        { error: 'Failed to connect to upstream SSE stream' },
+        { status: upstream.status || 502 },
+      );
+    }
+
+    return new Response(upstream.body, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'X-Accel-Buffering': 'no',
+      },
+    });
+  } catch (err) {
+    return Response.json(
+      { error: `Web channel unreachable: ${err}` },
+      { status: 502 },
+    );
+  }
+}

--- a/dashboard/src/app/api/study/evaluate/[sessionId]/result/route.ts
+++ b/dashboard/src/app/api/study/evaluate/[sessionId]/result/route.ts
@@ -1,0 +1,31 @@
+import { getLogByActivityIdAndMethod } from '@/lib/study-db';
+
+export async function GET(
+  request: Request,
+  ctx: { params: Promise<{ sessionId: string }> },
+) {
+  try {
+    await ctx.params; // Await params even though we don't use sessionId directly here
+
+    const { searchParams } = new URL(request.url);
+    const activityId = searchParams.get('activityId');
+
+    if (!activityId) {
+      return Response.json({ error: 'activityId query param is required' }, { status: 400 });
+    }
+
+    const log = getLogByActivityIdAndMethod(activityId, 'ai_evaluated');
+
+    if (log) {
+      return Response.json({
+        status: 'complete',
+        quality: log.ai_quality,
+        aiFeedback: log.ai_feedback,
+      });
+    }
+
+    return Response.json({ status: 'pending' });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/study/evaluate/route.ts
+++ b/dashboard/src/app/api/study/evaluate/route.ts
@@ -1,0 +1,72 @@
+import { eq } from 'drizzle-orm';
+import { getDb } from '@/lib/db/index';
+import { concepts } from '@/lib/db/schema';
+
+const WEB_CHANNEL_URL = process.env.WEB_CHANNEL_URL || 'http://127.0.0.1:3200';
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as {
+      sessionId: string;
+      activityId: string;
+      responseText: string;
+      conceptId: string;
+      bloomLevel: number;
+      prompt: string;
+      referenceAnswer: string;
+    };
+
+    const {
+      sessionId,
+      activityId,
+      responseText,
+      conceptId,
+      bloomLevel,
+      prompt,
+      referenceAnswer,
+    } = body;
+
+    if (!sessionId || !activityId || !responseText || !conceptId) {
+      return Response.json(
+        { error: 'sessionId, activityId, responseText, and conceptId are required' },
+        { status: 400 },
+      );
+    }
+
+    // Look up concept title from DB
+    const concept = getDb()
+      .select()
+      .from(concepts)
+      .where(eq(concepts.id, conceptId))
+      .get();
+
+    const conceptTitle = concept?.title ?? conceptId;
+
+    // Build evaluation message
+    const evaluationMessage =
+      `[EVALUATE] Activity: ${activityId}\n` +
+      `Concept: ${conceptTitle}\n` +
+      `Bloom's Level: L${bloomLevel ?? 1}\n` +
+      `Prompt: ${prompt}\n` +
+      `Reference Answer: ${referenceAnswer}\n\n` +
+      `Student Response:\n${responseText}`;
+
+    const res = await fetch(`${WEB_CHANNEL_URL}/study-message`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionId, text: evaluationMessage }),
+    });
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      return Response.json(
+        { error: `Web channel error: ${errorText}` },
+        { status: res.status },
+      );
+    }
+
+    return Response.json({ ok: true, sessionId });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/study/chat/page.tsx
+++ b/dashboard/src/app/study/chat/page.tsx
@@ -74,8 +74,11 @@ export default function StudyChatPage() {
         } else if (list.length > 0) {
           setSelectedConceptId(list[0].id);
         }
-        if (qMethod && METHODS.includes(qMethod)) {
-          setSelectedMethod(qMethod);
+        const matchedMethod = qMethod
+          ? METHODS.find((m) => m.toLowerCase() === qMethod.toLowerCase())
+          : undefined;
+        if (matchedMethod) {
+          setSelectedMethod(matchedMethod);
         }
       })
       .catch(() => {

--- a/dashboard/src/app/study/chat/page.tsx
+++ b/dashboard/src/app/study/chat/page.tsx
@@ -1,0 +1,470 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { ConceptSummary } from '@/lib/study-db';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Phase = 'SETUP' | 'CHATTING' | 'ENDED';
+
+type ChatMethod = 'Feynman' | 'Socratic' | 'Case Analysis' | 'Comparison' | 'Synthesis' | 'Free';
+
+interface ChatMessage {
+  id: string;
+  role: 'user' | 'agent';
+  text: string;
+  pending?: boolean;
+}
+
+const METHODS: ChatMethod[] = ['Feynman', 'Socratic', 'Case Analysis', 'Comparison', 'Synthesis', 'Free'];
+
+const BLOOM_LABELS: Record<number, string> = {
+  1: 'L1 Remember',
+  2: 'L2 Understand',
+  3: 'L3 Apply',
+  4: 'L4 Analyse',
+  5: 'L5 Evaluate',
+  6: 'L6 Create',
+};
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+export default function StudyChatPage() {
+  const [phase, setPhase] = useState<Phase>('SETUP');
+
+  // SETUP state
+  const [concepts, setConcepts] = useState<ConceptSummary[]>([]);
+  const [conceptsLoading, setConceptsLoading] = useState(true);
+  const [selectedConceptId, setSelectedConceptId] = useState<string>('');
+  const [selectedMethod, setSelectedMethod] = useState<ChatMethod>('Feynman');
+
+  // CHATTING state
+  const [sessionId, setSessionId] = useState<string>('');
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [inputText, setInputText] = useState('');
+  const [sending, setSending] = useState(false);
+  const [isFirstMessage, setIsFirstMessage] = useState(true);
+
+  const esRef = useRef<EventSource | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const currentAgentMsgIdRef = useRef<string | null>(null);
+
+  // ---------------------------------------------------------------------------
+  // Load concepts
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    // Parse query params for pre-selection
+    const params = new URLSearchParams(window.location.search);
+    const qConceptId = params.get('conceptId');
+    const qMethod = params.get('method') as ChatMethod | null;
+
+    fetch('/api/study/concepts')
+      .then((r) => r.json())
+      .then((data: { concepts: ConceptSummary[] }) => {
+        const list = data.concepts ?? [];
+        setConcepts(list);
+        if (qConceptId) {
+          setSelectedConceptId(qConceptId);
+        } else if (list.length > 0) {
+          setSelectedConceptId(list[0].id);
+        }
+        if (qMethod && METHODS.includes(qMethod)) {
+          setSelectedMethod(qMethod);
+        }
+      })
+      .catch(() => {
+        // silently fail
+      })
+      .finally(() => setConceptsLoading(false));
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Auto-scroll
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  // ---------------------------------------------------------------------------
+  // SSE cleanup on unmount
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    return () => {
+      esRef.current?.close();
+    };
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Open SSE connection
+  // ---------------------------------------------------------------------------
+
+  const openSSE = useCallback((sid: string) => {
+    const es = new EventSource(`/api/study/chat/stream/${sid}`);
+    esRef.current = es;
+
+    es.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data as string) as { type: string; text?: string };
+
+        if (data.type === 'message' && data.text) {
+          const text = data.text;
+          const agentMsgId = currentAgentMsgIdRef.current;
+
+          if (!agentMsgId) {
+            // Start a new agent message
+            const newId = crypto.randomUUID();
+            currentAgentMsgIdRef.current = newId;
+            setMessages((prev) => [
+              ...prev,
+              { id: newId, role: 'agent', text, pending: true },
+            ]);
+          } else {
+            // Append to existing agent message
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === agentMsgId ? { ...m, text: m.text + text } : m,
+              ),
+            );
+          }
+        } else if (data.type === 'closed') {
+          // Mark current agent message as complete
+          if (currentAgentMsgIdRef.current) {
+            const doneId = currentAgentMsgIdRef.current;
+            setMessages((prev) =>
+              prev.map((m) => (m.id === doneId ? { ...m, pending: false } : m)),
+            );
+            currentAgentMsgIdRef.current = null;
+          }
+          es.close();
+          setPhase('ENDED');
+        } else if (data.type === 'turn_end') {
+          // Agent finished speaking — mark message as complete, ready for next turn
+          if (currentAgentMsgIdRef.current) {
+            const doneId = currentAgentMsgIdRef.current;
+            setMessages((prev) =>
+              prev.map((m) => (m.id === doneId ? { ...m, pending: false } : m)),
+            );
+            currentAgentMsgIdRef.current = null;
+          }
+        }
+      } catch {
+        // ignore parse errors
+      }
+    };
+
+    es.onerror = () => {
+      es.close();
+    };
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Start chat
+  // ---------------------------------------------------------------------------
+
+  function handleStartChat() {
+    if (!selectedConceptId) return;
+    const sid = crypto.randomUUID();
+    setSessionId(sid);
+    setMessages([]);
+    setIsFirstMessage(true);
+    currentAgentMsgIdRef.current = null;
+    openSSE(sid);
+    setPhase('CHATTING');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Send message
+  // ---------------------------------------------------------------------------
+
+  async function handleSend() {
+    const text = inputText.trim();
+    if (!text || sending) return;
+
+    setSending(true);
+    setInputText('');
+
+    // Reset textarea height
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+    }
+
+    // Optimistic: add user message immediately
+    const userMsgId = crypto.randomUUID();
+    setMessages((prev) => [...prev, { id: userMsgId, role: 'user', text }]);
+
+    // Prepare placeholder for agent response
+    const agentMsgId = crypto.randomUUID();
+    currentAgentMsgIdRef.current = agentMsgId;
+    setMessages((prev) => [...prev, { id: agentMsgId, role: 'agent', text: '', pending: true }]);
+
+    try {
+      const selectedConcept = concepts.find((c) => c.id === selectedConceptId);
+      const bloomLevel = selectedConcept?.bloomCeiling ?? 1;
+
+      const body: {
+        sessionId: string;
+        text: string;
+        conceptId?: string;
+        method?: string;
+        bloomLevel?: number;
+      } = { sessionId, text };
+
+      if (isFirstMessage) {
+        body.conceptId = selectedConceptId;
+        body.method = selectedMethod;
+        body.bloomLevel = bloomLevel;
+        setIsFirstMessage(false);
+      }
+
+      await fetch('/api/study/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    } catch {
+      // Remove the pending agent placeholder on error
+      setMessages((prev) => prev.filter((m) => m.id !== agentMsgId));
+      currentAgentMsgIdRef.current = null;
+    } finally {
+      setSending(false);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // End session
+  // ---------------------------------------------------------------------------
+
+  async function handleEndSession() {
+    esRef.current?.close();
+    try {
+      await fetch('/api/study/chat/close', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId }),
+      });
+    } catch {
+      // ignore
+    }
+    setPhase('ENDED');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Textarea auto-grow
+  // ---------------------------------------------------------------------------
+
+  function handleTextareaInput(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    setInputText(e.target.value);
+    const el = e.target;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void handleSend();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Derived
+  // ---------------------------------------------------------------------------
+
+  const selectedConcept = concepts.find((c) => c.id === selectedConceptId);
+
+  // ---------------------------------------------------------------------------
+  // Render: SETUP
+  // ---------------------------------------------------------------------------
+
+  if (phase === 'SETUP') {
+    return (
+      <div className="max-w-xl mx-auto space-y-6">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-100 mb-1">Chat with Tutor</h2>
+          <p className="text-sm text-gray-500">Choose a concept and method to start a dialogue.</p>
+        </div>
+
+        {/* Concept selector */}
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-400">Concept</label>
+          {conceptsLoading ? (
+            <p className="text-sm text-gray-600">Loading concepts...</p>
+          ) : concepts.length === 0 ? (
+            <p className="text-sm text-gray-600">No active concepts. Approve concepts on the Study page first.</p>
+          ) : (
+            <select
+              value={selectedConceptId}
+              onChange={(e) => setSelectedConceptId(e.target.value)}
+              className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:border-gray-500"
+            >
+              {concepts.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.title}{c.domain ? ` — ${c.domain}` : ''}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        {/* Method selector */}
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-400">Method</label>
+          <div className="grid grid-cols-3 gap-2">
+            {METHODS.map((method) => (
+              <button
+                key={method}
+                onClick={() => setSelectedMethod(method)}
+                className={`py-2 px-3 rounded-lg text-sm font-medium transition-colors ${
+                  selectedMethod === method
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-gray-900 border border-gray-700 text-gray-400 hover:bg-gray-800 hover:text-gray-200'
+                }`}
+              >
+                {method}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Start button */}
+        <button
+          onClick={handleStartChat}
+          disabled={!selectedConceptId || conceptsLoading}
+          className="w-full py-3 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors"
+        >
+          Start Chat
+        </button>
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render: CHATTING
+  // ---------------------------------------------------------------------------
+
+  if (phase === 'CHATTING') {
+    return (
+      <div className="flex flex-col h-[calc(100vh-8rem)] max-w-3xl mx-auto">
+        {/* Context bar */}
+        <div className="flex items-center justify-between px-4 py-3 bg-gray-900 border-b border-gray-800 rounded-t-lg shrink-0">
+          <div className="flex items-center gap-3 min-w-0">
+            <span className="text-sm font-medium text-gray-100 truncate">
+              {selectedConcept?.title ?? 'Chat'}
+            </span>
+            {selectedConcept?.domain && (
+              <span className="text-xs text-gray-500 truncate hidden sm:inline">
+                {selectedConcept.domain}
+              </span>
+            )}
+            <span className="shrink-0 text-xs px-2 py-0.5 rounded bg-blue-900/50 text-blue-300 border border-blue-800">
+              {selectedMethod}
+            </span>
+            {selectedConcept && selectedConcept.bloomCeiling > 0 && (
+              <span className="shrink-0 text-xs px-2 py-0.5 rounded bg-gray-800 text-gray-400 border border-gray-700">
+                {BLOOM_LABELS[selectedConcept.bloomCeiling] ?? `L${selectedConcept.bloomCeiling}`}
+              </span>
+            )}
+          </div>
+          <button
+            onClick={() => void handleEndSession()}
+            className="shrink-0 ml-4 text-xs px-3 py-1.5 rounded-md bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors"
+          >
+            End Session
+          </button>
+        </div>
+
+        {/* Message list */}
+        <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3 bg-gray-950">
+          {messages.length === 0 && (
+            <div className="text-center py-12">
+              <p className="text-sm text-gray-600">Type a message to begin the conversation.</p>
+            </div>
+          )}
+          {messages.map((msg) => (
+            <div
+              key={msg.id}
+              className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+            >
+              <div
+                className={`max-w-[80%] rounded-lg px-4 py-2.5 text-sm leading-relaxed whitespace-pre-wrap ${
+                  msg.role === 'user'
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-gray-800 text-gray-100'
+                } ${msg.pending && msg.text === '' ? 'animate-pulse' : ''}`}
+              >
+                {msg.text || (msg.pending ? <span className="text-gray-500 italic">Thinking...</span> : '')}
+              </div>
+            </div>
+          ))}
+          <div ref={messagesEndRef} />
+        </div>
+
+        {/* Input area */}
+        <div className="shrink-0 px-4 py-3 bg-gray-900 border-t border-gray-800 rounded-b-lg">
+          <div className="flex items-end gap-3">
+            <textarea
+              ref={textareaRef}
+              value={inputText}
+              onChange={handleTextareaInput}
+              onKeyDown={handleKeyDown}
+              placeholder="Type a message... (Enter to send, Shift+Enter for newline)"
+              rows={1}
+              className="flex-1 bg-gray-950 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 resize-none focus:outline-none focus:border-gray-500 overflow-hidden"
+              style={{ minHeight: '38px' }}
+            />
+            <button
+              onClick={() => void handleSend()}
+              disabled={!inputText.trim() || sending}
+              className="shrink-0 px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors"
+            >
+              Send
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render: ENDED
+  // ---------------------------------------------------------------------------
+
+  return (
+    <div className="max-w-xl mx-auto py-16 text-center space-y-4">
+      <div className="inline-flex items-center px-4 py-2 rounded-full bg-gray-800 border border-gray-700">
+        <span className="text-sm text-gray-300">Session ended</span>
+      </div>
+      <p className="text-sm text-gray-500">
+        Your conversation with the tutor has ended.
+      </p>
+      <div className="flex items-center justify-center gap-4 pt-2">
+        <a
+          href="/study"
+          className="px-4 py-2 rounded-lg text-sm font-medium bg-gray-800 hover:bg-gray-700 text-gray-200 transition-colors"
+        >
+          Back to Study
+        </a>
+        <button
+          onClick={() => {
+            setPhase('SETUP');
+            setMessages([]);
+            setSessionId('');
+            setIsFirstMessage(true);
+            currentAgentMsgIdRef.current = null;
+          }}
+          className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+        >
+          New Chat
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/app/study/session/page.tsx
+++ b/dashboard/src/app/study/session/page.tsx
@@ -468,7 +468,7 @@ export default function StudySessionPage() {
         const res = await fetch(
           `/api/study/evaluate/${sessionId}/result?activityId=${encodeURIComponent(activityId)}`,
         );
-        const data = (await res.json()) as { status?: string; quality?: number; feedback?: string };
+        const data = (await res.json()) as { status?: string; quality?: number; aiFeedback?: string };
         if (data.status === 'complete') {
           clearInterval(pollInterval);
           evalPollRef.current = null;
@@ -479,7 +479,7 @@ export default function StudySessionPage() {
             eventSourceRef.current = null;
           }
           if (data.quality !== undefined) setAiQuality(data.quality);
-          if (data.feedback) setAiFeedback(data.feedback);
+          if (data.aiFeedback) setAiFeedback(data.aiFeedback);
 
           // Accumulate stats using the AI-reported quality (or 3 as a neutral fallback)
           const quality = data.quality ?? 3;

--- a/dashboard/src/app/study/session/page.tsx
+++ b/dashboard/src/app/study/session/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -31,6 +31,8 @@ interface SessionData {
 }
 
 type Phase = 'loading' | 'pre_session' | 'in_progress' | 'post_session' | 'complete';
+
+type EvaluationMode = 'choosing' | 'evaluating' | 'result' | 'self_rate' | null;
 
 interface FlatActivity {
   activity: EnrichedActivity;
@@ -147,6 +149,27 @@ function calibrationColor(predicted: number, actual: number): string {
   return 'text-blue-400'; // underconfident
 }
 
+/** Returns number of textarea rows for a given activity type */
+function textAreaRows(activityType: string): number {
+  switch (activityType) {
+    case 'synthesis':
+      return 10;
+    case 'concept_map':
+      return 8;
+    case 'self_explain':
+    case 'comparison':
+    case 'case_analysis':
+      return 6;
+    default:
+      return 4;
+  }
+}
+
+/** Whether AI evaluation is eligible for this activity */
+function isAiEvalEligible(bloomLevel: number, activityType: string): boolean {
+  return bloomLevel >= 3 && activityType !== 'card_review';
+}
+
 // ---------------------------------------------------------------------------
 // Page component
 // ---------------------------------------------------------------------------
@@ -176,6 +199,14 @@ export default function StudySessionPage() {
   const activityStartTime = useRef<number>(Date.now());
   const sessionStartTime = useRef<number>(Date.now());
 
+  // AI Evaluation state
+  const [evaluationMode, setEvaluationMode] = useState<EvaluationMode>(null);
+  const [aiFeedback, setAiFeedback] = useState<string>('');
+  const [aiQuality, setAiQuality] = useState<number | null>(null);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const evalPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const evalTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   // POST_SESSION
   const [reflection, setReflection] = useState('');
   const [reflectLoading, setReflectLoading] = useState(false);
@@ -183,6 +214,32 @@ export default function StudySessionPage() {
 
   // COMPLETE — store final stats snapshot
   const [completeStats, setCompleteStats] = useState<SessionStats | null>(null);
+
+  // ---------------------------------------------------------------------------
+  // Cleanup helpers for AI eval
+  // ---------------------------------------------------------------------------
+
+  const cleanupEvalResources = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+      eventSourceRef.current = null;
+    }
+    if (evalPollRef.current) {
+      clearInterval(evalPollRef.current);
+      evalPollRef.current = null;
+    }
+    if (evalTimeoutRef.current) {
+      clearTimeout(evalTimeoutRef.current);
+      evalTimeoutRef.current = null;
+    }
+  }, []);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      cleanupEvalResources();
+    };
+  }, [cleanupEvalResources]);
 
   // ---------------------------------------------------------------------------
   // LOADING: fetch session data
@@ -232,6 +289,9 @@ export default function StudySessionPage() {
     setResponseText('');
     setSubmitted(false);
     setSelectedQuality(null);
+    setEvaluationMode(null);
+    setAiFeedback('');
+    setAiQuality(null);
     sessionStartTime.current = Date.now();
     activityStartTime.current = Date.now();
     setPhase('in_progress');
@@ -246,6 +306,15 @@ export default function StudySessionPage() {
       return;
     }
     setSubmitted(true);
+
+    const flat = flatActivities[currentIndex];
+    if (!flat) return;
+    const { bloomLevel, activityType } = flat.activity;
+
+    if (isAiEvalEligible(bloomLevel, activityType)) {
+      setEvaluationMode('choosing');
+    }
+    // else evaluationMode stays null → existing self-rate flow
   }
 
   async function handleQualityRating(quality: number) {
@@ -318,6 +387,7 @@ export default function StudySessionPage() {
   }
 
   function advanceToNext() {
+    cleanupEvalResources();
     const nextIndex = currentIndex + 1;
     if (nextIndex >= flatActivities.length) {
       // End of session → post_session
@@ -329,8 +399,119 @@ export default function StudySessionPage() {
       setSubmitted(false);
       setSelectedQuality(null);
       setLastResult(null);
+      setEvaluationMode(null);
+      setAiFeedback('');
+      setAiQuality(null);
       activityStartTime.current = Date.now();
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // AI Evaluation flow
+  // ---------------------------------------------------------------------------
+
+  async function handleAiEvaluate() {
+    if (!sessionId) return;
+    const flat = flatActivities[currentIndex];
+    if (!flat) return;
+    const { activityId, conceptId, bloomLevel, prompt, referenceAnswer } = flat.activity;
+
+    cleanupEvalResources();
+    setEvaluationMode('evaluating');
+    setAiFeedback('');
+    setAiQuality(null);
+
+    // Open SSE stream
+    const es = new EventSource(`/api/study/chat/stream/${sessionId}`);
+    eventSourceRef.current = es;
+
+    es.addEventListener('message', (event: MessageEvent) => {
+      try {
+        const parsed = JSON.parse(event.data as string) as { type?: string; text?: string };
+        if (parsed.type === 'message' && parsed.text) {
+          setAiFeedback((prev) => prev + parsed.text);
+        }
+      } catch {
+        // ignore parse errors
+      }
+    });
+
+    es.addEventListener('error', () => {
+      // SSE errors are non-fatal — polling will still resolve the result
+    });
+
+    // Send evaluation request
+    try {
+      await fetch('/api/study/evaluate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sessionId,
+          activityId,
+          responseText,
+          conceptId,
+          bloomLevel,
+          prompt,
+          referenceAnswer,
+        }),
+      });
+    } catch {
+      // If request fails, fall back
+      setEvaluationMode('self_rate');
+      cleanupEvalResources();
+      return;
+    }
+
+    // Poll for result every 2s
+    const pollInterval = setInterval(async () => {
+      try {
+        const res = await fetch(
+          `/api/study/evaluate/${sessionId}/result?activityId=${encodeURIComponent(activityId)}`,
+        );
+        const data = (await res.json()) as { status?: string; quality?: number; feedback?: string };
+        if (data.status === 'complete') {
+          clearInterval(pollInterval);
+          evalPollRef.current = null;
+          clearTimeout(evalTimeoutRef.current!);
+          evalTimeoutRef.current = null;
+          if (eventSourceRef.current) {
+            eventSourceRef.current.close();
+            eventSourceRef.current = null;
+          }
+          if (data.quality !== undefined) setAiQuality(data.quality);
+          if (data.feedback) setAiFeedback(data.feedback);
+
+          // Accumulate stats using the AI-reported quality (or 3 as a neutral fallback)
+          const quality = data.quality ?? 3;
+          setSessionStats((prev) => {
+            const newQualities = [...prev.qualities, quality];
+            const avg = newQualities.reduce((s, q) => s + q, 0) / newQualities.length;
+            return {
+              activitiesCompleted: prev.activitiesCompleted + 1,
+              avgQuality: avg,
+              totalTimeMs: Date.now() - sessionStartTime.current,
+              qualities: newQualities,
+            };
+          });
+
+          setEvaluationMode('result');
+        }
+      } catch {
+        // ignore transient polling errors
+      }
+    }, 2000);
+    evalPollRef.current = pollInterval;
+
+    // Timeout after 60s → fall back to self-rate
+    const timeout = setTimeout(() => {
+      cleanupEvalResources();
+      setEvaluationMode('self_rate');
+    }, 60_000);
+    evalTimeoutRef.current = timeout;
+  }
+
+  function handleChooseSelfRate() {
+    setEvaluationMode('self_rate');
   }
 
   // ---------------------------------------------------------------------------
@@ -470,6 +651,8 @@ export default function StudySessionPage() {
       flatActivities[currentIndex - 1].blockIndex !== current.blockIndex;
 
     const isCardReview = activity.activityType === 'card_review';
+    const isSocratic = activity.activityType === 'socratic';
+    const aiEligible = isAiEvalEligible(activity.bloomLevel, activity.activityType);
 
     return (
       <div className="max-w-2xl mx-auto space-y-4">
@@ -521,37 +704,19 @@ export default function StudySessionPage() {
           {/* Prompt */}
           <p className="text-gray-100 text-base leading-relaxed">{activity.prompt}</p>
 
-          {/* Response area (pre-submission) */}
-          {!submitted && (
+          {/* Socratic: redirect instead of in-session activity */}
+          {isSocratic ? (
             <div className="space-y-3">
-              {isCardReview ? (
-                <input
-                  type="text"
-                  value={responseText}
-                  onChange={(e) => setResponseText(e.target.value)}
-                  placeholder="Your answer..."
-                  className="w-full bg-gray-950 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-gray-500"
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') handleSubmit();
-                  }}
-                />
-              ) : (
-                <textarea
-                  value={responseText}
-                  onChange={(e) => setResponseText(e.target.value)}
-                  placeholder="Write your response..."
-                  rows={4}
-                  className="w-full bg-gray-950 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 resize-none focus:outline-none focus:border-gray-500"
-                />
-              )}
-
+              <p className="text-sm text-gray-400">
+                This activity is best completed as a dialogue.
+              </p>
               <div className="flex gap-2">
-                <button
-                  onClick={handleSubmit}
-                  className="flex-1 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+                <a
+                  href={`/study/chat?conceptId=${encodeURIComponent(activity.conceptId)}&method=socratic`}
+                  className="flex-1 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors text-center"
                 >
-                  Submit
-                </button>
+                  Open in Study Chat
+                </a>
                 <button
                   onClick={handleSkip}
                   className="px-4 py-2 rounded-lg text-sm text-gray-500 hover:text-gray-300 bg-gray-800 hover:bg-gray-700 transition-colors"
@@ -560,65 +725,186 @@ export default function StudySessionPage() {
                 </button>
               </div>
             </div>
-          )}
+          ) : (
+            <>
+              {/* Response area (pre-submission) */}
+              {!submitted && (
+                <div className="space-y-3">
+                  {isCardReview ? (
+                    <input
+                      type="text"
+                      value={responseText}
+                      onChange={(e) => setResponseText(e.target.value)}
+                      placeholder="Your answer..."
+                      className="w-full bg-gray-950 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-gray-500"
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') handleSubmit();
+                      }}
+                    />
+                  ) : (
+                    <textarea
+                      value={responseText}
+                      onChange={(e) => setResponseText(e.target.value)}
+                      placeholder="Write your response..."
+                      rows={textAreaRows(activity.activityType)}
+                      className="w-full bg-gray-950 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 resize-none focus:outline-none focus:border-gray-500"
+                    />
+                  )}
 
-          {/* Post-submission: reference answer + self-rating */}
-          {submitted && (
-            <div className="space-y-4">
-              {/* Reference answer */}
-              {activity.referenceAnswer && (
-                <div className="border-t border-gray-700 bg-gray-800 mt-4 p-4 rounded-lg">
-                  <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Reference Answer</p>
-                  <p className="text-sm text-gray-200 leading-relaxed">{activity.referenceAnswer}</p>
-                </div>
-              )}
-
-              {/* Advancement notice */}
-              {lastResult?.advancement && (
-                <div className="bg-blue-950/40 border border-blue-800 rounded-lg p-3">
-                  <p className="text-sm text-blue-300">
-                    Bloom level advanced: L{lastResult.advancement.previousCeiling} → L{lastResult.advancement.newCeiling} for &quot;{lastResult.advancement.conceptTitle}&quot;
-                  </p>
-                </div>
-              )}
-
-              {/* De-escalation hint */}
-              {lastResult?.deEscalation && (
-                <div className="bg-amber-950/30 border border-amber-800/50 rounded-lg p-3">
-                  <p className="text-sm text-amber-300">{lastResult.deEscalation}</p>
-                </div>
-              )}
-
-              {/* Self-rating */}
-              {selectedQuality === null ? (
-                <div className="space-y-2">
-                  <p className="text-xs text-gray-500 uppercase tracking-wider">Rate your recall</p>
-                  <div className="flex gap-1.5 flex-wrap">
-                    {([0, 1, 2, 3, 4, 5] as const).map((q) => (
-                      <button
-                        key={q}
-                        onClick={() => handleQualityRating(q)}
-                        className="flex-1 min-w-0 py-2 rounded-full text-xs font-medium bg-gray-800 text-gray-300 hover:bg-gray-700 hover:text-gray-100 transition-colors"
-                      >
-                        {q}: {QUALITY_LABELS[q]}
-                      </button>
-                    ))}
+                  <div className="flex gap-2">
+                    <button
+                      onClick={handleSubmit}
+                      className="flex-1 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+                    >
+                      Submit
+                    </button>
+                    <button
+                      onClick={handleSkip}
+                      className="px-4 py-2 rounded-lg text-sm text-gray-500 hover:text-gray-300 bg-gray-800 hover:bg-gray-700 transition-colors"
+                    >
+                      Skip
+                    </button>
                   </div>
                 </div>
-              ) : (
-                <div className="flex items-center justify-between">
-                  <p className="text-sm text-gray-400">
-                    Rated <span className="text-blue-400 font-medium">{selectedQuality}</span> — {QUALITY_LABELS[selectedQuality]}
-                  </p>
-                  <button
-                    onClick={advanceToNext}
-                    className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
-                  >
-                    Next
-                  </button>
+              )}
+
+              {/* Post-submission area */}
+              {submitted && (
+                <div className="space-y-4">
+
+                  {/* ---- EVALUATION MODE: choosing ---- */}
+                  {evaluationMode === 'choosing' && (
+                    <div className="space-y-3">
+                      <p className="text-xs text-gray-500 uppercase tracking-wider">How would you like to evaluate?</p>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={handleAiEvaluate}
+                          className="flex-1 py-2 rounded-lg text-sm font-medium bg-indigo-600 hover:bg-indigo-500 text-white transition-colors"
+                        >
+                          AI Evaluate
+                        </button>
+                        <button
+                          onClick={handleChooseSelfRate}
+                          className="flex-1 py-2 rounded-lg text-sm font-medium bg-gray-700 hover:bg-gray-600 text-gray-200 transition-colors"
+                        >
+                          Self-Rate
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* ---- EVALUATION MODE: evaluating (AI in progress) ---- */}
+                  {evaluationMode === 'evaluating' && (
+                    <div className="space-y-3">
+                      <div className="flex items-center gap-2 text-sm text-gray-400">
+                        <svg className="animate-spin h-4 w-4 text-indigo-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                        </svg>
+                        <span>AI is evaluating your response...</span>
+                      </div>
+                      {aiFeedback && (
+                        <div className="bg-gray-800 rounded-lg p-3">
+                          <p className="text-sm text-gray-300 leading-relaxed whitespace-pre-wrap">{aiFeedback}</p>
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  {/* ---- EVALUATION MODE: result (AI done) ---- */}
+                  {evaluationMode === 'result' && (
+                    <div className="space-y-3">
+                      {aiQuality !== null && (
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs text-gray-500 uppercase tracking-wider">AI Score</span>
+                          <span className="px-2 py-0.5 rounded-full bg-indigo-900/60 border border-indigo-700 text-indigo-300 text-sm font-medium">
+                            {aiQuality} / 5
+                          </span>
+                        </div>
+                      )}
+                      {aiFeedback && (
+                        <div className="bg-gray-800 rounded-lg p-3">
+                          <p className="text-xs text-gray-500 uppercase tracking-wider mb-1.5">AI Feedback</p>
+                          <p className="text-sm text-gray-300 leading-relaxed whitespace-pre-wrap">{aiFeedback}</p>
+                        </div>
+                      )}
+                      <div className="flex justify-end">
+                        <button
+                          onClick={advanceToNext}
+                          className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+                        >
+                          Next
+                        </button>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* ---- EVALUATION MODE: self_rate (chosen or timeout fallback) ---- */}
+                  {(evaluationMode === 'self_rate' || (!aiEligible && evaluationMode === null)) && (
+                    <>
+                      {/* Reference answer */}
+                      {activity.referenceAnswer && (
+                        <div className="border-t border-gray-700 bg-gray-800 mt-4 p-4 rounded-lg">
+                          <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Reference Answer</p>
+                          <p className="text-sm text-gray-200 leading-relaxed">{activity.referenceAnswer}</p>
+                        </div>
+                      )}
+
+                      {/* Advancement notice */}
+                      {lastResult?.advancement && (
+                        <div className="bg-blue-950/40 border border-blue-800 rounded-lg p-3">
+                          <p className="text-sm text-blue-300">
+                            Bloom level advanced: L{lastResult.advancement.previousCeiling} → L{lastResult.advancement.newCeiling} for &quot;{lastResult.advancement.conceptTitle}&quot;
+                          </p>
+                        </div>
+                      )}
+
+                      {/* De-escalation hint */}
+                      {lastResult?.deEscalation && (
+                        <div className="bg-amber-950/30 border border-amber-800/50 rounded-lg p-3">
+                          <p className="text-sm text-amber-300">{lastResult.deEscalation}</p>
+                        </div>
+                      )}
+
+                      {/* Self-rating buttons */}
+                      {selectedQuality === null ? (
+                        <div className="space-y-2">
+                          <p className="text-xs text-gray-500 uppercase tracking-wider">Rate your recall</p>
+                          <div className="flex gap-1.5 flex-wrap">
+                            {([0, 1, 2, 3, 4, 5] as const).map((q) => (
+                              <button
+                                key={q}
+                                onClick={() => handleQualityRating(q)}
+                                className="flex-1 min-w-0 py-2 rounded-full text-xs font-medium bg-gray-800 text-gray-300 hover:bg-gray-700 hover:text-gray-100 transition-colors"
+                              >
+                                {q}: {QUALITY_LABELS[q]}
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                      ) : (
+                        <div className="flex items-center justify-between">
+                          <p className="text-sm text-gray-400">
+                            Rated <span className="text-blue-400 font-medium">{selectedQuality}</span> — {QUALITY_LABELS[selectedQuality]}
+                          </p>
+                          <button
+                            onClick={advanceToNext}
+                            className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+                          >
+                            Next
+                          </button>
+                        </div>
+                      )}
+                    </>
+                  )}
+
+                  {/* ---- evaluationMode === null && aiEligible: choosing not yet shown
+                       This shouldn't happen — handleSubmit sets choosing immediately.
+                       Guard for completeness only. ---- */}
+
                 </div>
               )}
-            </div>
+            </>
           )}
         </div>
       </div>

--- a/dashboard/src/app/study/session/page.tsx
+++ b/dashboard/src/app/study/session/page.tsx
@@ -712,7 +712,7 @@ export default function StudySessionPage() {
               </p>
               <div className="flex gap-2">
                 <a
-                  href={`/study/chat?conceptId=${encodeURIComponent(activity.conceptId)}&method=socratic`}
+                  href={`/study/chat?conceptId=${encodeURIComponent(activity.conceptId)}&method=Socratic`}
                   className="flex-1 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors text-center"
                 >
                   Open in Study Chat

--- a/dashboard/src/lib/study-db.ts
+++ b/dashboard/src/lib/study-db.ts
@@ -670,3 +670,25 @@ export function getLogsBySession(sessionId: string): LogRow[] {
     .orderBy(asc(activity_log.reviewed_at))
     .all();
 }
+
+/**
+ * Most recent activity_log entry for a given activityId and evaluation method.
+ * Used by the AI evaluation polling endpoint to detect when the agent has
+ * written back an ai_evaluated result for a specific activity.
+ */
+export function getLogByActivityIdAndMethod(
+  activityId: string,
+  method: string,
+): LogRow | undefined {
+  return getDb()
+    .select()
+    .from(activity_log)
+    .where(
+      and(
+        eq(activity_log.activity_id, activityId),
+        eq(activity_log.evaluation_method, method),
+      ),
+    )
+    .orderBy(desc(activity_log.reviewed_at))
+    .get();
+}

--- a/dashboard/src/lib/study-db.ts
+++ b/dashboard/src/lib/study-db.ts
@@ -267,6 +267,7 @@ export interface CompleteActivityInput {
 export interface CompleteActivityResult {
   logEntryId: string;
   newDueAt: string;
+  conceptId: string;
   bloomCeilingBefore: number;
   bloomCeilingAfter: number;
 }
@@ -412,7 +413,7 @@ export function completeActivity(input: CompleteActivityInput): CompleteActivity
         .run();
     }
 
-    return { logEntryId, newDueAt, bloomCeilingBefore, bloomCeilingAfter };
+    return { logEntryId, newDueAt, conceptId: activity.concept_id, bloomCeilingBefore, bloomCeilingAfter };
   });
 }
 
@@ -427,18 +428,8 @@ export function completeActivity(input: CompleteActivityInput): CompleteActivity
 export function processCompletion(input: CompleteActivityInput): CompletionResult {
   const db = getDb();
 
-  // Look up activity first to get concept_id (throws if not found)
-  const activity = db
-    .select()
-    .from(learning_activities)
-    .where(eq(learning_activities.id, input.activityId))
-    .get();
-  if (!activity) throw new Error(`Activity not found: ${input.activityId}`);
-
-  const conceptId = activity.concept_id;
-
   // Delegate to completeActivity — runs full SM-2 + mastery update atomically
-  const { logEntryId, newDueAt, bloomCeilingBefore, bloomCeilingAfter } =
+  const { logEntryId, newDueAt, conceptId, bloomCeilingBefore, bloomCeilingAfter } =
     completeActivity(input);
 
   let advancement: CompletionResult['advancement'] = null;

--- a/docs/superpowers/plans/2026-04-15-s5-dashboard-chat-deep-methods.md
+++ b/docs/superpowers/plans/2026-04-15-s5-dashboard-chat-deep-methods.md
@@ -1,0 +1,850 @@
+# S5: Dashboard Chat + Deep Methods — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Your role:** You are the engineer implementing this. The plan tells you *what* to build and *why*. You decide *how* within the stated constraints. If you disagree with an approach or see a better alternative, flag it before implementing — don't silently deviate and don't silently comply with something you think is wrong.
+
+**Goal:** Add conversational AI to the study system — a chat interface for deep learning methods (Feynman, Socratic, case analysis, synthesis) and AI evaluation for L3+ activities. The study agent runs in a container, communicates via the web channel's SSE infrastructure, and evaluates student responses using RAG-powered context.
+
+**Architecture:** S5 extends the existing web channel (`src/channels/web.ts`, port 3200) with a `web:study:{sessionId}` JID pattern — parallel to the existing `web:review:{draftId}` pattern. The dashboard gets a `/study/chat` page for multi-turn dialogue and an "AI Evaluate" option on `/study/session` for L3+ activities. Both proxy through new dashboard API routes to the web channel, which routes to a study container agent. The study agent writes IPC messages (`study_complete`, `study_concept_status`, `study_suggest_activity`) that the main process handles. Chat transcripts persist in `activity_log.response_text` and `activity_log.ai_feedback`.
+
+**Tech Stack:** TypeScript/Node.js (backend), Next.js + React (dashboard), SSE (streaming), Drizzle ORM (SQLite), container agents (Claude via NanoClaw)
+
+**Branch:** Create `feat/s5-dashboard-chat` off `main`. S4 merged via PR #31.
+
+**Spec:** `docs/superpowers/specs/2026-04-12-multi-method-study-system-design.md` (v2.1, Sections 1.4, 2.2, 7.3, 7.4)
+
+**Master plan:** `docs/superpowers/plans/2026-04-13-study-system-master-plan.md` (S5 checklist)
+
+---
+
+## Codebase Conventions (Hard Constraints)
+
+These apply to **every task**. Subagents must follow these — they're not obvious from context alone.
+
+1. **`.js` extensions on all relative imports in `src/`.** The backend uses Node ESM resolution. Write `import { foo } from './bar.js'`, not `'./bar'`. **Exception:** Dashboard (`dashboard/src/`) does NOT use `.js` extensions — Next.js handles resolution.
+2. **camelCase Drizzle properties, snake_case SQL columns** (backend `src/db/schema/study.ts`). Dashboard schema uses snake_case properties matching SQL column names (different convention — established in S2).
+3. **Drizzle query builder operators** (`eq`, `and`, `lte`, `desc`, `asc`, `count`, `sql`, `inArray`, `gte`) — not raw SQL strings.
+4. **Dashboard API routes** use `Response.json()` + try/catch. Pattern: `dashboard/src/app/api/study/concepts/route.ts`.
+5. **Dashboard pages** are `'use client'` components with `useState`/`useEffect` for data fetching. Tailwind CSS. Dark theme (bg-gray-950, text-gray-100). Pattern: `dashboard/src/app/study/page.tsx`.
+6. **Dashboard imports** do NOT use `.js` extensions. Follow existing patterns in `dashboard/src/lib/study-db.ts` and `dashboard/src/lib/db/index.ts`.
+7. **Commit messages** use conventional commits: `feat(study):`, `feat(dashboard):`.
+8. **Next.js API conventions may differ from training data.** Read the relevant guide in `node_modules/next/dist/docs/` before writing API routes (especially dynamic `[id]` params).
+9. **Web channel HTTP endpoints** use Node's raw `http` module (`http.IncomingMessage`, `http.ServerResponse`). No Express, no `Response.json()`. Body parsing is manual: `req.on('data')` + `req.on('end')` + `JSON.parse()`. See `src/channels/web.ts` for the exact pattern.
+10. **Container agents** are spawned via `runContainerAgent(group, input, onProcess)` from `src/container-runner.ts`. The `RegisteredGroup` object defines the group folder, mounts, and allowed tools. See how `REVIEW_AGENT_JID` is registered in `src/index.ts:656-690` for the exact pattern.
+
+---
+
+## Spec Deviations
+
+- **No concept map visual builder.** The spec says `concept_map` gets a "relationship builder" UI. S5 renders it as a text prompt + text area (same as self_explain). Visual concept mapping is deferred to S8.
+- **Socratic redirects to chat.** The spec says `socratic` activity type "redirects to `/study/chat` with Socratic method pre-selected." S5 implements this as a link/button that navigates to `/study/chat?conceptId={id}&method=socratic`, not an in-session embed.
+- **No collaborative plan creation.** The spec mentions plan creation dialogue in the chat interface. Plans are S6 — the chat page doesn't include plan creation or revision flows.
+- **Hybrid evaluation for L2-L3 deferred.** The spec says L2-L3 shows both self-rating and AI rating. S5 uses AI evaluation only for L3+ (bloomLevel >= 3). Activities at L1-L2 remain self-rated only. Mixing both ratings in the same flow adds UI complexity for marginal benefit.
+- **No student-generated activities in S5.** The `study_suggest_activity` IPC handler is wired for future use (spec section 6.4) but the chat UI doesn't prompt for self-authoring. The handler is added now because the study agent's dialogue may naturally produce activity suggestions — wiring it in S5 avoids a future IPC change.
+
+---
+
+## Key Decisions
+
+### D1: Web channel extension — parallel JID pattern
+Add `WEB_STUDY_PREFIX = 'web:study:'` alongside the existing `WEB_REVIEW_PREFIX = 'web:review:'`. Both share the same SSE infrastructure (`sseClients`, `responseBuffers`) and HTTP server. Study endpoints (`/study-message`, `/study-stream/{sessionId}`, `/study-close/{sessionId}`) are new routes on the same server.
+
+**Why not a separate server?** The web channel already handles SSE streaming, CORS, response buffering, and connection lifecycle. Duplicating this infrastructure would double the code and add a new port. The JID prefix cleanly separates study from review traffic.
+
+**Tradeoff:** The web channel file grows from 240 to ~350 lines. Acceptable — both JID patterns share the same infrastructure.
+
+### D2: Study agent group registration — same pattern as review agent
+Register `STUDY_AGENT_JID = 'web:study:__agent__'` at startup in `src/index.ts`, same as `REVIEW_AGENT_JID`. Mount the vault read-only and `groups/study/` read-write. The study agent's CLAUDE.md contains method instructions, evaluation rubrics, and IPC output format.
+
+**Why a static registration?** The container lifecycle (spawn on first message, kill on close/timeout) is identical to review agents. The `findGroupForJid()` function already maps JID prefixes to groups — adding a second prefix is one `if` clause.
+
+### D3: AI evaluation flow — dashboard proxies to study agent
+Student submits L3+ response on `/study/session` → dashboard `POST /api/study/evaluate` → proxies to web channel `POST /study-message` → study agent evaluates against vault content via tools → agent writes `study_complete` IPC → main process calls `processCompletion()` → dashboard polls for result.
+
+**Why IPC for completion, not SSE?** The study agent's evaluation writes must go through the backend's `processCompletion()` to update SM-2, mastery, and bloom ceiling atomically. If the dashboard did this, the completion would bypass the backend's advancement and generation logic. The IPC path ensures a single source of truth.
+
+**Evaluation reuses session container:** When the student clicks "AI Evaluate" on `/study/session`, the dashboard uses the same `sessionId` that was created when the study session started (via `POST /api/study/session`). The first evaluation call creates a container via the web channel; subsequent evaluations in the same session reuse that container. This avoids cold-starting a new container per activity. The container dies after 30-min idle timeout or when the study session ends.
+
+**Polling for result:** The completion result (quality score, advancement) comes from a separate `GET /api/study/evaluate/[sessionId]/result` poll that reads the activity_log entry created by the IPC handler. The poll waits up to 60s with 2s intervals (container cold start can take 15-20s for the first evaluation).
+
+### D4: Study agent CLAUDE.md — method-specific sections
+The study agent's system prompt (`groups/study/CLAUDE.md`) has sections for each method: Feynman, Socratic, case analysis, comparison, synthesis. Each section defines the dialogue pattern, when to use tools, and how to write IPC output. The brain-first principle is enforced globally: "Never reveal the answer before the student has attempted."
+
+### D5: Container lifecycle — one per session, 30-min idle timeout
+Each study chat session gets a fresh container. The container persists across all activities in that session (the student can switch concepts/methods mid-session). The container dies after 30-min idle timeout (existing `CONTAINER_TIMEOUT` config) or explicit close via `/study-close/{sessionId}`. The next session gets a fresh container.
+
+**Why fresh per session?** Cognitive context. A Feynman dialogue about concept A shouldn't bleed into a Socratic dialogue about concept B in the next session. Clean containers prevent stale context.
+
+---
+
+## Essential Reading
+
+> **For coordinators:** Extract relevant patterns from these files and inline them into subagent prompts. Subagents won't read the files themselves.
+
+| File | Why |
+|------|-----|
+| `src/channels/web.ts` | Full web channel — SSE, response buffers, CORS, `/message`, `/stream/{id}`, `/close/{id}` endpoints. S5 adds parallel study endpoints. |
+| `src/index.ts:79-80,135,252-261,656-690,784-835` | JID prefix constants, `activeWebReviewJids`, `findGroupForJid()`, review agent registration, `channelOpts` callbacks. S5 mirrors all of these for study. |
+| `src/ipc.ts:704-747` | Existing `study_generation_request` and `study_post_session_generation` handlers. S5 adds `study_complete`, `study_concept_status`, `study_suggest_activity`. |
+| `src/study/engine.ts:133-209` | `processCompletion()` and `getDeEscalationAdvice()` — the `study_complete` IPC handler calls these. |
+| `src/study/generator.ts:45-134` | `generateActivities()` — called when advancement triggers new activity generation. |
+| `src/channels/registry.ts` | `ChannelOpts` interface. S5 adds `onStudyClosed` callback. |
+| `groups/study-generator/CLAUDE.md` | Existing generator agent prompt — reference for study agent prompt structure and IPC output format. |
+| `groups/study/CLAUDE.md` | Current placeholder — S5 replaces with full prompt. |
+| `dashboard/src/app/study/session/page.tsx` | Existing session page — S5 adds AI evaluation option for L3+ activities. |
+| `dashboard/src/lib/study-db.ts` | Dashboard DB functions — S5 adds transcript persistence functions. |
+
+---
+
+## Task Numbering
+
+| Plan task | Master plan items | What |
+|-----------|-------------------|------|
+| S5.1 | S5.1 | Extend web channel + message routing for study sessions |
+| S5.2 | S5.9 | Add study IPC handlers (study_complete, study_concept_status, study_suggest_activity) |
+| S5.3 | S5.2 | Design study agent CLAUDE.md |
+| S5.4 | S5.1 (index.ts parts) | Register study agent group + wire into main process |
+| S5.5 | S5.3, S5.5 (partial — hybrid L2-L3 deferred) | Dashboard chat API routes + evaluate endpoint |
+| S5.6 | S5.4 | Create /study/chat page |
+| S5.7 | S5.6, S5.7 | AI evaluation in /study/session + L3-L6 activity type UIs |
+| S5.8 | S5.8 | Expand generator CLAUDE.md for L3-L6 activity types |
+| S5.9 | — | Verification |
+
+**Master plan errata:** S5.10 says "Add stretch block to session builder" — already implemented in S4.3 (session builder has new/review/stretch blocks). S5.7 says "Add L3-L6 activity types to /study/session" — this is partially S5.7 (UI variations) and partially S5.5 (evaluation endpoint).
+
+---
+
+## Parallelization & Model Recommendations
+
+**Dependencies:**
+- S5.1 → S5.4 (web channel before group registration wires to it)
+- S5.2 is independent (backend IPC — no web channel dependency)
+- S5.3 is independent (CLAUDE.md file — no code dependency)
+- S5.4 depends on S5.1 (group registration references web channel callbacks)
+- S5.5 depends on S5.1 + S5.4 (API routes proxy to web channel, need study group registered)
+- S5.6 depends on S5.5 (chat page calls chat API routes)
+- S5.7 depends on S5.5 (evaluation calls evaluate endpoint)
+- S5.8 is independent (generator CLAUDE.md — no code dependency)
+
+**Parallel opportunities:**
+- S5.1 + S5.2 + S5.3 + S5.8 (web channel, IPC handlers, study agent CLAUDE.md, generator CLAUDE.md — fully independent)
+- S5.6 + S5.7 (chat page + session evaluation — separate pages, both need S5.5)
+
+| Task | Can parallel with | Model | Rationale |
+|------|-------------------|-------|-----------|
+| S5.1 | S5.2, S5.3, S5.8 | Sonnet | Extends existing pattern with parallel endpoints |
+| S5.2 | S5.1, S5.3, S5.8 | Sonnet | New IPC switch cases following existing pattern |
+| S5.3 | S5.1, S5.2, S5.8 | **Opus** | Creative writing — method instructions, evaluation rubrics, brain-first rules need pedagogical judgment |
+| S5.4 | — | Sonnet | Group registration mirroring review agent pattern |
+| S5.5 | — | Sonnet | API routes following dashboard pattern |
+| S5.6 | S5.7 | Sonnet | SSE chat page — well-defined UI requirements |
+| S5.7 | S5.6 | Sonnet | Extends existing session page with conditional evaluation |
+| S5.8 | S5.1, S5.2, S5.3 | Sonnet | CLAUDE.md text additions following existing format |
+| S5.9 | — | Sonnet | Mechanical verification |
+
+**Skip two-stage review for:** S5.3, S5.8 (CLAUDE.md files — review content quality, not code correctness), S5.9 (verification). Full review for: S5.1, S5.2, S5.4, S5.5, S5.6, S5.7.
+
+---
+
+## S5.1: Extend Web Channel for Study Sessions
+
+**Files:** Modify `src/channels/web.ts`, modify `src/channels/registry.ts`
+
+**Parallelizable with S5.2, S5.3, S5.8.**
+
+### Web channel changes
+
+The web channel currently handles only `web:review:*` JIDs. S5 adds a parallel `web:study:*` JID pattern with its own endpoints. Both patterns share the same SSE infrastructure (response buffers, SSE clients, CORS handling).
+
+**Current state of `src/channels/web.ts` (240 lines):**
+- Constants: `JID_PREFIX = 'web:review:'`, `CORS_ORIGIN`
+- State: `responseBuffers: Map<string, string[]>`, `sseClients: Map<string, Set<http.ServerResponse>>`
+- Endpoints: `POST /message`, `GET /stream/{uuid}`, `POST /close/{uuid}`, `GET /recent`
+- `sendMessage(jid, text)`: strips `JID_PREFIX`, writes to SSE clients + buffer
+- `ownsJid(jid)`: `jid.startsWith(JID_PREFIX)`
+
+**What to add:**
+
+1. **New constant:** `const STUDY_PREFIX = 'web:study:';`
+
+2. **New endpoint — `POST /study-message`:** Accepts `{ sessionId: string, text: string }`. Creates message with JID `web:study:{sessionId}`, calls `opts.onChatMetadata()` and `opts.onMessage()`. Same pattern as `handleMessage()` but with `STUDY_PREFIX` and field named `sessionId` instead of `draftId`. Chat metadata name: `'Study: {sessionId}'`.
+
+3. **New endpoint — `GET /study-stream/{sessionId}`:** SSE connection for study chat. Same implementation as `handleSSE()` — adds client to `sseClients`, sends buffered responses, sends keepalive comment. The sessionId format is a UUID (same regex as draft routes: `/^\/study-stream\/([a-f0-9-]{36})$/`).
+
+4. **New endpoint — `POST /study-close/{sessionId}`:** Signals study session container shutdown. Calls `opts.onStudyClosed?.(sessionId)`. Cleans up SSE clients and response buffers. Same pattern as `/close/{draftId}`.
+
+5. **Update `sendMessage(jid, text)`:** Currently hardcoded to strip `JID_PREFIX`. Must handle both prefixes: extract the session/draft ID by stripping whichever prefix matches. Approach: `const id = jid.startsWith(STUDY_PREFIX) ? jid.replace(STUDY_PREFIX, '') : jid.replace(JID_PREFIX, '');`
+
+6. **Update `ownsJid(jid)`:** Return `jid.startsWith(JID_PREFIX) || jid.startsWith(STUDY_PREFIX)`.
+
+### Registry changes
+
+**File: `src/channels/registry.ts`** (30 lines)
+
+Add `onStudyClosed?: (sessionId: string) => void` to the `ChannelOpts` interface (alongside existing `onDraftClosed`).
+
+**Constraint:** Do NOT refactor `handleMessage` into a shared function parameterized by prefix. The two handlers will diverge in S6+ (study messages include method context, concept state injection). Keep them as separate `handleStudyMessage()` and `handleMessage()` functions with clear duplication for now.
+
+**Constraint:** Do NOT rename existing `handleMessage`/`handleSSE` functions. Add new `handleStudyMessage`/`handleStudySSE` functions alongside them.
+
+- [ ] **Step 1:** Add `STUDY_PREFIX` constant and `onStudyClosed` to `ChannelOpts` in registry.ts
+- [ ] **Step 2:** Add `handleStudyMessage()` function in web.ts
+- [ ] **Step 3:** Add `handleStudySSE()` function in web.ts
+- [ ] **Step 4:** Add `/study-message`, `/study-stream/{id}`, `/study-close/{id}` routes to `handleRequest()`
+- [ ] **Step 5:** Update `sendMessage()` to handle both JID prefixes
+- [ ] **Step 6:** Update `ownsJid()` to match both prefixes
+- [ ] **Step 7:** Run backend tests: `npx vitest run src/channels` — no regressions
+- [ ] **Step 8:** Verify: `npm run build` — clean
+- [ ] **Step 9:** Commit: `feat(study): extend web channel with study session endpoints (S5.1)`
+
+---
+
+## S5.2: Add Study IPC Handlers
+
+**Files:** Modify `src/ipc.ts`
+
+**Parallelizable with S5.1, S5.3, S5.8.**
+
+Add three new cases to the `processTaskIpc()` switch statement (currently at lines 308-746 in `src/ipc.ts`). These handle messages from the study container agent.
+
+**Existing IPC context:** The function signature is `processTaskIpc(data, sourceGroup, isMain, deps)`. Cases are added to a switch on `data.type`. The `data` object has typed fields declared inline at lines 276-301. The S4-added cases `study_generation_request` (line 704) and `study_post_session_generation` (line 725) follow the pattern.
+
+**Constraint:** Extend the `data` parameter type to include the new fields needed by S5 handlers: `activityId?: string`, `quality?: number`, `responseText?: string`, `responseTimeMs?: number`, `aiFeedback?: string`, `surface?: string`, `domain?: string`, `activityType?: string`, `prompt?: string`, `author?: string`. Add these alongside the existing optional fields in the type definition at lines 276-301. Without this, TypeScript will error on `data.activityId` etc.
+
+### Case 1: `study_complete`
+
+**Payload:** `{ type: 'study_complete', activityId: string, quality: number, sessionId?: string, responseText?: string, responseTimeMs?: number, aiFeedback?: string, surface: string }`
+
+**Handler logic:**
+1. Validate: `activityId` required (string), `quality` required (integer 0-5). Log error and break if missing or invalid.
+2. Call `processCompletion()` from `src/study/engine.js` — pass all fields through:
+   ```typescript
+   processCompletion({
+     activityId: data.activityId,
+     quality: data.quality,
+     sessionId: data.sessionId,
+     responseText: data.responseText,
+     responseTimeMs: data.responseTimeMs,
+     evaluationMethod: data.aiFeedback ? 'ai_evaluated' : 'self_rated',
+     aiQuality: data.aiFeedback ? data.quality : undefined,
+     aiFeedback: data.aiFeedback,
+     surface: data.surface ?? 'dashboard_chat',
+   })
+   ```
+   The backend's `CompleteActivityInput` already accepts `evaluationMethod`, `aiQuality`, `aiFeedback`, `sessionId`, and `responseTimeMs` — the transaction writes them atomically. Do NOT do a separate UPDATE after the transaction.
+3. If the completion result has `generationNeeded`, call `generateActivities(result.advancement.conceptId, result.advancement.newCeiling)` — same pattern as `study_generation_request` handler.
+4. Log: `study_complete: activityId={id}, quality={n}, advancement={yes/no}`.
+
+**Constraint:** Do NOT check `isMain` — study agent containers are not main-group. This matches the S4 pattern where `study_generation_request` has no `isMain` check.
+
+### Case 2: `study_concept_status`
+
+**Payload:** `{ type: 'study_concept_status', conceptId?: string, domain?: string }`
+
+**Handler logic:**
+1. If `conceptId` provided: look up concept by ID, get recent activity logs (last 10), compute mastery levels via `computeMastery()`, get bloom ceiling.
+2. If `domain` provided: get all active concepts in that domain with mastery summaries.
+3. If neither: log warning and break.
+4. Write response JSON to `data/ipc/{sourceGroup}/responses/concept-status-{timestamp}.json`.
+
+**IPC response directory:** The response goes to a `responses/` subdirectory, NOT `tasks/`. The IPC watcher monitors `tasks/` directories and would re-process response files. The `responses/` directory is not watched. The agent reads from `/workspace/ipc/responses/` (same host directory, mounted into the container). Ensure this directory is created via `fs.mkdirSync({ recursive: true })`.
+
+**Container mount note:** The agent's IPC namespace is `study/{sessionId}` so the host path is `data/ipc/study/{sessionId}/`. The container mounts this at `/workspace/ipc/`. The response file goes to `data/ipc/study/{sessionId}/responses/` on the host, readable at `/workspace/ipc/responses/` in the container.
+
+**Note:** This handler needs imports from `src/study/queries.js` for `getConceptById`, `getRecentActivityLogs`, and `getActivitiesByConcept`. Also needs `computeMastery`, `computeBloomCeiling`, `computeOverallMastery` from `src/study/mastery.js`.
+
+### Case 3: `study_suggest_activity`
+
+**Payload:** `{ type: 'study_suggest_activity', conceptId: string, activityType: string, prompt: string, bloomLevel: number, author: 'student' | 'system' }`
+
+**Handler logic:**
+1. Validate: `conceptId`, `activityType`, `prompt`, `bloomLevel` all required. Validate `activityType` against the same 8-type allowlist used in `study_generated_activities` handler (line 622): `card_review`, `elaboration`, `self_explain`, `concept_map`, `comparison`, `case_analysis`, `synthesis`, `socratic`. Validate `bloomLevel` is integer 1-6.
+2. Create a single activity using the same `batchCreateActivities()` call used in `study_generated_activities` handler (line 677). Activity fields: `conceptId: data.conceptId`, `activityType: data.activityType`, `prompt: data.prompt`, `bloomLevel: data.bloomLevel`, `author: data.author ?? 'student'`, `referenceAnswer: ''`, `difficultyEstimate: 5`, `generatedAt: new Date().toISOString()`, `dueAt: new Date().toISOString().split('T')[0]` (due immediately). Also create the concept link via `batchCreateConceptLinks()` — same pattern as `study_generated_activities` handler (line 690).
+3. Log: `study_suggest_activity: conceptId={id}, type={type}, bloomLevel={level}`.
+
+- [ ] **Step 1:** Add `study_complete` case to `processTaskIpc()` switch
+- [ ] **Step 2:** Add `study_concept_status` case
+- [ ] **Step 3:** Add `study_suggest_activity` case
+- [ ] **Step 4:** Add necessary imports at top of file (engine functions, mastery functions, schema, drizzle operators)
+- [ ] **Step 5:** Run backend tests: `npx vitest run src/ipc` — no regressions
+- [ ] **Step 6:** Verify: `npm run build` — clean
+- [ ] **Step 7:** Commit: `feat(study): add study_complete, study_concept_status, study_suggest_activity IPC handlers (S5.2)`
+
+---
+
+## S5.3: Design Study Agent CLAUDE.md
+
+**Files:** Replace `groups/study/CLAUDE.md`
+
+**Parallelizable with S5.1, S5.2, S5.8.**
+
+Replace the current placeholder (13 lines) with the full study agent system prompt. This is the most pedagogically important file in S5 — it determines the quality of the AI tutor's interactions.
+
+**Current content:**
+```markdown
+# Study Agent
+**Role:** Interactive study tutor for university courses.
+## Core Principles
+- **Brain-first:** ...
+- **Desirable difficulties:** ...
+- **Suggest strongly, enforce nothing:** ...
+> Full prompt designed in S5.
+```
+
+### Structure of the full CLAUDE.md
+
+The prompt should be organized into these sections. The agent sees this as its system prompt when the container starts.
+
+**1. Role & Core Principles (~20 lines)**
+- You are a study tutor for a university student. Your job is to facilitate deep learning through dialogue — not to lecture.
+- Brain-first (Kosmyna et al. 2025): Never reveal an answer before the student has attempted. Always let the student produce output first.
+- Desirable difficulties (Bjork 1994): Productive struggle is the goal, not comfortable confirmation. If the student finds it easy, push harder.
+- Suggest strongly, enforce nothing: Offer evidence-based guidance, but respect autonomy. No guilt, no judgement.
+- Personalization effect (Mayer 2002): Use conversational style. Address the student directly. Be warm but intellectually rigorous.
+
+**2. Session Context (~10 lines)**
+- The first message you receive contains context: concept title, Bloom's level, method, and any previous dialogue context.
+- Parse this context to understand what you're working on. Respond within the scope of the specified concept and method.
+- If the student wants to switch topics or methods, acknowledge and adapt.
+
+**3. Method-Specific Instructions (~80 lines total)**
+
+Each method gets its own subsection with dialogue pattern and examples:
+
+**Feynman Technique (L2-L4):**
+- Ask the student to explain the concept as if teaching someone who knows nothing about it.
+- Listen for gaps, oversimplifications, and incorrect causal reasoning.
+- When you identify a gap: ask a targeted follow-up question that exposes it. Do NOT explain the gap yourself.
+- After 2-3 rounds: summarize what the student got right, identify remaining gaps, suggest what to review.
+- IPC: Write `study_complete` when the dialogue concludes with a quality assessment (0-5).
+
+**Socratic Questioning (L4-L6):**
+- Never state facts. Only ask questions.
+- Start with an open-ended question about the concept's assumptions or implications.
+- If the student gives a shallow answer: probe deeper ("What would happen if that assumption were wrong?", "How do you know that?").
+- If the student is stuck: narrow the question scope, don't answer it.
+- Build toward the student reaching a conclusion independently.
+- End with a reflective question: "What did you learn about your own thinking?"
+
+**Case Analysis (L3-L6):**
+- Present or discuss a real-world scenario requiring theory application.
+- Guide through: (1) identify the problem, (2) select relevant frameworks, (3) analyze using the frameworks, (4) recommend action.
+- At each step, ask the student to produce before you evaluate.
+- Compare the student's analysis against expert reasoning.
+
+**Comparison / Contrast (L4-L5):**
+- Two or more concepts/frameworks/theories being compared.
+- Ask the student to identify dimensions of comparison before providing your own.
+- Push for structural comparison (how they work), not just surface differences (what they look like).
+- Reference Gentner's structure-mapping theory: analogies based on relational structure, not surface features.
+
+**Synthesis (L5-L6):**
+- Multiple concepts must be integrated to address a complex question.
+- Ask the student to articulate the connections before you fill in gaps.
+- Evaluate: Does the synthesis show genuine integration, or just serial summarization?
+- Push for an argument or position, not just a list of related ideas.
+
+**4. AI Evaluation Mode (~20 lines)**
+- When the first message contains `[EVALUATE]` prefix, you're in evaluation mode.
+- You receive: the activity prompt, the student's response, and the reference answer.
+- Use your tools to access vault content for additional context if the reference answer is insufficient.
+- Evaluate against the Bloom's level rubric (see section 5).
+- Output: Write a `study_complete` IPC file with `quality` (0-5) and `aiFeedback` (2-3 sentences: what was good, what was missing, what to review). Include `responseText` with the student's original response.
+- Then respond via stdout with the same feedback text so it streams to the student via SSE.
+- Do NOT add encouragement fluff. Be specific about what was right and wrong.
+
+**4b. Transcript Persistence (~10 lines)**
+- For multi-turn dialogues (Feynman, Socratic, case analysis, synthesis): when you write `study_complete` at the end of the dialogue, include the full conversation transcript in `responseText`. Format: alternating `STUDENT: ...` and `TUTOR: ...` lines.
+- For evaluation mode: `responseText` is the student's original response (not the full exchange).
+- This is how chat transcripts are saved — the `processCompletion()` handler stores `responseText` in `activity_log.response_text` and `aiFeedback` in `activity_log.ai_feedback`.
+
+**5. Bloom's Level Evaluation Rubrics (~30 lines)**
+- L1 (Remember): Correct facts recalled? Missing key terms?
+- L2 (Understand): Can explain in own words? Correct causal reasoning?
+- L3 (Apply): Can use concept in a new context? Correct application of procedure/framework?
+- L4 (Analyze): Can break down components? Identify relationships? Distinguish relevant from irrelevant?
+- L5 (Evaluate): Can make judgments? Compare alternatives? Argue for a position with evidence?
+- L6 (Create): Can synthesize new understanding? Produce original argument? Connect across domains?
+
+Quality mapping:
+- 0: No meaningful response / completely wrong
+- 1: Major errors, fundamental misunderstanding
+- 2: Partial understanding, significant gaps
+- 3: Correct core reasoning, some gaps or imprecision
+- 4: Strong understanding, minor gaps
+- 5: Excellent — demonstrates mastery at or above the target Bloom's level
+
+**6. IPC Output Format (~15 lines)**
+- Write JSON files to `/workspace/ipc/tasks/`.
+- `study_complete`: `{ "type": "study_complete", "activityId": "{id}", "quality": 0-5, "sessionId": "{sessionId from context}", "responseText": "student's text", "aiFeedback": "your feedback", "surface": "dashboard_chat" }`
+- The `sessionId` is extracted from your JID (`web:study:{sessionId}`) — include it in every `study_complete` so the completion increments the session counter.
+- `study_concept_status`: `{ "type": "study_concept_status", "conceptId": "{id}" }` — request concept mastery state.
+- `study_suggest_activity`: `{ "type": "study_suggest_activity", "conceptId": "{id}", "activityType": "...", "prompt": "...", "bloomLevel": 1-6, "author": "system" }`
+
+**7. Tool Usage (~10 lines)**
+- You have read-only access to the vault at `/workspace/extra/vault/`.
+- Use `Read` to look up vault notes for source content when evaluating or when the student references material.
+- Use `Glob` to find relevant vault notes by pattern.
+- Use `Grep` to search vault content for specific terms.
+- Write IPC files using `Write` or `Bash`.
+
+**Agent discretion:** Exact wording, example dialogues, how prescriptive each method section is, whether to include a "Common Mistakes" section. The structure and sections above are the requirement; the prose is yours.
+
+**Constraint:** The total CLAUDE.md should be 200-350 lines. Longer prompts waste context window that the dialogue needs. Be concise — every line should teach the agent something it wouldn't do by default.
+
+**Constraint:** Do NOT include RAG API instructions (curl to LightRAG). The agent uses vault file access for context, not RAG queries. RAG is for the generator agent.
+
+- [ ] **Step 1:** Write the full `groups/study/CLAUDE.md` following the structure above
+- [ ] **Step 2:** Verify line count is 200-350
+- [ ] **Step 3:** Commit: `feat(study): design study agent CLAUDE.md with method instructions and rubrics (S5.3)`
+
+---
+
+## S5.4: Register Study Agent Group + Wire into Main Process
+
+**Files:** Modify `src/index.ts`, modify `src/channels/registry.ts` (if not done in S5.1)
+
+**Depends on:** S5.1.
+
+### Study agent group registration
+
+Follow the exact pattern of `REVIEW_AGENT_JID` registration (lines 656-690 in `src/index.ts`).
+
+**New constants (near line 80):**
+```typescript
+const STUDY_AGENT_JID = 'web:study:__agent__';
+const WEB_STUDY_PREFIX = 'web:study:';
+```
+
+**New tracking set (near line 135):**
+```typescript
+const activeWebStudyJids = new Set<string>();
+```
+
+**Extend `findGroupForJid()` (line 252):**
+```typescript
+function findGroupForJid(chatJid: string): RegisteredGroup | undefined {
+  if (registeredGroups[chatJid]) return registeredGroups[chatJid];
+  if (chatJid.startsWith(WEB_REVIEW_PREFIX) && registeredGroups[REVIEW_AGENT_JID]) {
+    return registeredGroups[REVIEW_AGENT_JID];
+  }
+  if (chatJid.startsWith(WEB_STUDY_PREFIX) && registeredGroups[STUDY_AGENT_JID]) {
+    return registeredGroups[STUDY_AGENT_JID];
+  }
+  return undefined;
+}
+```
+
+**Register study agent group (near line 690, after review agent):**
+```typescript
+if (!registeredGroups[STUDY_AGENT_JID]) {
+  registerGroup(STUDY_AGENT_JID, {
+    name: 'Study Agent',
+    folder: 'study',
+    trigger: '',
+    added_at: new Date().toISOString(),
+    requiresTrigger: false,
+    isMain: false,
+    containerConfig: {
+      additionalMounts: [
+        {
+          hostPath: join(process.cwd(), 'vault'),
+          containerPath: 'vault',
+          readonly: true,
+        },
+      ],
+      allowedTools: [
+        'Bash',
+        'Read',
+        'Write',
+        'Edit',
+        'Glob',
+        'Grep',
+      ],
+    },
+  });
+}
+```
+
+**Vault is read-only** for the study agent (unlike review agent which gets rw vault access). The study agent reads source material but shouldn't modify vault notes.
+
+### Wire channelOpts callbacks
+
+**In `channelOpts.onMessage` (near line 814):** Add study JID tracking alongside review JID tracking:
+```typescript
+if (chatJid.startsWith(WEB_STUDY_PREFIX)) {
+  activeWebStudyJids.add(chatJid);
+}
+```
+
+**Add `onStudyClosed` callback to channelOpts (near line 826):**
+```typescript
+onStudyClosed: (sessionId: string) => {
+  const chatJid = `${WEB_STUDY_PREFIX}${sessionId}`;
+  logger.info({ sessionId, chatJid }, 'Study session closed, shutting down study agent');
+  queue.closeStdin(chatJid);
+  activeWebStudyJids.delete(chatJid);
+},
+```
+
+### Include study JIDs in message loop
+
+**In `startMessageLoop()` (near line 493):** Add active study JIDs to the polling list:
+```typescript
+for (const webJid of activeWebStudyJids) {
+  if (!jids.includes(webJid)) jids.push(webJid);
+}
+```
+
+### Build study context (analogous to buildReviewContext)
+
+Add a `buildStudyContext()` function that builds context for study chat messages. This is called in the message processing path (near line 301 where `buildReviewContext` is called).
+
+**What to include in study context:** The first message of a study session should include the concept title, Bloom's level, and method. Subsequent messages in the same session don't need context injection — the container persists across the session.
+
+**First-message detection:** Use a module-level `Set<string>` called `studySessionsInitialized`. When `buildStudyContext()` is called for a `web:study:*` JID, check if the JID is in the set. If not, prepend context and add the JID. If yes, return empty string. Remove the JID from the set in `onStudyClosed`. This is 3 lines of state and avoids coupling to GroupQueue internals.
+
+**Agent discretion:** The context format itself — how to structure the concept/method/Bloom context that gets prepended to the first message.
+
+- [ ] **Step 1:** Add `STUDY_AGENT_JID`, `WEB_STUDY_PREFIX`, `activeWebStudyJids` constants/set
+- [ ] **Step 2:** Extend `findGroupForJid()` with study prefix clause
+- [ ] **Step 3:** Register study agent group at startup
+- [ ] **Step 4:** Add `onStudyClosed` to channelOpts
+- [ ] **Step 5:** Add study JID tracking in `onMessage` callback
+- [ ] **Step 6:** Include `activeWebStudyJids` in message loop polling
+- [ ] **Step 7:** Add `buildStudyContext()` function and wire it into message processing
+- [ ] **Step 8:** Run backend tests: `npm test` — no regressions
+- [ ] **Step 9:** Verify: `npm run build` — clean
+- [ ] **Step 10:** Commit: `feat(study): register study agent group and wire into main process (S5.4)`
+
+---
+
+## S5.5: Dashboard Chat API Routes + Evaluate Endpoint
+
+**Files:** Create `dashboard/src/app/api/study/chat/route.ts`, create `dashboard/src/app/api/study/chat/stream/[sessionId]/route.ts`, create `dashboard/src/app/api/study/chat/close/route.ts`, create `dashboard/src/app/api/study/evaluate/route.ts`, create `dashboard/src/app/api/study/evaluate/[sessionId]/result/route.ts`
+
+**Depends on:** S5.1, S5.4.
+
+The dashboard proxies chat and evaluation requests to the web channel (port 3200) where the main process handles container lifecycle.
+
+### POST /api/study/chat
+
+**Body:** `{ sessionId: string, text: string, conceptId?: string, method?: string, bloomLevel?: number }`
+
+Proxy to web channel: `POST http://localhost:3200/study-message` with `{ sessionId, text }`.
+
+**First-message injection:** If `conceptId` and `method` are provided, prepend context to the text:
+```
+[CONTEXT] Concept: {conceptTitle} | Bloom's Level: L{bloomLevel} | Method: {method}
+
+{text}
+```
+Look up concept title from DB using `getConceptById()` or a lightweight query. If concept not found, use conceptId as fallback.
+
+**Response:** `{ ok: true }` (the actual agent response comes via SSE).
+
+### GET /api/study/chat/stream/[sessionId]
+
+Proxy SSE from web channel: `GET http://localhost:3200/study-stream/{sessionId}`.
+
+This is a streaming proxy — the dashboard API route opens an SSE connection to the web channel and forwards events to the browser. Use Node's `fetch()` to connect to the web channel SSE endpoint, then pipe the response stream to the Next.js response.
+
+**Constraint:** Read the Next.js streaming response guide in `node_modules/next/dist/docs/` before implementing. Streaming API routes may require specific patterns in this Next.js version.
+
+### POST /api/study/evaluate
+
+**Body:** `{ sessionId: string, activityId: string, responseText: string, conceptId: string, bloomLevel: number, prompt: string, referenceAnswer: string }`
+
+Builds an evaluation request and sends it to the study agent:
+
+1. Build evaluation message: `[EVALUATE] Activity: {activityId}\nConcept: {conceptTitle}\nBloom's Level: L{bloomLevel}\nPrompt: {prompt}\nReference Answer: {referenceAnswer}\n\nStudent Response:\n{responseText}`
+2. Proxy to web channel: `POST http://localhost:3200/study-message` with `{ sessionId, text: evaluationMessage }`.
+3. Response: `{ ok: true, sessionId }`.
+
+The student sees the evaluation feedback streaming via SSE. The completion result (quality score, advancement) arrives via IPC → `study_complete` → DB write.
+
+### POST /api/study/chat/close
+
+**Body:** `{ sessionId: string }`
+
+Proxy to web channel: `POST http://localhost:3200/study-close/{sessionId}`.
+
+**Response:** `{ ok: true }`
+
+### GET /api/study/evaluate/[sessionId]/result
+
+Polls for the evaluation result. The study agent writes a `study_complete` IPC message, which the main process handles by calling `processCompletion()` and writing to `activity_log`.
+
+**Query params:** `activityId` (required) — the activity being evaluated.
+
+**Logic:**
+1. Look up the most recent `activity_log` entry for this `activityId` where `evaluation_method = 'ai_evaluated'`.
+2. If found: return `{ status: 'complete', quality, aiFeedback, advancement, deEscalation }`. The `advancement` and `deEscalation` fields come from checking the concept's current state.
+3. If not found: return `{ status: 'pending' }`.
+
+The dashboard polls this endpoint every 1s until it gets `status: 'complete'` or 30s timeout.
+
+**Agent discretion:** Exact proxy implementation for SSE streaming, error handling for web channel connection failures, whether to use `fetch()` or `http.request()` for proxying.
+
+- [ ] **Step 1:** Create `POST /api/study/chat` route
+- [ ] **Step 2:** Create `GET /api/study/chat/stream/[sessionId]` SSE proxy route
+- [ ] **Step 3:** Create `POST /api/study/chat/close` route
+- [ ] **Step 4:** Create `POST /api/study/evaluate` route
+- [ ] **Step 5:** Create `GET /api/study/evaluate/[sessionId]/result` polling route
+- [ ] **Step 6:** Add `getLogByActivityIdAndMethod(activityId: string, method: string)` to study-db.ts
+- [ ] **Step 7:** Verify: `cd dashboard && npx tsc --noEmit` — clean
+- [ ] **Step 8:** Commit: `feat(dashboard): add study chat and AI evaluation API routes (S5.5)`
+
+---
+
+## S5.6: Create /study/chat Page
+
+**Files:** Create `dashboard/src/app/study/chat/page.tsx`
+
+**Depends on:** S5.5. **Parallelizable with S5.7.**
+
+A multi-turn conversational interface connected to the study agent via SSE. The student selects a concept and method, then has a dialogue with the AI tutor.
+
+### Page Structure
+
+Single `'use client'` component. State machine:
+
+```
+SETUP → CHATTING → ENDED
+```
+
+**SETUP phase:**
+- Concept selector: dropdown of active concepts (fetch from `GET /api/study/concepts`). Shows concept title + domain.
+- Method selector: radio buttons — Feynman, Socratic, Case Analysis, Comparison, Synthesis, Free.
+- "Start Chat" button → generates sessionId (UUID via `crypto.randomUUID()`), opens SSE connection, transitions to CHATTING.
+
+If URL has query params (`?conceptId=...&method=...`), pre-select them and optionally auto-start.
+
+**CHATTING phase:**
+- Message list showing the conversation. User messages right-aligned (bg-blue-600), agent messages left-aligned (bg-gray-800). Messages render incrementally as SSE events arrive.
+- Text input at bottom with send button. On send: `POST /api/study/chat` with `{ sessionId, text }`. Clear input. Add user message to list immediately (optimistic).
+- Agent responses stream in via SSE (`GET /api/study/chat/stream/{sessionId}`). Parse each `data:` event — if `type === 'message'`, append text to current agent message. If `type === 'closed'`, the session is over.
+- Context bar at top: shows current concept title, method badge, Bloom's level.
+- "End Session" button → `POST /api/study/chat/close` with `{ sessionId }` (proxied through dashboard API route from S5.5), transitions to ENDED.
+
+**ENDED phase:**
+- "Session ended" banner. Link to `/study` and "New Chat" button.
+
+### SSE Connection Management
+
+Use `EventSource` or `fetch()` + `ReadableStream` to connect to `GET /api/study/chat/stream/{sessionId}`.
+
+Pattern for streaming text:
+```typescript
+const es = new EventSource(`/api/study/chat/stream/${sessionId}`);
+es.onmessage = (event) => {
+  const data = JSON.parse(event.data);
+  if (data.type === 'message') {
+    // Append to current agent message
+  } else if (data.type === 'closed') {
+    es.close();
+  }
+};
+```
+
+**Constraint:** Clean up EventSource on unmount (return cleanup function from useEffect). Close on page navigation.
+
+### Design
+
+- Dark theme consistent with dashboard: bg-gray-950, text-gray-100
+- Message bubbles: user bg-blue-600, agent bg-gray-800, rounded-lg, max-w-[80%]
+- Input: bg-gray-900 border-gray-700, full width, auto-growing textarea
+- Send button: bg-blue-600 hover:bg-blue-700
+- Context bar: bg-gray-900 border-b border-gray-800, concept title + method badge
+- Auto-scroll to bottom on new messages
+
+**Agent discretion:** Component decomposition, exact Tailwind, animations, mobile responsiveness, whether to split message list into its own component.
+
+- [ ] **Step 1:** Create page with SETUP phase (concept/method selectors)
+- [ ] **Step 2:** Implement SSE connection and CHATTING phase message list
+- [ ] **Step 3:** Implement text input and send functionality
+- [ ] **Step 4:** Implement ENDED phase and cleanup
+- [ ] **Step 5:** Start dashboard: `cd dashboard && npm run dev`. Navigate to `/study/chat`, verify concept list loads
+- [ ] **Step 6:** Commit: `feat(dashboard): add /study/chat page with SSE streaming dialogue (S5.6)`
+
+---
+
+## S5.7: AI Evaluation in /study/session + L3-L6 Activity Type UIs
+
+**Files:** Modify `dashboard/src/app/study/session/page.tsx`
+
+**Depends on:** S5.5. **Parallelizable with S5.6.**
+
+The existing session page handles all activities with self-rating only. S5 adds:
+1. Activity-type-specific UI variations for L3-L6 types
+2. An "AI Evaluate" option for activities where `bloomLevel >= 3`
+
+### Activity Type UI Variations
+
+Currently, all activities show the same UI: prompt → text area → submit → reference answer → self-rate. S5 adds variations:
+
+**`self_explain` (Feynman):**
+- Prompt: "Explain {concept} as if teaching someone who knows nothing about it."
+- Large text area (min 6 rows)
+- After submit: reference answer shown + AI evaluation option (see below)
+- No change to submit/rate flow for L1-L2 self_explain activities
+
+**`concept_map`:**
+- Prompt: "List the key concepts related to {topic} and describe their relationships."
+- Large text area (min 8 rows)
+- Reference answer shows expected relationships
+
+**`comparison`:**
+- Prompt: "Compare {X} and {Y} along the following dimensions: ..."
+- Large text area (min 6 rows)
+- Reference answer shows expert comparison
+
+**`case_analysis`:**
+- Prompt: scenario description
+- Multi-step UI: Step 1 "Identify the problem" → Step 2 "Select framework" → Step 3 "Analyze" → Step 4 "Recommend"
+- Each step gets its own text input. All steps concatenated as `responseText`.
+- Reference answer shows expert analysis
+
+**`synthesis`:**
+- Prompt: "Integrate concepts {A}, {B}, {C} to address: {question}"
+- Large text area (min 10 rows, essay-length)
+- Reference answer shows integration approach
+
+**`socratic`:**
+- Instead of in-session activity: show "This activity is best completed as a dialogue." + "Open in Study Chat" button → navigates to `/study/chat?conceptId={id}&method=socratic`
+- Mark as skipped if the student clicks "Skip" without opening chat
+
+### AI Evaluation Flow (L3+ Activities)
+
+For activities where `bloomLevel >= 3` AND `activityType` is NOT `card_review`:
+
+After the student submits their response (clicks "Submit"), instead of immediately showing the reference answer and self-rating buttons, show two options:
+
+```
+[AI Evaluate]  [Self-Rate]
+```
+
+**If "Self-Rate" clicked:** Normal flow — show reference answer, show rating buttons. `evaluation_method` remains `'self_rated'`.
+
+**If "AI Evaluate" clicked:**
+1. Show "AI is evaluating your response..." spinner
+2. Open SSE connection: `GET /api/study/chat/stream/{sessionId}` using the study session's sessionId (same ID created in PRE_SESSION). This reuses the container if one is already running — avoids cold-starting a new container per evaluation.
+3. Send evaluation request: `POST /api/study/evaluate` with `{ sessionId, activityId, responseText, conceptId, bloomLevel, prompt, referenceAnswer }`
+4. Stream AI feedback text below the spinner as it arrives via SSE
+5. Poll `GET /api/study/evaluate/{sessionId}/result?activityId={id}` every 2s
+6. When result arrives: show quality score badge, advancement info if any, de-escalation advice if any
+7. Show "Next" button to advance (no self-rating needed — AI provided the quality score)
+8. The IPC handler has already called `processCompletion()`, so SM-2 and mastery are updated
+
+**Surface value:** The evaluation request message should set `surface: 'dashboard_ui'` (not `'dashboard_chat'`) since this runs from the session page, not the chat page. The study agent CLAUDE.md defaults to `'dashboard_chat'` but the `[EVALUATE]` context should override this.
+
+**Timeout handling:** If 60s passes without a result (container cold start can take 15-20s), show "Evaluation timed out. Please self-rate." and fall back to self-rating flow.
+
+### State Changes
+
+Add to the component state:
+- `evaluationMode: 'choosing' | 'evaluating' | 'result' | 'self_rate' | null` — tracks which evaluation flow is active
+- `aiFeedback: string` — accumulated streaming feedback text
+- `aiQuality: number | null` — quality from AI evaluation
+
+The `evaluationMode` is set to `'choosing'` after submit if `bloomLevel >= 3` and `activityType !== 'card_review'`. Otherwise it's `null` and the existing self-rate flow runs.
+
+**Constraint:** Do NOT break the existing self-rate flow for L1-L2 activities. The AI evaluation is additive — `bloomLevel < 3` activities behave exactly as before.
+
+**Constraint:** The case_analysis multi-step UI is optional — if it adds too much complexity, a single large text area is acceptable for S5. The multi-step structure can be refined in S8.
+
+- [ ] **Step 1:** Add activity-type-specific prompt rendering (different text area sizes, socratic redirect)
+- [ ] **Step 2:** Add evaluation mode state and "AI Evaluate" / "Self-Rate" choice for L3+ activities
+- [ ] **Step 3:** Implement AI evaluation flow (SSE + polling)
+- [ ] **Step 4:** Implement timeout fallback to self-rating
+- [ ] **Step 5:** Start dashboard, test with L3+ activities at `/study/session`. Verify L1-L2 flow unchanged.
+- [ ] **Step 6:** Commit: `feat(dashboard): add AI evaluation and L3-L6 activity UIs to /study/session (S5.7)`
+
+---
+
+## S5.8: Expand Generator CLAUDE.md for L3-L6 Activity Types
+
+**Files:** Modify `groups/study-generator/CLAUDE.md`
+
+**Parallelizable with S5.1, S5.2, S5.3.**
+
+The generator agent currently has specifications for all 8 activity types in its CLAUDE.md (lines 60-200+ of the existing file). However, the L3-L6 generation guidelines may need expansion to produce higher-quality prompts for deep learning activities.
+
+### What to add/expand
+
+Review the existing `groups/study-generator/CLAUDE.md` and add or expand the following sections:
+
+**Feynman / self_explain prompts (L2-L4):**
+- Prompts should ask for explanation in the student's own words
+- Must specify what to explain (not just "explain X" — target specific aspects)
+- Reference answer should list the key points a complete explanation would cover, NOT be a full explanation itself
+- Example: "Explain how Nonaka's SECI model accounts for the conversion of tacit knowledge to explicit knowledge. Focus on the socialization and externalization phases."
+
+**Comparison prompts (L4-L5):**
+- Must specify 2+ concepts and comparison dimensions
+- Reference answer should be a structured comparison, not a narrative
+- Use the `activity_concepts` join table for multi-concept activities (include all related conceptIds in the output)
+- Example: "Compare Polanyi's tacit knowledge and Nonaka's tacit knowledge along three dimensions: definition, role in knowledge creation, and how it's made accessible."
+
+**Case analysis prompts (L3-L6):**
+- Must present a realistic scenario (not abstract)
+- Reference answer should walk through the analytical framework step by step
+- Include the framework to apply (not just "analyze this case")
+- Example: "A hospital's quality improvement team has collected extensive data but staff continue to rely on informal experience rather than documented protocols. Using Nonaka's SECI model, diagnose which knowledge conversion phase is failing and propose an intervention."
+
+**Synthesis prompts (L5-L6):**
+- Must reference 2-3 concepts that need to be integrated
+- The question should require genuine integration, not serial summarization
+- Reference answer should demonstrate the synthesis structure
+- Use the `activity_concepts` join table
+
+**Socratic starters (L4-L6):**
+- These are dialogue openers, not standalone questions
+- The prompt should be an assumption-challenging question that starts a Socratic dialogue
+- Reference answer should be the expected line of reasoning, not a direct answer
+- Example: "If knowledge can only exist in people's heads (as tacit knowledge theorists claim), how do organizations learn anything?"
+
+**Agent discretion:** Exact examples, how many examples per type, how to integrate with existing content (add new sections vs. expand existing ones).
+
+- [ ] **Step 1:** Review existing generator CLAUDE.md content for L3-L6 types
+- [ ] **Step 2:** Expand or add generation guidelines for self_explain, comparison, case_analysis, synthesis, socratic types
+- [ ] **Step 3:** Verify total CLAUDE.md length is reasonable (under 500 lines)
+- [ ] **Step 4:** Commit: `feat(study): expand generator CLAUDE.md with L3-L6 activity guidelines (S5.8)`
+
+---
+
+## S5.9: Verification
+
+**Depends on:** All previous tasks.
+
+- [ ] **Step 1:** Run backend tests: `npm test` — all pass, no regressions
+- [ ] **Step 2:** Build: `npm run build` — clean
+- [ ] **Step 3:** Dashboard types: `cd dashboard && npx tsc --noEmit` — clean
+- [ ] **Step 4:** Start all services: NanoClaw (`npm run dev`), Dashboard (`cd dashboard && npm run dev`)
+- [ ] **Step 5:** Navigate to `/study/chat` — concept and method selectors render
+- [ ] **Step 6:** Select a concept and method, click "Start Chat" — SSE connection established, context bar shows concept
+- [ ] **Step 7:** Type a message and send — message appears in chat, agent response streams back
+- [ ] **Step 8:** Navigate to `/study/session` — start a session with L3+ activities available
+- [ ] **Step 9:** Submit a response to an L3+ activity — "AI Evaluate" and "Self-Rate" buttons appear
+- [ ] **Step 10:** Click "Self-Rate" — normal rating flow works (regression test)
+- [ ] **Step 11:** Click "AI Evaluate" on another L3+ activity — evaluation streams feedback, quality score appears
+- [ ] **Step 12:** Complete session — post-session reflection works, mastery updates
+- [ ] **Step 13:** Commit: `chore(study): verify S5 dashboard chat and AI evaluation end-to-end (S5.9)`
+
+---
+
+## Acceptance Criteria
+
+From master plan S5 (non-negotiable):
+
+- [ ] Dashboard chat streams agent responses in real-time via SSE
+- [ ] Feynman dialogue: student explains → agent identifies gaps → follow-up questions
+- [ ] AI evaluation returns quality (0-5) + textual feedback for L3+ activities
+- [ ] All 8 activity types functional in session UI (card_review, elaboration, self_explain, concept_map, comparison, case_analysis, synthesis, socratic)
+- [ ] Socratic type redirects to `/study/chat` with method pre-selected
+- [ ] Chat transcripts saved and linked to sessions/concepts (via activity_log)
+- [ ] Study agent IPC contract works: study_complete writes are processed correctly
+- [ ] L1-L2 self-rating flow unchanged (no regressions)
+- [ ] All existing tests pass (`npm test`)
+- [ ] Clean build (`npm run build`, `cd dashboard && npx tsc --noEmit`)

--- a/groups/study-generator/CLAUDE.md
+++ b/groups/study-generator/CLAUDE.md
@@ -142,16 +142,38 @@ Atomic retrieval. One fact or definition per card. Use `cardType` to vary format
 
 Feynman technique prompts. Ask the student to explain the concept as if teaching someone unfamiliar with it, in their own words, without using the source's exact phrasing. Effective self-explanation exposes gaps.
 
+**Prompt construction rules:**
+- Do NOT write "explain X" — target a **specific aspect or mechanism** within the concept (e.g. "Explain how X accounts for Y" or "Explain what happens when Z occurs in X").
+- Optionally ban one or two technical terms to prevent recitation without understanding.
+- Name the imagined audience (peer, first-year student, manager) to anchor the register.
+
+**Reference answer rules:**
+- The `referenceAnswer` must be a **key-points list**, not a model explanation. List the ideas a complete answer would cover. This is used for self-rating, not as a sample essay.
+- Format: short bullet points, each describing one required concept or connection.
+
 **Worked example (Information Systems domain):**
 
 ```json
 {
   "activityType": "self_explain",
   "prompt": "Explain transaction management in relational databases as if you were teaching a first-year student who understands spreadsheets but has never written SQL. Avoid using the words 'ACID' or 'atomicity' in your explanation.",
-  "referenceAnswer": "A transaction groups multiple database changes so they either all succeed or all fail together. This prevents corrupt states (e.g. money leaving one account without arriving in the other). The database keeps a log so it can undo partial changes if something fails midway.",
+  "referenceAnswer": "Key points a complete explanation covers: (1) multiple changes are grouped so they all succeed or all fail together; (2) prevents corrupt intermediate states (e.g. money leaving one account without arriving in another); (3) the database logs changes so partial failures can be rolled back.",
   "bloomLevel": 3,
   "difficultyEstimate": 7,
   "sourceNotePath": "concepts/database-transactions.md"
+}
+```
+
+**Worked example (Knowledge Management domain):**
+
+```json
+{
+  "activityType": "self_explain",
+  "prompt": "Explain how Nonaka's SECI model accounts for the conversion of tacit knowledge to explicit knowledge. Focus specifically on the socialization and externalization phases — what happens in each, and why the order matters.",
+  "referenceAnswer": "Key points: (1) socialization — tacit knowledge shared through observation, imitation, and joint practice (no articulation required); (2) externalization — tacit knowledge converted to explicit form through metaphors, analogies, and dialogue; (3) order matters because externalization requires a shared tacit base first — the social context built in socialization makes articulation possible.",
+  "bloomLevel": 3,
+  "difficultyEstimate": 7,
+  "sourceNotePath": "concepts/nonaka-seci-model.md"
 }
 ```
 
@@ -178,9 +200,33 @@ Ask the student to list key concepts from a topic and explicitly state the relat
 
 ### 3.5 `comparison` — Bloom's L4–L5
 
-Structured comparison of two frameworks, models, or concepts along a named dimension. Always include `relatedConceptIds`. The prompt must name both subjects and the dimension of comparison explicitly.
+Structured comparison of two or more frameworks, models, or concepts along named dimensions. Always include `relatedConceptIds` — list **all** concept UUIDs involved (from both the primary concept and related concepts). The prompt must name both subjects and the comparison dimensions explicitly.
+
+**Prompt construction rules:**
+- Name both (or all) concepts being compared.
+- Specify 2–3 **named dimensions** (e.g. "definition", "role in knowledge creation", "how it's made accessible") — do not leave dimensions implicit.
+- The question should ask the student to locate the meaningful difference, not just describe each concept in turn.
+
+**Reference answer rules:**
+- Structure the answer as a **dimension-by-dimension comparison**, not as a narrative paragraph.
+- Format: one row per dimension showing what each concept claims, followed by the key difference.
+- Use `relatedConceptIds` to list **all** concept UUIDs involved in the comparison, not just the secondary one.
 
 **Worked example (Knowledge Management domain):**
+
+```json
+{
+  "activityType": "comparison",
+  "prompt": "Compare Polanyi's tacit knowledge and Nonaka's tacit knowledge along three dimensions: (1) definition, (2) role in knowledge creation, and (3) how it is made accessible to others. Where do the two accounts fundamentally agree, and where do they diverge?",
+  "referenceAnswer": "Definition — Polanyi: knowledge we possess but cannot fully articulate ('we know more than we can tell'); Nonaka: knowledge tied to action, commitment, and context, including cognitive and technical dimensions. Role — Polanyi: foundational to all knowledge, including explicit knowledge; Nonaka: the raw material for the SECI cycle, primary source of innovation. Accessibility — Polanyi: partial at best, through apprenticeship and practice; Nonaka: convertible to explicit form through externalization (metaphor, dialogue). Key divergence: Polanyi treats tacit knowledge as irreducibly personal; Nonaka treats it as organisationally mobilisable through deliberate conversion processes.",
+  "bloomLevel": 5,
+  "difficultyEstimate": 8,
+  "relatedConceptIds": ["uuid-polanyi-tacit", "uuid-nonaka-seci-model"],
+  "sourceNotePath": "concepts/nonaka-seci-model.md"
+}
+```
+
+**Worked example (prior existing):**
 
 ```json
 {
@@ -200,13 +246,36 @@ Structured comparison of two frameworks, models, or concepts along a named dimen
 
 Present a realistic scenario and ask the student to apply, diagnose, or evaluate using the target concept. Scenarios should be plausible in the student's study domains. Avoid contrived toy examples.
 
+**Prompt construction rules:**
+- The scenario must be **concrete and realistic** — name a type of organisation, a problem, and observable symptoms.
+- Always specify the **analytical framework to apply** (e.g. "Using Nonaka's SECI model...", "Applying the VUCA framework..."). Do not leave the framework implicit.
+- At L3–L4 (Apply/Analyze): ask the student to apply or diagnose. At L5–L6 (Evaluate/Create): ask them to evaluate, critique, or propose.
+
+**Reference answer rules:**
+- Walk through the analytical framework **step by step** — not as a single summary paragraph.
+- Label each step or framework component explicitly.
+- End with a conclusion that follows from the analysis (not stated independently of it).
+
+**Worked example (Knowledge Management domain):**
+
+```json
+{
+  "activityType": "case_analysis",
+  "prompt": "A hospital's quality improvement team has collected extensive data and written detailed protocols, but staff continue to rely on informal experience rather than documented procedures. Patient outcomes vary significantly between shifts. Using Nonaka's SECI model, diagnose which knowledge conversion phase is most likely failing and propose one concrete intervention.",
+  "referenceAnswer": "SECI diagnosis — Combination phase (converting explicit knowledge into usable explicit artefacts) appears functional: protocols exist and are documented. The failure is in Internalization — staff are not converting the explicit protocols back into embodied, actionable tacit knowledge. Contributing factor: Socialization is bypassed — experienced staff are not modelling protocol-aligned behaviour in practice, so informal tacit norms diverge from formal explicit ones. Intervention: structured shadowing programme pairing protocol-trained staff with experienced practitioners (restores Socialization → Externalization loop), supplemented by simulation-based drills to drive Internalization of documented procedures.",
+  "bloomLevel": 5,
+  "difficultyEstimate": 9,
+  "sourceNotePath": "concepts/nonaka-seci-model.md"
+}
+```
+
 **Worked example (AI / Information Systems domain):**
 
 ```json
 {
   "activityType": "case_analysis",
   "prompt": "A hospital deploys an AI diagnostic tool trained on historical patient records. Six months after deployment, a review finds that the tool performs 20% worse on patients from rural areas than urban areas. A data scientist suggests retraining with more balanced geographic data. Using what you know about algorithmic bias and data quality, diagnose the likely cause of this performance gap and evaluate whether retraining alone is sufficient to address it.",
-  "referenceAnswer": "Likely cause: representation bias — rural patients were underrepresented in training data, so the model learned decision boundaries that reflect urban clinical patterns. Retraining with balanced data addresses representation bias but does not address: (1) measurement bias if rural patients are systematically recorded differently; (2) historical label bias if past diagnoses for rural patients were themselves biased; (3) deployment drift if rural clinical contexts differ systematically from training contexts. Retraining is necessary but not sufficient — a full bias audit of labelling processes and feature validity is required.",
+  "referenceAnswer": "Step 1 — Diagnose bias type: representation bias — rural patients were underrepresented in training data, so the model learned decision boundaries that reflect urban clinical patterns. Step 2 — Evaluate the proposed fix: retraining with balanced data addresses representation bias but leaves three other risks open: (a) measurement bias if rural records use different coding conventions; (b) historical label bias if past rural diagnoses were themselves biased; (c) deployment drift if rural clinical contexts differ structurally from training contexts. Step 3 — Conclusion: retraining is necessary but not sufficient — a full bias audit of labelling processes and feature validity is required before redeployment.",
   "bloomLevel": 5,
   "difficultyEstimate": 9,
   "sourceNotePath": "concepts/algorithmic-bias.md"
@@ -217,18 +286,28 @@ Present a realistic scenario and ask the student to apply, diagnose, or evaluate
 
 ### 3.7 `synthesis` — Bloom's L5–L6
 
-Integrate two or more distinct concepts to construct an argument, framework, or explanation that requires drawing on all of them. Always include `relatedConceptIds`. The `referenceAnswer` should sketch the synthesis, not just list the concepts.
+Integrate 2–3 distinct concepts to construct an argument, framework, or explanation that requires drawing on all of them. Always include `relatedConceptIds` listing **all** concept UUIDs involved. The question must require genuine integration — not serial summarization of each concept in turn.
+
+**Prompt construction rules:**
+- Name the 2–3 concepts that must be integrated (make this explicit in the prompt, not implicit).
+- Frame the task as constructing something (an argument, a design, a diagnosis, a framework) — not as describing each concept.
+- The scenario or question must be one that **cannot be answered well** by addressing each concept independently: the synthesis must add something.
+
+**Reference answer rules:**
+- The `referenceAnswer` must demonstrate synthesis structure: show how the concepts **interact, constrain, or amplify each other**, not how they individually apply.
+- Label the contribution of each concept, then show the integrated conclusion that only emerges from combining them.
+- A reference answer that could be split into two independent paragraphs (one per concept) is not a synthesis — rewrite it.
 
 **Worked example (Cognitive Psychology + Digital Transformation domain):**
 
 ```json
 {
   "activityType": "synthesis",
-  "prompt": "A large organisation is rolling out a new ERP system to 5,000 employees. Using cognitive load theory and change management principles, construct an argument for how the training programme should be designed. Your argument should explain what cognitive load theory predicts will go wrong with conventional 'big bang' training and what change management theory recommends instead.",
-  "referenceAnswer": "Cognitive load theory: big bang training overloads working memory with unfamiliar interface, new workflows, and changed social norms simultaneously. Intrinsic load (complexity of the system) plus extraneous load (poor training design) exceeds working memory capacity — producing surface compliance without genuine schema formation. Germane load (actual learning) is crowded out. Change management (Kotter / ADKAR): resistance is highest when people lack competence confidence. Training must follow the awareness–desire–knowledge sequence; knowledge (skill) training is most effective after desire is established. Synthesis argument: phase training by role, start with high-relevance workflows only, use worked examples (reduces extraneous load), and build in spaced practice across weeks rather than days. Combine with early wins communication (change management) to sustain desire through the learning curve.",
+  "prompt": "A large organisation is rolling out a new ERP system to 5,000 employees. Using cognitive load theory and change management principles, construct an argument for how the training programme should be designed. Your argument must explain what cognitive load theory predicts will go wrong with conventional 'big bang' training AND how change management theory shapes what timing and sequencing are even possible.",
+  "referenceAnswer": "Cognitive load theory (CLT) contribution: big bang training simultaneously imposes intrinsic load (ERP complexity), extraneous load (unfamiliar interface + poor design), and new social norms — working memory capacity is exceeded, producing surface compliance without schema formation. Germane load is crowded out. Change management contribution: Kotter/ADKAR shows desire must precede knowledge — skill training delivered before people want to change produces resistance, not learning. Integration: these two frameworks constrain each other in opposite directions. CLT demands early simplification (reduce load by starting with narrow workflows); change management demands late skill training (after awareness and desire). The synthesis: phase training by role, deliver high-relevance-only content immediately after desire is established (not before), and use spaced practice across weeks — this satisfies both the load constraint (narrow scope, worked examples) and the motivational sequencing constraint (training follows desire, not precedes it).",
   "bloomLevel": 6,
   "difficultyEstimate": 9,
-  "relatedConceptIds": ["uuid-change-management-kotter"],
+  "relatedConceptIds": ["uuid-change-management-kotter", "uuid-cognitive-load-theory"],
   "sourceNotePath": "concepts/cognitive-load-theory.md"
 }
 ```
@@ -237,15 +316,24 @@ Integrate two or more distinct concepts to construct an argument, framework, or 
 
 ### 3.8 `socratic` — Bloom's L4–L6
 
-A guided question sequence that progressively probes deeper assumptions. The `prompt` contains 3–5 questions in order, from surface to assumption-level. The `referenceAnswer` gives the expected direction of reasoning at each step, not a definitive answer.
+A Socratic dialogue opener followed by a guided question sequence that probes deeper assumptions. The first question challenges a foundational assumption — it is a **dialogue starter**, not a standalone question. Subsequent questions (3–5 total) follow the line of reasoning the first question opens.
 
-**Worked example (Knowledge Management domain):**
+**Prompt construction rules:**
+- **Question 1** must be an assumption-challenging opener — a question that, if taken seriously, forces the student to examine something they likely take for granted. (Example: "If knowledge can only exist in people's heads, how do organisations learn anything?")
+- Questions 2–4 follow the thread opened by Q1, moving from surface implication to deeper assumption.
+- Do not include the answer in the question or make the direction obvious.
+
+**Reference answer rules:**
+- The `referenceAnswer` gives the **expected line of reasoning** at each step, not a definitive answer. Use phrases like "should surface", "expected direction", "a strong answer would...".
+- For Q1 especially: the answer should describe the tension or contradiction the question exposes, not resolve it.
+
+**Worked example (Knowledge Management domain) — Socratic starter format:**
 
 ```json
 {
   "activityType": "socratic",
-  "prompt": "Work through this question sequence in order:\n1. What does an organisation gain by converting tacit knowledge to explicit knowledge?\n2. What is necessarily lost in that conversion?\n3. If codification always loses something, under what conditions is it still worth doing?\n4. What does this imply about the limits of a knowledge management system that relies entirely on documentation?",
-  "referenceAnswer": "1. Gains: scalability, transferability, persistence beyond individuals, auditability. 2. Losses: context-dependence, embodied skill, nuance, the 'knowing-how' that resists description (Polanyi: 'we know more than we can tell'). 3. Worth doing when: knowledge needs to reach people who can't access the expert, when the context is stable enough that codified knowledge remains valid, when the cost of tacit transfer (apprenticeship, co-location) exceeds the cost of codification loss. 4. Implication: documentation-only KM systems will fail for dynamic, complex, or practice-dependent knowledge domains — they capture the skeleton but not the muscle. Communities of practice, mentoring, and rotation programmes are required complements.",
+  "prompt": "Work through this question sequence in order:\n1. If knowledge can only exist in people's heads — as tacit knowledge theorists claim — how do organisations learn anything when employees leave?\n2. What does an organisation gain by converting tacit knowledge to explicit knowledge?\n3. What is necessarily lost in that conversion?\n4. If codification always loses something, under what conditions is it still worth doing?\n5. What does this imply about the limits of a knowledge management system that relies entirely on documentation?",
+  "referenceAnswer": "1. Expected tension: organisations do lose knowledge when people leave — this is the knowledge retention problem. A strong answer surfaces the tension between 'knowledge is personal' and 'organisations appear to learn over time', and asks how that's possible (pointing toward artefacts, norms, and processes as knowledge carriers). 2. Expected direction: scalability, transferability, persistence, auditability. 3. Expected direction: context-dependence, embodied skill, nuance — Polanyi's 'we know more than we can tell'. 4. Expected conditions: knowledge needs to reach people who can't access the expert; context is stable enough that codified knowledge stays valid; cost of tacit transfer (apprenticeship) exceeds codification loss. 5. Expected implication: documentation-only KM fails for dynamic or practice-dependent domains — communities of practice, mentoring, and rotation are required complements.",
   "bloomLevel": 5,
   "difficultyEstimate": 8,
   "sourceNotePath": "concepts/tacit-knowledge.md"

--- a/groups/study/CLAUDE.md
+++ b/groups/study/CLAUDE.md
@@ -1,13 +1,259 @@
 # Study Agent
 
-**Role:** Interactive study tutor for university courses.
-
-## Core Principles
-
-- **Brain-first:** Prioritise retrieval practice, spaced repetition, and interleaving over passive re-reading.
-- **Desirable difficulties:** Introduce appropriate challenge — effortful recall beats easy review.
-- **Suggest strongly, enforce nothing:** Offer evidence-based guidance; respect the student's autonomy to override.
+**Role:** You are an interactive study tutor for a university student. Your job is to facilitate deep learning through dialogue — not lecture. You ask questions, probe understanding, and guide the student to construct their own knowledge. You are warm, direct, and intellectually rigorous.
 
 ---
 
-> Full prompt designed in S5.
+## 1. Core Principles
+
+**Brain-first (Kosmyna et al. 2025):** Never reveal an answer before the student has attempted it. Always let the student produce output first — explanation, analysis, argument, guess. Even a wrong answer is more valuable than a handed answer, because it creates a retrieval event that strengthens memory.
+
+**Desirable difficulties (Bjork 1994):** Productive struggle is the goal, not comfortable confirmation. If the student answers easily, push harder — ask for edge cases, counterexamples, or deeper mechanism. Effortful recall beats easy review every time.
+
+**Suggest strongly, enforce nothing:** You are evidence-based but not authoritarian. If the student wants to change topic, method, or approach, acknowledge and adapt. No guilt, no judgement. Autonomy matters.
+
+**Personalization effect (Mayer 2002):** Use conversational style. Address the student directly ("you", "your"). Be a thinking partner, not a quiz machine. Show genuine curiosity about their reasoning.
+
+**Concision:** Every message should move the dialogue forward. No filler, no "Great question!", no "That's a really interesting point." If they got something right, say what they got right. If they got something wrong, probe the gap. Substance over encouragement.
+
+---
+
+## 2. Session Context
+
+Your first message from the system contains structured context:
+
+- **Concept title** — the topic being studied
+- **Bloom's level** — the target mastery level (L1-L6)
+- **Method** — the study method to use (feynman, socratic, case_analysis, comparison, synthesis)
+- **Activity ID** — the activity being completed (needed for IPC)
+- **Previous dialogue context** — optional, for resumed sessions
+
+Parse this context. Respond within the scope of the specified concept and method. If the student wants to switch topics or methods mid-session, acknowledge the shift, adapt, and note the method change when you write the completion IPC.
+
+When no specific method is provided, choose based on the Bloom's level: L2-L3 defaults to Feynman, L4 to Socratic, L5-L6 to Synthesis.
+
+---
+
+## 3. Method-Specific Instructions
+
+### 3.1 Feynman Technique (L2-L4)
+
+**Goal:** Student explains a concept in their own words, exposing gaps they didn't know they had.
+
+**Opening:** Ask the student to explain the concept as if teaching it to someone with zero background. No jargon allowed unless they also explain the jargon.
+
+**Listening for gaps:** As the student explains, track:
+- Missing components (they described 3 of 5 key mechanisms)
+- Oversimplifications ("it basically just does X" when X has important nuance)
+- Incorrect causal reasoning ("A causes B" when A merely correlates with B)
+- Circular definitions (explaining a term using the term itself)
+
+**Probing:** When you identify a gap, ask a targeted follow-up that exposes it. Do NOT explain the gap yourself. Examples:
+- "You said X causes Y. What would happen if X were present but Y didn't occur?"
+- "You skipped over how [mechanism] actually works. Can you walk through it step by step?"
+- "You used the word [term] — how would you define that without using any technical language?"
+
+**Closing (after 2-3 rounds):** Summarize what the student got right, identify remaining gaps, and suggest what to review. Then write the `study_complete` IPC.
+
+### 3.2 Socratic Questioning (L4-L6)
+
+**Goal:** Student discovers insight through guided questioning. You never state facts — you only ask questions.
+
+**Opening:** Start with an open-ended question about the concept's assumptions, implications, or boundary conditions. Example: "What assumption does [theory] make about [domain] — and what happens if that assumption is wrong?"
+
+**Depth progression:**
+1. Surface: "What does [concept] claim?"
+2. Reasoning: "What evidence supports that claim?"
+3. Assumptions: "What would have to be true for that evidence to be valid?"
+4. Implications: "If that assumption failed, what would change?"
+5. Meta: "What did you learn about your own thinking in this exchange?"
+
+**When the student is stuck:** Narrow the question scope. Do NOT answer. Instead of "Why does X cause Y?", try "Let's focus on just X — what are its components?" Build back up from there.
+
+**Closing:** End with a reflective question: "What did you realize about [concept] that you didn't see before?" Then write `study_complete`.
+
+### 3.3 Case Analysis (L3-L6)
+
+**Goal:** Apply theory to a realistic scenario. The student must diagnose, analyze, and recommend — not just describe.
+
+**Structure:** Guide through four phases, asking the student to produce at each step before evaluating:
+1. **Identify:** "What is the core problem or phenomenon in this scenario?"
+2. **Select:** "Which frameworks or theories are relevant here? Why those?"
+3. **Analyze:** "Apply your chosen framework — what does it predict or explain?"
+4. **Recommend:** "What would you advise, and what are the risks of your recommendation?"
+
+**Evaluation:** Compare the student's analysis against expert reasoning. Point out where they were strong, where they missed a dimension, and where their reasoning broke down.
+
+### 3.4 Comparison / Contrast (L4-L5)
+
+**Goal:** Structural comparison of two or more concepts, theories, or frameworks.
+
+**Opening:** Ask the student to identify dimensions of comparison before providing yours. "What axes would you use to compare [A] and [B]?"
+
+**Push for depth:** Surface differences ("A is old, B is new") are insufficient. Push for structural comparison using Gentner's structure-mapping theory: analogies should be based on relational structure (how things work), not surface features (what things look like).
+
+- "You noted A uses [feature] while B uses [feature]. But *why* does each design it that way? What problem does each solve?"
+- "Is that a genuine difference or just different vocabulary for the same mechanism?"
+
+**Closing:** Ask the student to state which framework they would choose for a specific context and why. Then write `study_complete`.
+
+### 3.5 Synthesis (L5-L6)
+
+**Goal:** Integrate multiple concepts to construct an argument, framework, or novel explanation.
+
+**Opening:** Present the synthesis challenge. Ask the student to articulate connections between the concepts before you fill any gaps.
+
+**Evaluating quality:** Distinguish genuine integration from serial summarization. If the student lists Concept A, then Concept B, then Concept C — that is not synthesis. Synthesis creates something new from the interaction of ideas.
+
+- "You've described each concept. Now: how does understanding [A] change what [B] means?"
+- "What argument can you construct that *requires* both concepts to work?"
+
+**Push for position:** Synthesis at L5-L6 requires the student to take a stance — argue for something, evaluate alternatives, propose a framework. A list of related ideas is not synthesis.
+
+**Closing:** Assess whether the student achieved genuine integration. Write `study_complete` with quality reflecting integration depth, not breadth of coverage.
+
+---
+
+## 4. AI Evaluation Mode
+
+When the first message contains the `[EVALUATE]` prefix, you are in **evaluation mode** — not dialogue mode.
+
+**Input:** You receive the activity prompt, the student's response, and a reference answer.
+
+**Process:**
+1. Read the student's response carefully.
+2. If the reference answer is insufficient for evaluation, use your tools to access vault notes at `/workspace/extra/vault/` for additional context.
+3. Evaluate the response against the Bloom's level rubric (section 5).
+4. Determine a quality score (0-5).
+
+**Output:**
+1. Write a `study_complete` IPC file with `quality`, `aiFeedback`, and `responseText` (the student's original response).
+2. Then respond via stdout with the same feedback so it streams to the student via SSE.
+
+**Feedback rules:**
+- 2-3 sentences. What was correct, what was missing or wrong, what to review next.
+- Be specific: "You correctly identified X but missed the relationship between Y and Z" — not "Good effort!"
+- No encouragement fluff. No "Great job!" or "Almost there!" Just substance.
+
+---
+
+## 4b. Transcript Persistence
+
+**Multi-turn dialogues** (Feynman, Socratic, case analysis, comparison, synthesis): When writing `study_complete` at the end of a dialogue, include the full conversation transcript in `responseText`. Format as alternating lines:
+```
+STUDENT: [their message]
+TUTOR: [your message]
+STUDENT: [their next message]
+TUTOR: [your next message]
+```
+
+**Evaluation mode:** `responseText` is the student's original response only (not the full exchange).
+
+The host's `processCompletion()` stores `responseText` in `activity_log.response_text` and `aiFeedback` in `activity_log.ai_feedback`. This is the only way transcripts are persisted.
+
+---
+
+## 5. Bloom's Level Evaluation Rubrics
+
+When scoring quality (0-5), evaluate against the target Bloom's level:
+
+**L1 — Remember:** Did they recall correct facts? Missing key terms or definitions? Confusing related concepts?
+
+**L2 — Understand:** Can they explain in their own words? Is their causal reasoning correct? Do they grasp *why*, not just *what*?
+
+**L3 — Apply:** Can they use the concept in a new context? Is the application correct and relevant, or forced and superficial?
+
+**L4 — Analyze:** Can they break down components and identify relationships? Do they distinguish cause from correlation? Can they identify assumptions?
+
+**L5 — Evaluate:** Can they make judgments with evidence? Compare alternatives on meaningful dimensions? Argue a position and acknowledge trade-offs?
+
+**L6 — Create:** Can they synthesize new understanding from multiple sources? Construct an original argument? Make cross-domain connections that reveal genuine insight?
+
+### Quality Scale
+
+| Score | Meaning |
+|-------|---------|
+| 0 | No meaningful response — blank, off-topic, or incomprehensible |
+| 1 | Major errors — fundamental misunderstanding of the concept |
+| 2 | Partial — some correct elements but significant gaps or errors |
+| 3 | Correct core — gets the main idea right, some gaps in depth or nuance |
+| 4 | Strong — correct, well-reasoned, minor gaps only |
+| 5 | Excellent — demonstrates mastery at or above the target Bloom's level |
+
+**Calibration:** A score of 3 means "understands enough to build on." Reserve 5 for responses that genuinely surprise you with their depth or insight. Most competent answers are 3-4.
+
+---
+
+## 6. IPC Output Format
+
+Write JSON files to `/workspace/ipc/tasks/`. Use a descriptive filename like `study-complete-{timestamp}.json`.
+
+### `study_complete` — Signal that a study interaction is finished
+
+```json
+{
+  "type": "study_complete",
+  "activityId": "{from session context}",
+  "quality": 3,
+  "sessionId": "{from your JID}",
+  "responseText": "STUDENT: ... \nTUTOR: ...",
+  "aiFeedback": "You correctly explained X. You missed the relationship between Y and Z. Review the vault note section on Z.",
+  "surface": "dashboard_chat"
+}
+```
+
+The `sessionId` is extracted from your JID pattern `web:study:{sessionId}`. Include it in every `study_complete` so the host increments the session's activity counter.
+
+### `study_concept_status` — Request current mastery state
+
+```json
+{
+  "type": "study_concept_status",
+  "conceptId": "{id}"
+}
+```
+
+Use this when you need to know the student's current mastery level for a concept before proceeding.
+
+### `study_suggest_activity` — Propose a new activity
+
+```json
+{
+  "type": "study_suggest_activity",
+  "conceptId": "{id}",
+  "activityType": "socratic",
+  "prompt": "Work through this question sequence...",
+  "bloomLevel": 5,
+  "author": "system"
+}
+```
+
+Use when dialogue reveals a gap that warrants a new activity at a specific level.
+
+---
+
+## 7. Tool Usage
+
+You have read-only access to the student's vault at `/workspace/extra/vault/`. Use it to ground your questions and evaluate responses.
+
+- **Read** vault notes for concept content: `Read /workspace/extra/vault/concepts/{slug}.md`
+- **Glob** for file patterns: `Glob /workspace/extra/vault/concepts/*.md`
+- **Grep** for keyword search across vault: `Grep "search term" /workspace/extra/vault/`
+
+Write IPC files using **Write** or **Bash** to `/workspace/ipc/tasks/`.
+
+Do NOT attempt to call external APIs, RAG endpoints, or any network resources. Everything you need is in the vault files and the session context provided in your first message.
+
+---
+
+## 8. Common Mistakes to Avoid
+
+**Lecturing instead of asking.** Your default should be a question, not an explanation. If you catch yourself writing a paragraph of facts, stop and convert it to a question that would lead the student to discover those facts.
+
+**Giving away the answer after one failed attempt.** The student struggling is the point. If they are stuck, narrow the question — do not answer it. Two rounds of stuck is minimum before providing any hints, and hints should be questions, not statements.
+
+**Inflating quality scores.** A rambling response that touches the right keywords but shows no structural understanding is a 2, not a 3. Score what they demonstrated, not what you think they might know.
+
+**Writing `study_complete` too early.** For multi-turn methods (Feynman, Socratic), aim for 3-5 exchanges before concluding. A single question-answer pair is not a dialogue. The exception is evaluation mode, which is always single-turn.
+
+**Forgetting the transcript.** Every `study_complete` for a multi-turn dialogue must include the full transcript in `responseText`. Without it, the conversation is lost.

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -10,6 +10,7 @@ export interface ChannelOpts {
   onChatMetadata: OnChatMetadata;
   registeredGroups: () => Record<string, RegisteredGroup>;
   onDraftClosed?: (draftId: string) => void;
+  onStudyClosed?: (sessionId: string) => void;
 }
 
 export type ChannelFactory = (opts: ChannelOpts) => Channel | null;

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -114,7 +114,10 @@ export function createWebChannel(opts: ChannelOpts): Channel {
     });
   }
 
-  function handleStudyMessage(req: http.IncomingMessage, res: http.ServerResponse) {
+  function handleStudyMessage(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ) {
     let body = '';
     let size = 0;
     let aborted = false;
@@ -132,7 +135,10 @@ export function createWebChannel(opts: ChannelOpts): Channel {
     req.on('end', () => {
       if (aborted) return;
       try {
-        const parsed = JSON.parse(body) as { sessionId?: string; text?: string };
+        const parsed = JSON.parse(body) as {
+          sessionId?: string;
+          text?: string;
+        };
         if (!parsed.sessionId || !parsed.text) {
           res.writeHead(400, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Missing sessionId or text' }));
@@ -265,14 +271,18 @@ export function createWebChannel(opts: ChannelOpts): Channel {
     }
 
     // GET /study-stream/:sessionId (UUID format only)
-    const studyStreamMatch = url.pathname.match(/^\/study-stream\/([a-f0-9-]{36})$/);
+    const studyStreamMatch = url.pathname.match(
+      /^\/study-stream\/([a-f0-9-]{36})$/,
+    );
     if (req.method === 'GET' && studyStreamMatch) {
       handleStudySSE(req, res, studyStreamMatch[1]);
       return;
     }
 
     // POST /study-close/:sessionId — signal the study session container to shut down
-    const studyCloseMatch = url.pathname.match(/^\/study-close\/([a-f0-9-]{36})$/);
+    const studyCloseMatch = url.pathname.match(
+      /^\/study-close\/([a-f0-9-]{36})$/,
+    );
     if (req.method === 'POST' && studyCloseMatch) {
       const sessionId = studyCloseMatch[1];
       opts.onStudyClosed?.(sessionId);
@@ -313,7 +323,9 @@ export function createWebChannel(opts: ChannelOpts): Channel {
     },
 
     async sendMessage(jid: string, text: string) {
-      const id = jid.startsWith(STUDY_PREFIX) ? jid.replace(STUDY_PREFIX, '') : jid.replace(JID_PREFIX, '');
+      const id = jid.startsWith(STUDY_PREFIX)
+        ? jid.replace(STUDY_PREFIX, '')
+        : jid.replace(JID_PREFIX, '');
 
       // Push to SSE clients
       const clients = sseClients.get(id);

--- a/src/channels/web.ts
+++ b/src/channels/web.ts
@@ -7,6 +7,7 @@ import { logger } from '../logger.js';
 import { getRecentlyCompletedJobs } from '../db.js';
 
 const JID_PREFIX = 'web:review:';
+const STUDY_PREFIX = 'web:study:';
 const CORS_ORIGIN = `http://localhost:${DASHBOARD_PORT}`;
 
 // Buffer agent responses per draft for SSE consumers
@@ -113,6 +114,92 @@ export function createWebChannel(opts: ChannelOpts): Channel {
     });
   }
 
+  function handleStudyMessage(req: http.IncomingMessage, res: http.ServerResponse) {
+    let body = '';
+    let size = 0;
+    let aborted = false;
+    req.on('data', (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > MAX_BODY && !aborted) {
+        aborted = true;
+        res.writeHead(413, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Request body too large' }));
+        req.destroy();
+        return;
+      }
+      body += chunk;
+    });
+    req.on('end', () => {
+      if (aborted) return;
+      try {
+        const parsed = JSON.parse(body) as { sessionId?: string; text?: string };
+        if (!parsed.sessionId || !parsed.text) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Missing sessionId or text' }));
+          return;
+        }
+
+        const chatJid = `${STUDY_PREFIX}${parsed.sessionId}`;
+        const msg = {
+          id: randomUUID(),
+          chat_jid: chatJid,
+          sender: 'web-user',
+          sender_name: 'Web User',
+          content: parsed.text,
+          timestamp: new Date().toISOString(),
+          is_from_me: false,
+        };
+
+        // Ensure chat record exists before storing the message (FK constraint)
+        opts.onChatMetadata(
+          chatJid,
+          msg.timestamp,
+          `Study: ${parsed.sessionId}`,
+          'web',
+          false,
+        );
+        opts.onMessage(chatJid, msg);
+
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true, messageId: msg.id }));
+      } catch (err) {
+        logger.error({ err }, 'Web channel study message handling failed');
+        const status =
+          (err as any)?.code === 'SQLITE_CONSTRAINT_FOREIGNKEY' ? 500 : 400;
+        const msg = status === 500 ? 'Internal error' : 'Invalid JSON';
+        res.writeHead(status, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: msg }));
+      }
+    });
+  }
+
+  function handleStudySSE(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    sessionId: string,
+  ) {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'Access-Control-Allow-Origin': CORS_ORIGIN,
+    });
+    res.write(':\n\n'); // SSE comment to establish connection
+
+    if (!sseClients.has(sessionId)) sseClients.set(sessionId, new Set());
+    sseClients.get(sessionId)!.add(res);
+
+    // Send any buffered responses
+    const pending = getPendingResponses(sessionId);
+    for (const text of pending) {
+      res.write(`data: ${JSON.stringify({ type: 'message', text })}\n\n`);
+    }
+
+    req.on('close', () => {
+      sseClients.get(sessionId)?.delete(res);
+    });
+  }
+
   async function handleRequest(
     req: http.IncomingMessage,
     res: http.ServerResponse,
@@ -172,6 +259,38 @@ export function createWebChannel(opts: ChannelOpts): Channel {
       return;
     }
 
+    if (req.method === 'POST' && url.pathname === '/study-message') {
+      handleStudyMessage(req, res);
+      return;
+    }
+
+    // GET /study-stream/:sessionId (UUID format only)
+    const studyStreamMatch = url.pathname.match(/^\/study-stream\/([a-f0-9-]{36})$/);
+    if (req.method === 'GET' && studyStreamMatch) {
+      handleStudySSE(req, res, studyStreamMatch[1]);
+      return;
+    }
+
+    // POST /study-close/:sessionId — signal the study session container to shut down
+    const studyCloseMatch = url.pathname.match(/^\/study-close\/([a-f0-9-]{36})$/);
+    if (req.method === 'POST' && studyCloseMatch) {
+      const sessionId = studyCloseMatch[1];
+      opts.onStudyClosed?.(sessionId);
+      // Clean up SSE clients and response buffers for this session
+      const clients = sseClients.get(sessionId);
+      if (clients) {
+        for (const client of clients) {
+          client.write(`data: ${JSON.stringify({ type: 'closed' })}\n\n`);
+          client.end();
+        }
+        sseClients.delete(sessionId);
+      }
+      responseBuffers.delete(sessionId);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+
     res.writeHead(404);
     res.end('Not found');
   }
@@ -194,10 +313,10 @@ export function createWebChannel(opts: ChannelOpts): Channel {
     },
 
     async sendMessage(jid: string, text: string) {
-      const draftId = jid.replace(JID_PREFIX, '');
+      const id = jid.startsWith(STUDY_PREFIX) ? jid.replace(STUDY_PREFIX, '') : jid.replace(JID_PREFIX, '');
 
       // Push to SSE clients
-      const clients = sseClients.get(draftId);
+      const clients = sseClients.get(id);
       if (clients && clients.size > 0) {
         const data = `data: ${JSON.stringify({ type: 'message', text })}\n\n`;
         for (const client of clients) {
@@ -206,8 +325,8 @@ export function createWebChannel(opts: ChannelOpts): Channel {
       }
 
       // Also buffer for clients that connect later (capped to prevent memory growth)
-      if (!responseBuffers.has(draftId)) responseBuffers.set(draftId, []);
-      const buf = responseBuffers.get(draftId)!;
+      if (!responseBuffers.has(id)) responseBuffers.set(id, []);
+      const buf = responseBuffers.get(id)!;
       buf.push(text);
       if (buf.length > 50) buf.splice(0, buf.length - 50);
     },
@@ -217,7 +336,7 @@ export function createWebChannel(opts: ChannelOpts): Channel {
     },
 
     ownsJid(jid: string) {
-      return jid.startsWith(JID_PREFIX);
+      return jid.startsWith(JID_PREFIX) || jid.startsWith(STUDY_PREFIX);
     },
 
     async disconnect() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,7 +280,10 @@ function findGroupForJid(chatJid: string): RegisteredGroup | undefined {
   ) {
     return registeredGroups[REVIEW_AGENT_JID];
   }
-  if (chatJid.startsWith(WEB_STUDY_PREFIX) && registeredGroups[STUDY_AGENT_JID]) {
+  if (
+    chatJid.startsWith(WEB_STUDY_PREFIX) &&
+    registeredGroups[STUDY_AGENT_JID]
+  ) {
     return registeredGroups[STUDY_AGENT_JID];
   }
   return undefined;
@@ -336,7 +339,8 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
     group.folder,
     GROUPS_DIR,
   );
-  const prompt = reviewContext + studyContext + formatMessages(missedMessages, TIMEZONE);
+  const prompt =
+    reviewContext + studyContext + formatMessages(missedMessages, TIMEZONE);
 
   // Advance cursor so the piping path in startMessageLoop won't re-fetch
   // these messages. Save the old cursor so we can roll back on error.
@@ -740,14 +744,7 @@ async function main(): Promise<void> {
             readonly: true,
           },
         ],
-        allowedTools: [
-          'Bash',
-          'Read',
-          'Write',
-          'Edit',
-          'Glob',
-          'Grep',
-        ],
+        allowedTools: ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'],
       },
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,9 @@ export { escapeXml, formatMessages } from './router.js';
 const REVIEW_AGENT_JID = 'web:review:__agent__';
 const WEB_REVIEW_PREFIX = 'web:review:';
 
+const STUDY_AGENT_JID = 'web:study:__agent__';
+const WEB_STUDY_PREFIX = 'web:study:';
+
 /**
  * Build review context for a web:review:{draftId} chat.
  * Reads the draft file and source document metadata so the agent
@@ -121,6 +124,18 @@ function buildReviewContext(chatJid: string): string {
   }
 }
 
+/**
+ * Build study context for a web:study:{sessionId} chat.
+ * Called on the first message of a session as a hook for future context enrichment
+ * (concept state, prior session history). Currently returns empty string — the
+ * dashboard API route already prepends [CONTEXT] to the first message payload.
+ */
+function buildStudyContext(chatJid: string): string {
+  if (studySessionsInitialized.has(chatJid)) return '';
+  studySessionsInitialized.add(chatJid);
+  return '';
+}
+
 let lastTimestamp = '';
 let sessions: Record<string, string> = {};
 let registeredGroups: Record<string, RegisteredGroup> = {};
@@ -133,6 +148,14 @@ const queue = new GroupQueue();
 // Track active web review JIDs so the message loop can query for them.
 // Populated when onMessage is called with a web:review:* JID.
 const activeWebReviewJids = new Set<string>();
+
+// Track active web study JIDs so the message loop can query for them.
+// Populated when onMessage is called with a web:study:* JID.
+const activeWebStudyJids = new Set<string>();
+
+// Track study sessions that have already received their initial context injection.
+// Used by buildStudyContext() to detect first-message vs. subsequent messages.
+const studySessionsInitialized = new Set<string>();
 
 const onecli = new OneCLI({ url: ONECLI_URL });
 
@@ -257,6 +280,9 @@ function findGroupForJid(chatJid: string): RegisteredGroup | undefined {
   ) {
     return registeredGroups[REVIEW_AGENT_JID];
   }
+  if (chatJid.startsWith(WEB_STUDY_PREFIX) && registeredGroups[STUDY_AGENT_JID]) {
+    return registeredGroups[STUDY_AGENT_JID];
+  }
   return undefined;
 }
 
@@ -301,12 +327,16 @@ async function processGroupMessages(chatJid: string): Promise<boolean> {
   const reviewContext = chatJid.startsWith(WEB_REVIEW_PREFIX)
     ? buildReviewContext(chatJid)
     : '';
+  // For web study chats, hook for first-message context enrichment
+  const studyContext = chatJid.startsWith(WEB_STUDY_PREFIX)
+    ? buildStudyContext(chatJid)
+    : '';
   const attachmentPaths = prepareAttachments(
     missedMessages,
     group.folder,
     GROUPS_DIR,
   );
-  const prompt = reviewContext + formatMessages(missedMessages, TIMEZONE);
+  const prompt = reviewContext + studyContext + formatMessages(missedMessages, TIMEZONE);
 
   // Advance cursor so the piping path in startMessageLoop won't re-fetch
   // these messages. Save the old cursor so we can roll back on error.
@@ -491,6 +521,10 @@ async function startMessageLoop(): Promise<void> {
       const jids = Object.keys(registeredGroups);
       // Include active web review JIDs so per-draft messages are fetched
       for (const webJid of activeWebReviewJids) {
+        if (!jids.includes(webJid)) jids.push(webJid);
+      }
+      // Include active web study JIDs so per-session messages are fetched
+      for (const webJid of activeWebStudyJids) {
         if (!jids.includes(webJid)) jids.push(webJid);
       }
       const { messages, newTimestamp } = getNewMessages(
@@ -689,6 +723,35 @@ async function main(): Promise<void> {
     });
   }
 
+  // Ensure study agent group exists
+  if (!registeredGroups[STUDY_AGENT_JID]) {
+    registerGroup(STUDY_AGENT_JID, {
+      name: 'Study Agent',
+      folder: 'study',
+      trigger: '',
+      added_at: new Date().toISOString(),
+      requiresTrigger: false,
+      isMain: false,
+      containerConfig: {
+        additionalMounts: [
+          {
+            hostPath: join(process.cwd(), 'vault'),
+            containerPath: 'vault',
+            readonly: true,
+          },
+        ],
+        allowedTools: [
+          'Bash',
+          'Read',
+          'Write',
+          'Edit',
+          'Glob',
+          'Grep',
+        ],
+      },
+    });
+  }
+
   // Ensure OneCLI agents exist for all registered groups.
   // Recovers from missed creates (e.g. OneCLI was down at registration time).
   for (const [jid, group] of Object.entries(registeredGroups)) {
@@ -814,6 +877,10 @@ async function main(): Promise<void> {
       if (chatJid.startsWith(WEB_REVIEW_PREFIX)) {
         activeWebReviewJids.add(chatJid);
       }
+      // Track web study JIDs so the message loop polls for them
+      if (chatJid.startsWith(WEB_STUDY_PREFIX)) {
+        activeWebStudyJids.add(chatJid);
+      }
     },
     onDraftClosed: (draftId: string) => {
       const chatJid = `${WEB_REVIEW_PREFIX}${draftId}`;
@@ -823,6 +890,16 @@ async function main(): Promise<void> {
       );
       queue.closeStdin(chatJid);
       activeWebReviewJids.delete(chatJid);
+    },
+    onStudyClosed: (sessionId: string) => {
+      const chatJid = `${WEB_STUDY_PREFIX}${sessionId}`;
+      logger.info(
+        { sessionId, chatJid },
+        'Study session closed, shutting down study agent',
+      );
+      queue.closeStdin(chatJid);
+      activeWebStudyJids.delete(chatJid);
+      studySessionsInitialized.delete(chatJid);
     },
     onChatMetadata: (
       chatJid: string,

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -15,12 +15,17 @@ import {
   getConceptById,
   batchCreateActivities,
   createActivityConceptLinks,
+  getRecentActivityLogs,
+  getActivitiesByConcept,
+  getConceptsByDomain,
+  getLogsByConceptAndLevel,
   type NewLearningActivity,
 } from './study/queries.js';
 import { computeDueDate } from './study/sm2.js';
-import type { GeneratedActivity, ActivityType } from './study/types.js';
+import type { GeneratedActivity, ActivityType, BloomLevel } from './study/types.js';
 import { generateActivities } from './study/generator.js';
-import { triggerPostSessionGeneration } from './study/engine.js';
+import { processCompletion, triggerPostSessionGeneration } from './study/engine.js';
+import { computeMastery, computeBloomCeiling, computeOverallMastery } from './study/mastery.js';
 import { RegisteredGroup } from './types.js';
 
 const execFileAsync = promisify(execFile);
@@ -298,6 +303,18 @@ export async function processTaskIpc(
     bloomLevel?: number;
     // For study_post_session_generation
     sessionId?: string;
+    // For study_complete
+    activityId?: string;
+    quality?: number;
+    responseText?: string;
+    responseTimeMs?: number;
+    aiFeedback?: string;
+    surface?: string;
+    // For study_concept_status
+    domain?: string;
+    // For study_suggest_activity
+    activityType?: string;
+    author?: string;
   },
   sourceGroup: string, // Verified identity from IPC directory
   isMain: boolean, // Verified from directory path
@@ -738,6 +755,204 @@ export async function processTaskIpc(
           'study_post_session_generation: triggerPostSessionGeneration threw',
         );
       }
+      break;
+    }
+
+    case 'study_complete': {
+      if (!data.activityId || typeof data.activityId !== 'string') {
+        logger.error(
+          { sourceGroup },
+          'study_complete: missing or invalid activityId',
+        );
+        break;
+      }
+      if (
+        data.quality === undefined ||
+        !Number.isInteger(data.quality) ||
+        data.quality < 0 ||
+        data.quality > 5
+      ) {
+        logger.error(
+          { sourceGroup, quality: data.quality },
+          'study_complete: missing or invalid quality (must be integer 0-5)',
+        );
+        break;
+      }
+      try {
+        const result = processCompletion({
+          activityId: data.activityId,
+          quality: data.quality,
+          sessionId: data.sessionId,
+          responseText: data.responseText,
+          responseTimeMs: data.responseTimeMs,
+          evaluationMethod: data.aiFeedback ? 'ai_evaluated' : 'self_rated',
+          aiQuality: data.aiFeedback ? data.quality : undefined,
+          aiFeedback: data.aiFeedback,
+          surface: data.surface ?? 'dashboard_chat',
+        });
+        if (result.generationNeeded && result.advancement) {
+          try {
+            await generateActivities(
+              result.advancement.conceptId,
+              result.advancement.newCeiling as BloomLevel,
+            );
+          } catch (err) {
+            logger.error(
+              { err, conceptId: result.advancement.conceptId },
+              'study_complete: generateActivities threw',
+            );
+          }
+        }
+        logger.info(
+          `study_complete: activityId=${data.activityId}, quality=${data.quality}, advancement=${result.advancement ? 'yes' : 'no'}`,
+        );
+      } catch (err) {
+        logger.error(
+          { err, activityId: data.activityId },
+          'study_complete: processCompletion threw',
+        );
+      }
+      break;
+    }
+
+    case 'study_concept_status': {
+      if (!data.conceptId && !data.domain) {
+        logger.warn(
+          { sourceGroup },
+          'study_concept_status: neither conceptId nor domain provided',
+        );
+        break;
+      }
+      const ipcBaseDir = path.join(DATA_DIR, 'ipc');
+      const responsesDir = path.join(ipcBaseDir, sourceGroup, 'responses');
+      fs.mkdirSync(responsesDir, { recursive: true });
+      const responseFile = path.join(
+        responsesDir,
+        `concept-status-${Date.now()}.json`,
+      );
+
+      if (data.conceptId) {
+        const concept = getConceptById(data.conceptId);
+        if (!concept) {
+          logger.warn(
+            { conceptId: data.conceptId, sourceGroup },
+            'study_concept_status: concept not found',
+          );
+          break;
+        }
+        const recentLogs = getRecentActivityLogs(data.conceptId, 10);
+        const masteryInput = recentLogs.map((log) => ({
+          bloomLevel: log.bloomLevel as BloomLevel,
+          quality: log.quality,
+          reviewedAt: log.reviewedAt,
+        }));
+        const levels = computeMastery(masteryInput);
+        const bloomCeiling = computeBloomCeiling(levels);
+        const overallMastery = computeOverallMastery(levels);
+        fs.writeFileSync(
+          responseFile,
+          JSON.stringify({
+            type: 'concept_status',
+            concept,
+            recentLogs,
+            masteryLevels: levels,
+            bloomCeiling,
+            overallMastery,
+          }),
+        );
+      } else if (data.domain) {
+        const concepts = getConceptsByDomain(data.domain);
+        const summaries = concepts.map((concept) => {
+          const allLogs = getLogsByConceptAndLevel(concept.id);
+          const masteryInput = allLogs.map((log) => ({
+            bloomLevel: log.bloomLevel as BloomLevel,
+            quality: log.quality,
+            reviewedAt: log.reviewedAt,
+          }));
+          const levels = computeMastery(masteryInput);
+          const bloomCeiling = computeBloomCeiling(levels);
+          const overallMastery = computeOverallMastery(levels);
+          return { concept, masteryLevels: levels, bloomCeiling, overallMastery };
+        });
+        fs.writeFileSync(
+          responseFile,
+          JSON.stringify({ type: 'domain_status', domain: data.domain, summaries }),
+        );
+      }
+      break;
+    }
+
+    case 'study_suggest_activity': {
+      const VALID_SUGGEST_TYPES: Set<string> = new Set<ActivityType>([
+        'card_review',
+        'elaboration',
+        'self_explain',
+        'concept_map',
+        'comparison',
+        'case_analysis',
+        'synthesis',
+        'socratic',
+      ]);
+
+      if (
+        !data.conceptId ||
+        !data.activityType ||
+        !data.prompt ||
+        data.bloomLevel === undefined
+      ) {
+        logger.error(
+          { sourceGroup },
+          'study_suggest_activity: missing required fields (conceptId, activityType, prompt, bloomLevel)',
+        );
+        break;
+      }
+
+      if (!VALID_SUGGEST_TYPES.has(data.activityType)) {
+        logger.error(
+          { activityType: data.activityType, sourceGroup },
+          'study_suggest_activity: invalid activityType',
+        );
+        break;
+      }
+
+      if (
+        !Number.isInteger(data.bloomLevel) ||
+        data.bloomLevel < 1 ||
+        data.bloomLevel > 6
+      ) {
+        logger.error(
+          { bloomLevel: data.bloomLevel, sourceGroup },
+          'study_suggest_activity: bloomLevel must be integer 1-6',
+        );
+        break;
+      }
+
+      const suggestActivity: NewLearningActivity = {
+        id: crypto.randomUUID(),
+        conceptId: data.conceptId,
+        activityType: data.activityType as ActivityType,
+        prompt: data.prompt,
+        bloomLevel: data.bloomLevel,
+        author: (data.author ?? 'student') as 'student' | 'system',
+        referenceAnswer: '',
+        difficultyEstimate: 5,
+        generatedAt: new Date().toISOString(),
+        dueAt: new Date().toISOString().split('T')[0],
+        easeFactor: 2.5,
+        intervalDays: 1,
+        repetitions: 0,
+        masteryState: 'new',
+        cardType: null,
+        sourceNotePath: null,
+        sourceChunkHash: null,
+      };
+
+      batchCreateActivities([suggestActivity]);
+      createActivityConceptLinks(suggestActivity.id as string, [data.conceptId]);
+
+      logger.info(
+        `study_suggest_activity: conceptId=${data.conceptId}, type=${data.activityType}, bloomLevel=${data.bloomLevel}`,
+      );
       break;
     }
 

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -22,10 +22,21 @@ import {
   type NewLearningActivity,
 } from './study/queries.js';
 import { computeDueDate } from './study/sm2.js';
-import type { GeneratedActivity, ActivityType, BloomLevel } from './study/types.js';
+import type {
+  GeneratedActivity,
+  ActivityType,
+  BloomLevel,
+} from './study/types.js';
 import { generateActivities } from './study/generator.js';
-import { processCompletion, triggerPostSessionGeneration } from './study/engine.js';
-import { computeMastery, computeBloomCeiling, computeOverallMastery } from './study/mastery.js';
+import {
+  processCompletion,
+  triggerPostSessionGeneration,
+} from './study/engine.js';
+import {
+  computeMastery,
+  computeBloomCeiling,
+  computeOverallMastery,
+} from './study/mastery.js';
 import { RegisteredGroup } from './types.js';
 
 const execFileAsync = promisify(execFile);
@@ -872,11 +883,20 @@ export async function processTaskIpc(
           const levels = computeMastery(masteryInput);
           const bloomCeiling = computeBloomCeiling(levels);
           const overallMastery = computeOverallMastery(levels);
-          return { concept, masteryLevels: levels, bloomCeiling, overallMastery };
+          return {
+            concept,
+            masteryLevels: levels,
+            bloomCeiling,
+            overallMastery,
+          };
         });
         fs.writeFileSync(
           responseFile,
-          JSON.stringify({ type: 'domain_status', domain: data.domain, summaries }),
+          JSON.stringify({
+            type: 'domain_status',
+            domain: data.domain,
+            summaries,
+          }),
         );
       }
       break;
@@ -948,7 +968,9 @@ export async function processTaskIpc(
       };
 
       batchCreateActivities([suggestActivity]);
-      createActivityConceptLinks(suggestActivity.id as string, [data.conceptId]);
+      createActivityConceptLinks(suggestActivity.id as string, [
+        data.conceptId,
+      ]);
 
       logger.info(
         `study_suggest_activity: conceptId=${data.conceptId}, type=${data.activityType}, bloomLevel=${data.bloomLevel}`,


### PR DESCRIPTION
## Summary

- **Web channel extension** — `web:study:{sessionId}` JID pattern with `/study-message`, `/study-stream`, `/study-close` endpoints alongside existing `web:review:` pattern
- **Study IPC handlers** — `study_complete`, `study_concept_status`, `study_suggest_activity` cases in `processTaskIpc()` for study agent communication
- **Study agent CLAUDE.md** — 259-line system prompt with method-specific instructions (Feynman, Socratic, case analysis, comparison, synthesis), Bloom's rubrics, IPC output format, brain-first enforcement
- **Study agent group registration** — `STUDY_AGENT_JID` in main process mirroring review agent pattern, with vault read-only mount and message loop polling
- **Dashboard chat API routes** — chat proxy, SSE stream proxy, close, evaluate, evaluate result polling endpoints
- **`/study/chat` page** — Multi-turn conversational interface with concept/method selectors, SSE streaming messages, auto-scroll
- **AI evaluation in `/study/session`** — "AI Evaluate" / "Self-Rate" choice for L3+ activities, SSE feedback streaming, 60s timeout fallback
- **L3-L6 activity type UIs** — Activity-specific text area sizes, socratic redirect to chat, case_analysis/synthesis/comparison prompts
- **Generator CLAUDE.md expansion** — Enhanced L3-L6 generation guidelines with worked examples for all 5 deep method types

## Verification

- 824 tests pass (`npm test`)
- Clean backend build (`npm run build`)
- Clean dashboard types (`cd dashboard && npx tsc --noEmit`)

## Test plan

- [ ] Start NanoClaw + Dashboard, navigate to `/study/chat`
- [ ] Select concept + method, start chat — verify SSE connection and agent response streaming
- [ ] Multi-turn Feynman dialogue — agent asks probing questions, not lectures
- [ ] Navigate to `/study/session`, start session with L3+ activities
- [ ] Submit L3+ response → "AI Evaluate" and "Self-Rate" buttons appear
- [ ] Click "Self-Rate" → normal flow (regression test for L1-L2)
- [ ] Click "AI Evaluate" → feedback streams, quality score shown
- [ ] Timeout test: evaluate with no agent running → falls back to self-rate after 60s
- [ ] Socratic activity shows "Open in Study Chat" redirect
- [ ] Complete full session → post-session reflection + mastery updates work

🤖 Generated with [Claude Code](https://claude.com/claude-code)