### PR TITLE
feat(study): S6 planning system — plan CRUD, plan-aware sessions, plan UI

### DIFF
--- a/dashboard/src/app/api/study/plans/[id]/concepts/route.ts
+++ b/dashboard/src/app/api/study/plans/[id]/concepts/route.ts
@@ -1,0 +1,35 @@
+import { addConceptsToPlan, removeConceptFromPlan } from '@/lib/study-db';
+
+export async function POST(
+  request: Request,
+  ctx: { params: Promise<Record<string, string>> },
+) {
+  try {
+    const { id } = await ctx.params;
+    const body = await request.json();
+    if (!Array.isArray(body.conceptIds) || body.conceptIds.length === 0) {
+      return Response.json({ error: 'conceptIds required' }, { status: 400 });
+    }
+    addConceptsToPlan(id, body.conceptIds, body.targetBloom);
+    return Response.json({ ok: true });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  ctx: { params: Promise<Record<string, string>> },
+) {
+  try {
+    const { id } = await ctx.params;
+    const body = await request.json();
+    if (!body.conceptId) {
+      return Response.json({ error: 'conceptId required' }, { status: 400 });
+    }
+    removeConceptFromPlan(id, body.conceptId);
+    return Response.json({ ok: true });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/study/plans/[id]/route.ts
+++ b/dashboard/src/app/api/study/plans/[id]/route.ts
@@ -1,0 +1,32 @@
+import { getPlanById, updatePlan } from '@/lib/study-db';
+
+export async function GET(
+  _request: Request,
+  ctx: { params: Promise<Record<string, string>> },
+) {
+  try {
+    const { id } = await ctx.params;
+    const plan = getPlanById(id);
+    if (!plan) {
+      return Response.json({ error: 'Plan not found' }, { status: 404 });
+    }
+    return Response.json({ plan });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  ctx: { params: Promise<Record<string, string>> },
+) {
+  try {
+    const { id } = await ctx.params;
+    const body = await request.json();
+    updatePlan(id, body);
+    const updated = getPlanById(id);
+    return Response.json({ plan: updated });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/study/plans/[id]/route.ts
+++ b/dashboard/src/app/api/study/plans/[id]/route.ts
@@ -16,6 +16,23 @@ export async function GET(
   }
 }
 
+// Maps camelCase request keys to snake_case DB columns
+const ALLOWED_FIELDS: Record<string, string> = {
+  title: 'title',
+  strategy: 'strategy',
+  status: 'status',
+  domain: 'domain',
+  course: 'course',
+  learningObjectives: 'learning_objectives',
+  desiredOutcomes: 'desired_outcomes',
+  implementationIntention: 'implementation_intention',
+  obstacle: 'obstacle',
+  studySchedule: 'study_schedule',
+  config: 'config',
+  checkpointIntervalDays: 'checkpoint_interval_days',
+  nextCheckpointAt: 'next_checkpoint_at',
+};
+
 export async function PATCH(
   request: Request,
   ctx: { params: Promise<Record<string, string>> },
@@ -23,7 +40,15 @@ export async function PATCH(
   try {
     const { id } = await ctx.params;
     const body = await request.json();
-    updatePlan(id, body);
+    const safeUpdates: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(body)) {
+      const col = ALLOWED_FIELDS[key];
+      if (col) safeUpdates[col] = value;
+    }
+    if (Object.keys(safeUpdates).length === 0) {
+      return Response.json({ error: 'No valid fields to update' }, { status: 400 });
+    }
+    updatePlan(id, safeUpdates);
     const updated = getPlanById(id);
     return Response.json({ plan: updated });
   } catch (err) {

--- a/dashboard/src/app/api/study/plans/route.ts
+++ b/dashboard/src/app/api/study/plans/route.ts
@@ -1,0 +1,45 @@
+import { getAllPlans, createPlan } from '@/lib/study-db';
+
+export async function GET() {
+  try {
+    const plans = getAllPlans();
+    return Response.json({ plans });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    if (!body.title || !Array.isArray(body.conceptIds) || body.conceptIds.length === 0) {
+      return Response.json({ error: 'title and conceptIds required' }, { status: 400 });
+    }
+
+    const planId = crypto.randomUUID();
+    const config = body.examDate ? JSON.stringify({ exam_date: body.examDate }) : undefined;
+
+    createPlan(
+      {
+        id: planId,
+        title: body.title,
+        domain: body.domain,
+        course: body.course,
+        strategy: body.strategy ?? 'open',
+        learningObjectives: body.learningObjectives,
+        desiredOutcomes: body.desiredOutcomes,
+        implementationIntention: body.implementationIntention,
+        obstacle: body.obstacle,
+        studySchedule: body.studySchedule,
+        config,
+        checkpointIntervalDays: body.checkpointIntervalDays,
+      },
+      body.conceptIds,
+      body.targetBloom,
+    );
+
+    return Response.json({ planId });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/study/session/route.ts
+++ b/dashboard/src/app/api/study/session/route.ts
@@ -6,9 +6,11 @@ import {
   updateSession,
 } from '@/lib/study-db';
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
-    const composition = buildSessionComposition();
+    const url = new URL(request.url);
+    const planId = url.searchParams.get('planId') ?? undefined;
+    const composition = buildSessionComposition({ planId });
     const enrichedBlocks = composition.blocks.map((block) => ({
       ...block,
       activities: block.activities
@@ -45,6 +47,7 @@ export async function POST(request: Request) {
     const body = (await request.json()) as {
       sessionType?: string;
       preConfidence?: Record<string, number>;
+      planId?: string;
     };
 
     // End any orphaned active session
@@ -62,6 +65,7 @@ export async function POST(request: Request) {
         ? JSON.stringify(body.preConfidence)
         : undefined,
       surface: 'dashboard_ui',
+      planId: body.planId,
     });
     return Response.json({ sessionId });
   } catch (err) {

--- a/dashboard/src/app/study/page.tsx
+++ b/dashboard/src/app/study/page.tsx
@@ -14,6 +14,14 @@ const BLOOM_LABELS: Record<number, string> = {
 
 const MASTERY_THRESHOLD = 10.0;
 
+interface PlanSummary {
+  id: string;
+  title: string;
+  strategy: string;
+  status: string;
+  progressPercent: number;
+}
+
 interface SessionPreview {
   blocks: Array<{
     type: string;
@@ -33,26 +41,36 @@ export default function StudyPage() {
   const [stats, setStats] = useState<ConceptStats | null>(null);
   const [session, setSession] = useState<SessionPreview | null>(null);
   const [streak, setStreak] = useState<number>(0);
+  const [activePlans, setActivePlans] = useState<PlanSummary[]>([]);
   const [loading, setLoading] = useState(true);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
     try {
-      const [conceptsRes, pendingRes, sessionRes, streakRes] = await Promise.all([
+      const [conceptsRes, pendingRes, sessionRes, streakRes, plansRes] = await Promise.all([
         fetch('/api/study/concepts'),
         fetch('/api/study/concepts/pending'),
         fetch('/api/study/session'),
         fetch('/api/study/streak'),
+        fetch('/api/study/plans'),
       ]);
       const conceptsData = await conceptsRes.json() as { concepts: ConceptSummary[]; stats: ConceptStats };
       const pendingData = await pendingRes.json() as { groups: PendingGroup[] };
       const sessionData = await sessionRes.json() as { session: SessionPreview };
       const streakData = await streakRes.json() as { streak: number };
+      const plansData = await plansRes.json() as { plans: PlanSummary[] };
       setConcepts(conceptsData.concepts ?? []);
       setStats(conceptsData.stats ?? null);
       setPendingGroups(pendingData.groups ?? []);
       setSession(sessionData.session ?? null);
       setStreak(streakData.streak ?? 0);
+      const allPlans: PlanSummary[] = plansData.plans ?? [];
+      setActivePlans(
+        allPlans
+          .filter((p) => p.status === 'active')
+          .sort((a, b) => b.progressPercent - a.progressPercent)
+          .slice(0, 3),
+      );
     } catch {
       // silently fail; data stays stale
     } finally {
@@ -150,7 +168,51 @@ export default function StudyPage() {
         </div>
       </section>
 
-      {/* Section 1 — Pending Approval */}
+      {/* Section 1 — Plans */}
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">
+            Plans
+            {activePlans.length > 0 && (
+              <span className="ml-2 text-gray-600 normal-case font-normal">({activePlans.length} active)</span>
+            )}
+          </h3>
+          <a
+            href="/study/plan"
+            className="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+          >
+            View All Plans →
+          </a>
+        </div>
+        {activePlans.length === 0 ? (
+          <div className="rounded-lg border border-gray-800 bg-gray-900 p-4 text-center">
+            <p className="text-sm text-gray-500">No active plans. <a href="/study/plan" className="text-blue-400 hover:text-blue-300">Create one →</a></p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {activePlans.map((plan) => (
+              <a
+                key={plan.id}
+                href={`/study/plan`}
+                className="flex items-center gap-4 rounded-lg border border-gray-800 bg-gray-900 p-3 hover:border-gray-700 transition-colors"
+              >
+                <span className="text-sm text-gray-100 font-medium min-w-0 truncate flex-1">{plan.title}</span>
+                <div className="flex items-center gap-3 shrink-0">
+                  <div className="w-24 h-1.5 bg-gray-700 rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-green-500 rounded-full"
+                      style={{ width: `${Math.min(100, Math.max(0, plan.progressPercent))}%` }}
+                    />
+                  </div>
+                  <span className="text-xs text-gray-500 w-8 text-right">{Math.round(plan.progressPercent)}%</span>
+                </div>
+              </a>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Section 2 — Pending Approval */}
       {pendingGroups.length > 0 && (
         <section className="space-y-4">
           <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">Pending Approval</h3>
@@ -192,7 +254,7 @@ export default function StudyPage() {
         </section>
       )}
 
-      {/* Section 2 — Active Concepts */}
+      {/* Section 3 — Active Concepts */}
       <section className="space-y-4">
         <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">Active Concepts</h3>
         {concepts.length === 0 ? (

--- a/dashboard/src/app/study/plan/page.tsx
+++ b/dashboard/src/app/study/plan/page.tsx
@@ -103,79 +103,6 @@ function formatDate(iso: string | null): string {
 }
 
 // ---------------------------------------------------------------------------
-// Concept selector sub-component
-// ---------------------------------------------------------------------------
-
-interface ConceptSelectorProps {
-  allConcepts: ConceptSummary[];
-  selected: Set<string>;
-  onToggle: (id: string) => void;
-  onSelectAll: (ids: string[]) => void;
-  excludeIds?: Set<string>;
-}
-
-function ConceptSelector({ allConcepts, selected, onToggle, onSelectAll, excludeIds }: ConceptSelectorProps) {
-  const filtered = excludeIds
-    ? allConcepts.filter((c) => !excludeIds.has(c.id))
-    : allConcepts;
-
-  // Group by domain
-  const domainMap = new Map<string, ConceptSummary[]>();
-  for (const c of filtered) {
-    const key = c.domain ?? 'Uncategorised';
-    if (!domainMap.has(key)) domainMap.set(key, []);
-    domainMap.get(key)!.push(c);
-  }
-
-  if (filtered.length === 0) {
-    return <p className="text-sm text-gray-500">No concepts available.</p>;
-  }
-
-  return (
-    <div className="space-y-4">
-      {Array.from(domainMap.entries()).map(([domain, concepts]) => {
-        const domainIds = concepts.map((c) => c.id);
-        const allSelected = domainIds.every((id) => selected.has(id));
-        return (
-          <div key={domain} className="space-y-2">
-            <div className="flex items-center justify-between">
-              <span className="text-xs font-medium text-gray-400 uppercase tracking-wider">{domain}</span>
-              <button
-                type="button"
-                onClick={() => onSelectAll(allSelected ? [] : domainIds)}
-                className="text-xs text-blue-400 hover:text-blue-300 transition-colors"
-              >
-                {allSelected ? 'Deselect all' : 'Select all'}
-              </button>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {concepts.map((c) => (
-                <label
-                  key={c.id}
-                  className={`flex items-center gap-1.5 cursor-pointer text-xs px-2.5 py-1.5 rounded-md border transition-colors ${
-                    selected.has(c.id)
-                      ? 'bg-blue-900/40 border-blue-700 text-blue-200'
-                      : 'bg-gray-800 border-gray-700 text-gray-300 hover:border-gray-600'
-                  }`}
-                >
-                  <input
-                    type="checkbox"
-                    checked={selected.has(c.id)}
-                    onChange={() => onToggle(c.id)}
-                    className="w-3 h-3 accent-blue-500"
-                  />
-                  {c.title}
-                </label>
-              ))}
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Page component
 // ---------------------------------------------------------------------------
 
@@ -318,16 +245,6 @@ export default function StudyPlanPage() {
     });
   }
 
-  function handleCreateSelectAll(ids: string[]) {
-    if (ids.length === 0) {
-      // Caller signals deselect (passes empty). We need the domain ids from the toggle.
-      // Since ConceptSelector passes all domain ids when deselecting, this is fine.
-      return;
-    }
-    selectAllCreateDomain(ids);
-  }
-
-  // Revised: ConceptSelector onSelectAll passes full domain ids or [] for deselect
   function handleCreateConceptSelectAll(ids: string[], allDomainIds: string[]) {
     if (ids.length === 0) {
       deselectAllCreateDomain(allDomainIds);

--- a/dashboard/src/app/study/plan/page.tsx
+++ b/dashboard/src/app/study/plan/page.tsx
@@ -1,0 +1,1060 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import type { ConceptSummary } from '@/lib/study-db';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PlanSummary {
+  id: string;
+  title: string;
+  domain: string | null;
+  course: string | null;
+  strategy: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  nextCheckpointAt: string | null;
+  conceptCount: number;
+  progressPercent: number;
+}
+
+interface PlanConceptDetail {
+  conceptId: string;
+  title: string;
+  domain: string | null;
+  bloomCeiling: number;
+  targetBloom: number;
+  masteryOverall: number;
+  atTarget: boolean;
+}
+
+interface PlanDetail extends PlanSummary {
+  learningObjectives: string | null;
+  desiredOutcomes: string | null;
+  implementationIntention: string | null;
+  obstacle: string | null;
+  studySchedule: string | null;
+  config: string | null;
+  checkpointIntervalDays: number;
+  concepts: PlanConceptDetail[];
+}
+
+type View = 'list' | 'create' | 'detail';
+
+type Strategy = 'open' | 'exam-prep' | 'weekly-review' | 'exploration';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const STRATEGY_OPTIONS: Array<{ value: Strategy; label: string }> = [
+  { value: 'open', label: 'Open' },
+  { value: 'exam-prep', label: 'Exam Prep' },
+  { value: 'weekly-review', label: 'Weekly Review' },
+  { value: 'exploration', label: 'Exploration' },
+];
+
+const STRATEGY_BADGE: Record<string, string> = {
+  open: 'bg-blue-900 text-blue-300',
+  'exam-prep': 'bg-red-900 text-red-300',
+  'weekly-review': 'bg-purple-900 text-purple-300',
+  exploration: 'bg-amber-900 text-amber-300',
+};
+
+const BLOOM_LABELS: Record<number, string> = {
+  1: 'L1 Remember',
+  2: 'L2 Understand',
+  3: 'L3 Apply',
+  4: 'L4 Analyse',
+  5: 'L5 Evaluate',
+  6: 'L6 Create',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function StrategyBadge({ strategy }: { strategy: string }) {
+  const cls = STRATEGY_BADGE[strategy] ?? 'bg-gray-800 text-gray-400';
+  const label = STRATEGY_OPTIONS.find((s) => s.value === strategy)?.label ?? strategy;
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${cls}`}>{label}</span>
+  );
+}
+
+function ProgressBar({ pct }: { pct: number }) {
+  return (
+    <div className="h-2 bg-gray-700 rounded-full overflow-hidden">
+      <div
+        className="h-full bg-green-500 rounded-full transition-all duration-300"
+        style={{ width: `${Math.min(100, Math.max(0, pct))}%` }}
+      />
+    </div>
+  );
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+// ---------------------------------------------------------------------------
+// Concept selector sub-component
+// ---------------------------------------------------------------------------
+
+interface ConceptSelectorProps {
+  allConcepts: ConceptSummary[];
+  selected: Set<string>;
+  onToggle: (id: string) => void;
+  onSelectAll: (ids: string[]) => void;
+  excludeIds?: Set<string>;
+}
+
+function ConceptSelector({ allConcepts, selected, onToggle, onSelectAll, excludeIds }: ConceptSelectorProps) {
+  const filtered = excludeIds
+    ? allConcepts.filter((c) => !excludeIds.has(c.id))
+    : allConcepts;
+
+  // Group by domain
+  const domainMap = new Map<string, ConceptSummary[]>();
+  for (const c of filtered) {
+    const key = c.domain ?? 'Uncategorised';
+    if (!domainMap.has(key)) domainMap.set(key, []);
+    domainMap.get(key)!.push(c);
+  }
+
+  if (filtered.length === 0) {
+    return <p className="text-sm text-gray-500">No concepts available.</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {Array.from(domainMap.entries()).map(([domain, concepts]) => {
+        const domainIds = concepts.map((c) => c.id);
+        const allSelected = domainIds.every((id) => selected.has(id));
+        return (
+          <div key={domain} className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-gray-400 uppercase tracking-wider">{domain}</span>
+              <button
+                type="button"
+                onClick={() => onSelectAll(allSelected ? [] : domainIds)}
+                className="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+              >
+                {allSelected ? 'Deselect all' : 'Select all'}
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {concepts.map((c) => (
+                <label
+                  key={c.id}
+                  className={`flex items-center gap-1.5 cursor-pointer text-xs px-2.5 py-1.5 rounded-md border transition-colors ${
+                    selected.has(c.id)
+                      ? 'bg-blue-900/40 border-blue-700 text-blue-200'
+                      : 'bg-gray-800 border-gray-700 text-gray-300 hover:border-gray-600'
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.has(c.id)}
+                    onChange={() => onToggle(c.id)}
+                    className="w-3 h-3 accent-blue-500"
+                  />
+                  {c.title}
+                </label>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+export default function StudyPlanPage() {
+  const router = useRouter();
+  const [view, setView] = useState<View>('list');
+  const [plans, setPlans] = useState<PlanSummary[]>([]);
+  const [selectedPlan, setSelectedPlan] = useState<PlanDetail | null>(null);
+  const [allConcepts, setAllConcepts] = useState<ConceptSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [detailLoading, setDetailLoading] = useState(false);
+
+  // Create form state
+  const [createTitle, setCreateTitle] = useState('');
+  const [createStrategy, setCreateStrategy] = useState<Strategy>('open');
+  const [createExamDate, setCreateExamDate] = useState('');
+  const [createSelectedConcepts, setCreateSelectedConcepts] = useState<Set<string>>(new Set());
+  const [createTargetBloom, setCreateTargetBloom] = useState(6);
+  const [createLearningObjectives, setCreateLearningObjectives] = useState('');
+  const [createDesiredOutcomes, setCreateDesiredOutcomes] = useState('');
+  const [createStudySchedule, setCreateStudySchedule] = useState('');
+  const [createImplementationIntention, setCreateImplementationIntention] = useState('');
+  const [createObstacle, setCreateObstacle] = useState('');
+  const [createCheckpointDays, setCreateCheckpointDays] = useState(14);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [createSubmitting, setCreateSubmitting] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  // Add concepts panel (detail view)
+  const [showAddConcepts, setShowAddConcepts] = useState(false);
+  const [addConceptsSelected, setAddConceptsSelected] = useState<Set<string>>(new Set());
+  const [addConceptsSubmitting, setAddConceptsSubmitting] = useState(false);
+
+  // ---------------------------------------------------------------------------
+  // Fetch helpers
+  // ---------------------------------------------------------------------------
+
+  const fetchPlans = useCallback(async () => {
+    try {
+      const res = await fetch('/api/study/plans');
+      const data = (await res.json()) as { plans: PlanSummary[] };
+      setPlans(data.plans ?? []);
+    } catch {
+      // silently fail
+    }
+  }, []);
+
+  const fetchConcepts = useCallback(async () => {
+    try {
+      const res = await fetch('/api/study/concepts');
+      const data = (await res.json()) as { concepts: ConceptSummary[] };
+      setAllConcepts(data.concepts ?? []);
+    } catch {
+      // silently fail
+    }
+  }, []);
+
+  const fetchPlanDetail = useCallback(async (id: string) => {
+    setDetailLoading(true);
+    try {
+      const res = await fetch(`/api/study/plans/${id}`);
+      const data = (await res.json()) as { plan: PlanDetail };
+      setSelectedPlan(data.plan ?? null);
+    } catch {
+      // silently fail
+    } finally {
+      setDetailLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    Promise.all([fetchPlans(), fetchConcepts()]).finally(() => setLoading(false));
+  }, [fetchPlans, fetchConcepts]);
+
+  // ---------------------------------------------------------------------------
+  // Handlers: navigation
+  // ---------------------------------------------------------------------------
+
+  function goToList() {
+    setView('list');
+    setSelectedPlan(null);
+    setShowAddConcepts(false);
+    setAddConceptsSelected(new Set());
+  }
+
+  function goToCreate() {
+    setCreateTitle('');
+    setCreateStrategy('open');
+    setCreateExamDate('');
+    setCreateSelectedConcepts(new Set());
+    setCreateTargetBloom(6);
+    setCreateLearningObjectives('');
+    setCreateDesiredOutcomes('');
+    setCreateStudySchedule('');
+    setCreateImplementationIntention('');
+    setCreateObstacle('');
+    setCreateCheckpointDays(14);
+    setShowAdvanced(false);
+    setCreateError(null);
+    setView('create');
+  }
+
+  async function goToDetail(plan: PlanSummary) {
+    setView('detail');
+    await fetchPlanDetail(plan.id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Handlers: concept toggle helpers
+  // ---------------------------------------------------------------------------
+
+  function toggleCreateConcept(id: string) {
+    setCreateSelectedConcepts((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function selectAllCreateDomain(ids: string[]) {
+    if (ids.length === 0) {
+      // Deselect all in domain — we'd need to know which domain; caller passes empty for deselect
+      // The selector passes [] when deselecting, but we need the domain ids — handled below
+      return;
+    }
+    setCreateSelectedConcepts((prev) => {
+      const next = new Set(prev);
+      // ids is the full domain list; if all selected, caller passed []
+      ids.forEach((id) => next.add(id));
+      return next;
+    });
+  }
+
+  function deselectAllCreateDomain(ids: string[]) {
+    setCreateSelectedConcepts((prev) => {
+      const next = new Set(prev);
+      ids.forEach((id) => next.delete(id));
+      return next;
+    });
+  }
+
+  function handleCreateSelectAll(ids: string[]) {
+    if (ids.length === 0) {
+      // Caller signals deselect (passes empty). We need the domain ids from the toggle.
+      // Since ConceptSelector passes all domain ids when deselecting, this is fine.
+      return;
+    }
+    selectAllCreateDomain(ids);
+  }
+
+  // Revised: ConceptSelector onSelectAll passes full domain ids or [] for deselect
+  function handleCreateConceptSelectAll(ids: string[], allDomainIds: string[]) {
+    if (ids.length === 0) {
+      deselectAllCreateDomain(allDomainIds);
+    } else {
+      selectAllCreateDomain(ids);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Handlers: create plan
+  // ---------------------------------------------------------------------------
+
+  async function handleCreatePlan(e: React.FormEvent) {
+    e.preventDefault();
+    if (!createTitle.trim() || createSelectedConcepts.size === 0) {
+      setCreateError('Title and at least one concept are required.');
+      return;
+    }
+    setCreateSubmitting(true);
+    setCreateError(null);
+    try {
+      const body: Record<string, unknown> = {
+        title: createTitle.trim(),
+        strategy: createStrategy,
+        conceptIds: Array.from(createSelectedConcepts),
+        targetBloom: createTargetBloom,
+        checkpointIntervalDays: createCheckpointDays,
+      };
+      if (createStrategy === 'exam-prep' && createExamDate) body.examDate = createExamDate;
+      if (createLearningObjectives.trim()) body.learningObjectives = createLearningObjectives.trim();
+      if (createDesiredOutcomes.trim()) body.desiredOutcomes = createDesiredOutcomes.trim();
+      if (createStudySchedule.trim()) body.studySchedule = createStudySchedule.trim();
+      if (createImplementationIntention.trim()) body.implementationIntention = createImplementationIntention.trim();
+      if (createObstacle.trim()) body.obstacle = createObstacle.trim();
+
+      const res = await fetch('/api/study/plans', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = (await res.json()) as { planId?: string; error?: string };
+      if (data.error || !data.planId) {
+        setCreateError(data.error ?? 'Failed to create plan.');
+        return;
+      }
+      await fetchPlans();
+      await fetchPlanDetail(data.planId);
+      setView('detail');
+    } catch (err) {
+      setCreateError(String(err));
+    } finally {
+      setCreateSubmitting(false);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Handlers: detail view actions
+  // ---------------------------------------------------------------------------
+
+  async function handleArchivePlan() {
+    if (!selectedPlan) return;
+    await fetch(`/api/study/plans/${selectedPlan.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'archived' }),
+    });
+    await fetchPlans();
+    goToList();
+  }
+
+  async function handleCompletePlan() {
+    if (!selectedPlan) return;
+    await fetch(`/api/study/plans/${selectedPlan.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'completed' }),
+    });
+    await fetchPlans();
+    goToList();
+  }
+
+  async function handleRemoveConcept(conceptId: string) {
+    if (!selectedPlan) return;
+    const ok = window.confirm('Remove this concept from the plan?');
+    if (!ok) return;
+    await fetch(`/api/study/plans/${selectedPlan.id}/concepts`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ conceptId }),
+    });
+    await fetchPlanDetail(selectedPlan.id);
+  }
+
+  async function handleAddConcepts() {
+    if (!selectedPlan || addConceptsSelected.size === 0) return;
+    setAddConceptsSubmitting(true);
+    try {
+      await fetch(`/api/study/plans/${selectedPlan.id}/concepts`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ conceptIds: Array.from(addConceptsSelected) }),
+      });
+      setShowAddConcepts(false);
+      setAddConceptsSelected(new Set());
+      await fetchPlanDetail(selectedPlan.id);
+    } finally {
+      setAddConceptsSubmitting(false);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Derived data
+  // ---------------------------------------------------------------------------
+
+  const activePlans = plans.filter((p) => p.status === 'active');
+  const inactivePlans = plans.filter((p) => p.status !== 'active');
+
+  const existingConceptIds = new Set(selectedPlan?.concepts.map((c) => c.conceptId) ?? []);
+
+  // Sort detail concepts: furthest from target first
+  const sortedDetailConcepts = selectedPlan
+    ? [...selectedPlan.concepts].sort((a, b) => {
+        const gapA = a.targetBloom - a.bloomCeiling;
+        const gapB = b.targetBloom - b.bloomCeiling;
+        return gapB - gapA;
+      })
+    : [];
+
+  // ---------------------------------------------------------------------------
+  // Render: loading
+  // ---------------------------------------------------------------------------
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-gray-500">Loading...</p>
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render: LIST view
+  // ---------------------------------------------------------------------------
+
+  if (view === 'list') {
+    return (
+      <div className="max-w-3xl space-y-8">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-gray-100">Study Plans</h2>
+          <button
+            onClick={goToCreate}
+            className="px-4 py-2 rounded-md bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium transition-colors"
+          >
+            New Plan
+          </button>
+        </div>
+
+        {/* Active plans */}
+        <section className="space-y-3">
+          <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">
+            Active Plans
+            {activePlans.length > 0 && (
+              <span className="ml-2 text-gray-600 normal-case font-normal">({activePlans.length})</span>
+            )}
+          </h3>
+          {activePlans.length === 0 ? (
+            <div className="rounded-lg border border-gray-800 bg-gray-900 p-8 text-center">
+              <p className="text-sm text-gray-500">No active plans. Create one to get started.</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {activePlans.map((plan) => (
+                <button
+                  key={plan.id}
+                  onClick={() => goToDetail(plan)}
+                  className="w-full text-left rounded-lg border border-gray-800 bg-gray-900 p-4 hover:border-gray-700 transition-colors"
+                >
+                  <div className="flex items-start justify-between gap-3 mb-2">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className="font-medium text-gray-100 truncate">{plan.title}</span>
+                      <StrategyBadge strategy={plan.strategy} />
+                    </div>
+                    <span className="shrink-0 text-xs text-gray-500">
+                      {plan.conceptCount} concept{plan.conceptCount !== 1 ? 's' : ''}
+                    </span>
+                  </div>
+                  <div className="space-y-1.5">
+                    <ProgressBar pct={plan.progressPercent} />
+                    <div className="flex justify-between text-xs text-gray-500">
+                      <span>{Math.round(plan.progressPercent)}% at target</span>
+                      {plan.nextCheckpointAt && (
+                        <span>Checkpoint {formatDate(plan.nextCheckpointAt)}</span>
+                      )}
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Archived / completed plans */}
+        {inactivePlans.length > 0 && (
+          <section className="space-y-3">
+            <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">
+              Archived / Completed
+              <span className="ml-2 text-gray-600 normal-case font-normal">({inactivePlans.length})</span>
+            </h3>
+            <div className="space-y-2">
+              {inactivePlans.map((plan) => (
+                <button
+                  key={plan.id}
+                  onClick={() => goToDetail(plan)}
+                  className="w-full text-left rounded-lg border border-gray-800 bg-gray-950 p-3 hover:border-gray-700 transition-colors opacity-60 hover:opacity-80"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm text-gray-300">{plan.title}</span>
+                    <StrategyBadge strategy={plan.strategy} />
+                    <span className="text-xs text-gray-600 capitalize ml-auto">{plan.status}</span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render: CREATE view
+  // ---------------------------------------------------------------------------
+
+  if (view === 'create') {
+    return (
+      <div className="max-w-2xl space-y-6">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-gray-100">New Study Plan</h2>
+          <button
+            onClick={goToList}
+            className="text-sm text-gray-500 hover:text-gray-300 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+
+        <form onSubmit={handleCreatePlan} className="space-y-6">
+          {/* Title */}
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-gray-300">Title *</label>
+            <input
+              type="text"
+              value={createTitle}
+              onChange={(e) => setCreateTitle(e.target.value)}
+              placeholder="e.g. Algorithms Exam Prep"
+              required
+              className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-gray-500"
+            />
+          </div>
+
+          {/* Strategy */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-300">Strategy</label>
+            <div className="flex flex-wrap gap-2">
+              {STRATEGY_OPTIONS.map((opt) => (
+                <label
+                  key={opt.value}
+                  className={`flex items-center gap-1.5 cursor-pointer px-3 py-1.5 rounded-full text-sm transition-colors ${
+                    createStrategy === opt.value
+                      ? STRATEGY_BADGE[opt.value]
+                      : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="strategy"
+                    value={opt.value}
+                    checked={createStrategy === opt.value}
+                    onChange={() => setCreateStrategy(opt.value)}
+                    className="sr-only"
+                  />
+                  {opt.label}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Exam date (only for exam-prep) */}
+          {createStrategy === 'exam-prep' && (
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-gray-300">Exam Date</label>
+              <input
+                type="date"
+                value={createExamDate}
+                onChange={(e) => setCreateExamDate(e.target.value)}
+                className="bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:border-gray-500"
+              />
+            </div>
+          )}
+
+          {/* Target Bloom */}
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-gray-300">
+              Target Bloom Level: <span className="text-blue-400">{BLOOM_LABELS[createTargetBloom] ?? `L${createTargetBloom}`}</span>
+            </label>
+            <div className="flex gap-2">
+              {[1, 2, 3, 4, 5, 6].map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  onClick={() => setCreateTargetBloom(n)}
+                  className={`flex-1 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                    createTargetBloom === n
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
+                  }`}
+                >
+                  L{n}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Concept selector */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-gray-300">
+              Concepts *
+              {createSelectedConcepts.size > 0 && (
+                <span className="ml-2 text-blue-400 font-normal">{createSelectedConcepts.size} selected</span>
+              )}
+            </label>
+            <div className="bg-gray-900 border border-gray-700 rounded-lg p-4 max-h-72 overflow-y-auto">
+              <ConceptSelectorForCreate
+                allConcepts={allConcepts}
+                selected={createSelectedConcepts}
+                onToggle={toggleCreateConcept}
+                onSelectAllDomain={handleCreateConceptSelectAll}
+              />
+            </div>
+          </div>
+
+          {/* Advanced section */}
+          <div className="space-y-4">
+            <button
+              type="button"
+              onClick={() => setShowAdvanced(!showAdvanced)}
+              className="text-sm text-gray-500 hover:text-gray-300 transition-colors flex items-center gap-1"
+            >
+              <span>{showAdvanced ? '▾' : '▸'}</span>
+              Advanced
+            </button>
+
+            {showAdvanced && (
+              <div className="space-y-4 pl-4 border-l border-gray-800">
+                <div className="space-y-1.5">
+                  <label className="text-sm text-gray-400">Learning Objectives</label>
+                  <textarea
+                    value={createLearningObjectives}
+                    onChange={(e) => setCreateLearningObjectives(e.target.value)}
+                    rows={3}
+                    placeholder="What do you want to be able to do?"
+                    className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 resize-none focus:outline-none focus:border-gray-500"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <label className="text-sm text-gray-400">Desired Outcomes</label>
+                  <textarea
+                    value={createDesiredOutcomes}
+                    onChange={(e) => setCreateDesiredOutcomes(e.target.value)}
+                    rows={3}
+                    placeholder="What will success look like?"
+                    className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 resize-none focus:outline-none focus:border-gray-500"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <label className="text-sm text-gray-400">Study Schedule</label>
+                  <input
+                    type="text"
+                    value={createStudySchedule}
+                    onChange={(e) => setCreateStudySchedule(e.target.value)}
+                    placeholder="e.g. Weekdays 8–9am"
+                    className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-gray-500"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <label className="text-sm text-gray-400">Implementation Intention</label>
+                  <input
+                    type="text"
+                    value={createImplementationIntention}
+                    onChange={(e) => setCreateImplementationIntention(e.target.value)}
+                    placeholder="When I sit down to study, I will..."
+                    className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-gray-500"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <label className="text-sm text-gray-400">Anticipated Obstacle</label>
+                  <input
+                    type="text"
+                    value={createObstacle}
+                    onChange={(e) => setCreateObstacle(e.target.value)}
+                    placeholder="What might get in the way?"
+                    className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-gray-500"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <label className="text-sm text-gray-400">
+                    Checkpoint Interval (days)
+                  </label>
+                  <input
+                    type="number"
+                    value={createCheckpointDays}
+                    onChange={(e) => setCreateCheckpointDays(Number(e.target.value))}
+                    min={1}
+                    max={90}
+                    className="w-24 bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:border-gray-500"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Error */}
+          {createError && (
+            <p className="text-sm text-red-400">{createError}</p>
+          )}
+
+          {/* Actions */}
+          <div className="flex items-center gap-3 pt-2">
+            <button
+              type="submit"
+              disabled={createSubmitting}
+              className="px-5 py-2 rounded-md bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors"
+            >
+              {createSubmitting ? 'Creating...' : 'Create Plan'}
+            </button>
+            <a
+              href="/study/chat?method=plan"
+              className="text-sm text-blue-400 hover:text-blue-300 transition-colors"
+            >
+              Or: Plan with AI
+            </a>
+          </div>
+        </form>
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render: DETAIL view
+  // ---------------------------------------------------------------------------
+
+  if (view === 'detail') {
+    if (detailLoading || !selectedPlan) {
+      return (
+        <div className="flex items-center justify-center py-20">
+          <p className="text-sm text-gray-500">Loading plan...</p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="max-w-3xl space-y-6">
+        {/* Back link */}
+        <button
+          onClick={goToList}
+          className="text-sm text-gray-500 hover:text-gray-300 transition-colors flex items-center gap-1"
+        >
+          ← Back to Plans
+        </button>
+
+        {/* Plan header */}
+        <div className="rounded-lg border border-gray-800 bg-gray-900 p-5 space-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="space-y-1">
+              <h2 className="text-xl font-semibold text-gray-100">{selectedPlan.title}</h2>
+              <div className="flex items-center gap-2">
+                <StrategyBadge strategy={selectedPlan.strategy} />
+                <span className="text-xs text-gray-500">
+                  Created {formatDate(selectedPlan.createdAt)}
+                </span>
+                {selectedPlan.nextCheckpointAt && (
+                  <span className="text-xs text-gray-500">
+                    · Next checkpoint {formatDate(selectedPlan.nextCheckpointAt)}
+                  </span>
+                )}
+              </div>
+            </div>
+            <button
+              onClick={() => router.push(`/study/session?planId=${selectedPlan.id}`)}
+              className="shrink-0 px-4 py-2 rounded-md bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium transition-colors"
+            >
+              Start Plan Session
+            </button>
+          </div>
+
+          {/* Progress */}
+          <div className="space-y-1.5">
+            <ProgressBar pct={selectedPlan.progressPercent} />
+            <p className="text-xs text-gray-500">
+              {Math.round(selectedPlan.progressPercent)}% of concepts at target · {selectedPlan.conceptCount} total
+            </p>
+          </div>
+        </div>
+
+        {/* Concept checklist */}
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">Concepts</h3>
+            <button
+              onClick={() => {
+                setShowAddConcepts(!showAddConcepts);
+                setAddConceptsSelected(new Set());
+              }}
+              className="text-xs px-3 py-1.5 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 transition-colors"
+            >
+              {showAddConcepts ? 'Cancel' : 'Add Concepts'}
+            </button>
+          </div>
+
+          {/* Add concepts panel */}
+          {showAddConcepts && (
+            <div className="rounded-lg border border-gray-700 bg-gray-900 p-4 space-y-4">
+              <ConceptSelectorForCreate
+                allConcepts={allConcepts}
+                selected={addConceptsSelected}
+                onToggle={(id) => {
+                  setAddConceptsSelected((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(id)) next.delete(id);
+                    else next.add(id);
+                    return next;
+                  });
+                }}
+                onSelectAllDomain={(ids, domainIds) => {
+                  if (ids.length === 0) {
+                    setAddConceptsSelected((prev) => {
+                      const next = new Set(prev);
+                      domainIds.forEach((id) => next.delete(id));
+                      return next;
+                    });
+                  } else {
+                    setAddConceptsSelected((prev) => {
+                      const next = new Set(prev);
+                      ids.forEach((id) => next.add(id));
+                      return next;
+                    });
+                  }
+                }}
+                excludeIds={existingConceptIds}
+              />
+              <button
+                onClick={handleAddConcepts}
+                disabled={addConceptsSelected.size === 0 || addConceptsSubmitting}
+                className="px-4 py-2 rounded-md bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors"
+              >
+                {addConceptsSubmitting
+                  ? 'Adding...'
+                  : addConceptsSelected.size > 0
+                    ? `Add ${addConceptsSelected.size} concept${addConceptsSelected.size !== 1 ? 's' : ''}`
+                    : 'Add Concepts'}
+              </button>
+            </div>
+          )}
+
+          {/* Concept list */}
+          {sortedDetailConcepts.length === 0 ? (
+            <div className="rounded-lg border border-gray-800 bg-gray-900 p-6 text-center">
+              <p className="text-sm text-gray-500">No concepts in this plan.</p>
+            </div>
+          ) : (
+            <div className="rounded-lg border border-gray-800 overflow-hidden">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-900 border-b border-gray-800">
+                  <tr>
+                    <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider">Concept</th>
+                    <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider hidden sm:table-cell">Domain</th>
+                    <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-32">Bloom</th>
+                    <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-28">Mastery</th>
+                    <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-16">Done</th>
+                    <th className="px-4 py-3 w-12" />
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-800 bg-gray-950">
+                  {sortedDetailConcepts.map((c) => (
+                    <tr key={c.conceptId} className="hover:bg-gray-900 transition-colors">
+                      <td className="px-4 py-3 text-gray-100 font-medium">{c.title}</td>
+                      <td className="px-4 py-3 text-gray-400 hidden sm:table-cell">{c.domain ?? '—'}</td>
+                      <td className="px-4 py-3 text-gray-400 text-xs">
+                        L{c.bloomCeiling} → <span className="text-blue-400">L{c.targetBloom}</span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="h-1.5 bg-gray-700 rounded-full overflow-hidden w-20">
+                          <div
+                            className="h-full bg-blue-500 rounded-full"
+                            style={{ width: `${Math.round(c.masteryOverall * 100)}%` }}
+                          />
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        {c.atTarget ? (
+                          <span className="text-green-400 text-base">✓</span>
+                        ) : (
+                          <span className="text-gray-600 text-base">–</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <button
+                          onClick={() => handleRemoveConcept(c.conceptId)}
+                          className="text-xs text-gray-600 hover:text-red-400 transition-colors"
+                          title="Remove from plan"
+                        >
+                          ✕
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+
+        {/* Danger zone */}
+        {selectedPlan.status === 'active' && (
+          <section className="flex items-center gap-3 pt-2">
+            <button
+              onClick={handleCompletePlan}
+              className="px-4 py-2 rounded-md bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-colors"
+            >
+              Mark Complete
+            </button>
+            <button
+              onClick={handleArchivePlan}
+              className="px-4 py-2 rounded-md bg-red-600 hover:bg-red-700 text-white text-sm font-medium transition-colors"
+            >
+              Archive Plan
+            </button>
+          </section>
+        )}
+      </div>
+    );
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Internal concept selector (with domain-aware toggle)
+// ---------------------------------------------------------------------------
+
+interface InternalConceptSelectorProps {
+  allConcepts: ConceptSummary[];
+  selected: Set<string>;
+  onToggle: (id: string) => void;
+  onSelectAllDomain: (ids: string[], allDomainIds: string[]) => void;
+  excludeIds?: Set<string>;
+}
+
+function ConceptSelectorForCreate({
+  allConcepts,
+  selected,
+  onToggle,
+  onSelectAllDomain,
+  excludeIds,
+}: InternalConceptSelectorProps) {
+  const filtered = excludeIds
+    ? allConcepts.filter((c) => !excludeIds.has(c.id))
+    : allConcepts;
+
+  // Group by domain
+  const domainMap = new Map<string, ConceptSummary[]>();
+  for (const c of filtered) {
+    const key = c.domain ?? 'Uncategorised';
+    if (!domainMap.has(key)) domainMap.set(key, []);
+    domainMap.get(key)!.push(c);
+  }
+
+  if (filtered.length === 0) {
+    return <p className="text-sm text-gray-500">No concepts available.</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {Array.from(domainMap.entries()).map(([domain, concepts]) => {
+        const domainIds = concepts.map((c) => c.id);
+        const allSel = domainIds.every((id) => selected.has(id));
+        return (
+          <div key={domain} className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-gray-400 uppercase tracking-wider">{domain}</span>
+              <button
+                type="button"
+                onClick={() =>
+                  allSel
+                    ? onSelectAllDomain([], domainIds)
+                    : onSelectAllDomain(domainIds, domainIds)
+                }
+                className="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+              >
+                {allSel ? 'Deselect all' : 'Select all'}
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {concepts.map((c) => (
+                <label
+                  key={c.id}
+                  className={`flex items-center gap-1.5 cursor-pointer text-xs px-2.5 py-1.5 rounded-md border transition-colors ${
+                    selected.has(c.id)
+                      ? 'bg-blue-900/40 border-blue-700 text-blue-200'
+                      : 'bg-gray-800 border-gray-700 text-gray-300 hover:border-gray-600'
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.has(c.id)}
+                    onChange={() => onToggle(c.id)}
+                    className="w-3 h-3 accent-blue-500"
+                  />
+                  {c.title}
+                </label>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/src/app/study/session/page.tsx
+++ b/dashboard/src/app/study/session/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { useSearchParams } from 'next/navigation';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -175,9 +176,13 @@ function isAiEvalEligible(bloomLevel: number, activityType: string): boolean {
 // ---------------------------------------------------------------------------
 
 export default function StudySessionPage() {
+  const searchParams = useSearchParams();
+  const planId = searchParams.get('planId');
+
   const [phase, setPhase] = useState<Phase>('loading');
   const [sessionData, setSessionData] = useState<SessionData | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [planTitle, setPlanTitle] = useState<string | null>(null);
 
   // PRE_SESSION
   const [preConfidence, setPreConfidence] = useState<Record<string, number>>({});
@@ -242,12 +247,26 @@ export default function StudySessionPage() {
   }, [cleanupEvalResources]);
 
   // ---------------------------------------------------------------------------
+  // Fetch plan title when planId is present
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (planId) {
+      fetch(`/api/study/plans/${planId}`)
+        .then((r) => r.json())
+        .then((data: { plan?: { title?: string } }) => setPlanTitle(data.plan?.title ?? null))
+        .catch(() => {});
+    }
+  }, [planId]);
+
+  // ---------------------------------------------------------------------------
   // LOADING: fetch session data
   // ---------------------------------------------------------------------------
 
   useEffect(() => {
     if (phase !== 'loading') return;
-    fetch('/api/study/session')
+    const url = planId ? `/api/study/session?planId=${planId}` : '/api/study/session';
+    fetch(url)
       .then((r) => r.json())
       .then((data: { session?: SessionData; error?: string }) => {
         if (data.error) {
@@ -266,7 +285,7 @@ export default function StudySessionPage() {
       .catch((err: unknown) => {
         setLoadError(String(err));
       });
-  }, [phase]);
+  }, [phase, planId]);
 
   // ---------------------------------------------------------------------------
   // PRE_SESSION: begin session
@@ -277,7 +296,11 @@ export default function StudySessionPage() {
     const res = await fetch('/api/study/session', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ preConfidence }),
+      body: JSON.stringify({
+        sessionType: 'daily',
+        preConfidence,
+        planId: planId || undefined,
+      }),
     });
     const data = (await res.json()) as { sessionId?: string; error?: string };
     if (!data.sessionId) return;
@@ -583,6 +606,18 @@ export default function StudySessionPage() {
 
     return (
       <div className="max-w-2xl mx-auto space-y-6">
+        {/* Plan context banner */}
+        {planTitle && (
+          <div className="bg-blue-900/30 border border-blue-800 rounded-lg px-4 py-2 flex items-center justify-between">
+            <span className="text-blue-300 text-sm">
+              Studying: <span className="font-medium text-blue-200">{planTitle}</span>
+            </span>
+            <a href="/study/plan" className="text-blue-400 hover:text-blue-300 text-sm">
+              &larr; Back to plan
+            </a>
+          </div>
+        )}
+
         {/* Header */}
         <div>
           <h2 className="text-xl font-semibold text-gray-100 mb-1">Today&apos;s Session</h2>
@@ -656,6 +691,18 @@ export default function StudySessionPage() {
 
     return (
       <div className="max-w-2xl mx-auto space-y-4">
+        {/* Plan context banner */}
+        {planTitle && (
+          <div className="bg-blue-900/30 border border-blue-800 rounded-lg px-4 py-2 flex items-center justify-between">
+            <span className="text-blue-300 text-sm">
+              Studying: <span className="font-medium text-blue-200">{planTitle}</span>
+            </span>
+            <a href="/study/plan" className="text-blue-400 hover:text-blue-300 text-sm">
+              &larr; Back to plan
+            </a>
+          </div>
+        )}
+
         {/* Progress bar */}
         <div>
           <div className="flex justify-between text-xs text-gray-500 mb-1">

--- a/dashboard/src/lib/db/schema.ts
+++ b/dashboard/src/lib/db/schema.ts
@@ -103,3 +103,29 @@ export const activity_log = sqliteTable('activity_log', {
   session_id: text('session_id'),
   reviewed_at: text('reviewed_at').notNull(),
 });
+
+export const study_plans = sqliteTable('study_plans', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  domain: text('domain'),
+  course: text('course'),
+  strategy: text('strategy').notNull().default('open'),
+  learning_objectives: text('learning_objectives'),
+  desired_outcomes: text('desired_outcomes'),
+  implementation_intention: text('implementation_intention'),
+  obstacle: text('obstacle'),
+  study_schedule: text('study_schedule'),
+  config: text('config'),
+  checkpoint_interval_days: integer('checkpoint_interval_days').default(14),
+  next_checkpoint_at: text('next_checkpoint_at'),
+  created_at: text('created_at').notNull(),
+  updated_at: text('updated_at').notNull(),
+  status: text('status').default('active'),
+});
+
+export const study_plan_concepts = sqliteTable('study_plan_concepts', {
+  plan_id: text('plan_id').notNull(),
+  concept_id: text('concept_id').notNull(),
+  target_bloom: integer('target_bloom').default(6),
+  sort_order: integer('sort_order').default(0),
+});

--- a/dashboard/src/lib/session-builder.ts
+++ b/dashboard/src/lib/session-builder.ts
@@ -5,7 +5,7 @@
  * new-material / review / stretch block layout from spec Section 4.5.
  */
 
-import { getDueActivities, getActiveConcepts } from './study-db';
+import { getDueActivities, getActiveConcepts, getPlanConceptIds } from './study-db';
 import type { ConceptSummary } from './study-db';
 
 // ---------------------------------------------------------------------------
@@ -36,6 +36,7 @@ export interface SessionComposition {
 export interface SessionOptions {
   targetActivities?: number;
   domainFocus?: string;
+  planId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -107,6 +108,13 @@ export function buildSessionComposition(
     return { blocks: [], totalActivities: 0, estimatedMinutes: 0, domainsCovered: [] };
   }
 
+  // Plan concept filtering
+  let activitiesToUse = dueActivities;
+  if (options?.planId) {
+    const planConceptIds = new Set(getPlanConceptIds(options.planId));
+    activitiesToUse = dueActivities.filter(a => planConceptIds.has(a.concept_id));
+  }
+
   const activeConcepts = getActiveConcepts();
 
   // Build concept lookup map keyed by id
@@ -123,7 +131,7 @@ export function buildSessionComposition(
   }
 
   const enriched: EnrichedActivity[] = [];
-  for (const act of dueActivities) {
+  for (const act of activitiesToUse) {
     const concept = conceptMap.get(act.concept_id);
     if (!concept) continue;
 

--- a/dashboard/src/lib/study-db.ts
+++ b/dashboard/src/lib/study-db.ts
@@ -7,9 +7,9 @@
  * mapped to camelCase response interfaces.
  */
 
-import { eq, and, lte, asc, desc, count, sql, inArray, isNull } from 'drizzle-orm';
+import { eq, and, lte, asc, desc, count, sql, inArray, isNull, gte } from 'drizzle-orm';
 import { getDb } from './db/index';
-import { concepts, learning_activities, study_sessions, activity_log } from './db/schema';
+import { concepts, learning_activities, study_sessions, activity_log, study_plans, study_plan_concepts } from './db/schema';
 import {
   sm2,
   computeDueDate,
@@ -691,4 +691,333 @@ export function getLogByActivityIdAndMethod(
     )
     .orderBy(desc(activity_log.reviewed_at))
     .get();
+}
+
+// ---------------------------------------------------------------------------
+// Plan interfaces
+// ---------------------------------------------------------------------------
+
+export interface PlanSummary {
+  id: string;
+  title: string;
+  domain: string | null;
+  course: string | null;
+  strategy: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  nextCheckpointAt: string | null;
+  conceptCount: number;
+  progressPercent: number;
+}
+
+export interface PlanDetail extends PlanSummary {
+  learningObjectives: string | null;
+  desiredOutcomes: string | null;
+  implementationIntention: string | null;
+  obstacle: string | null;
+  studySchedule: string | null;
+  config: string | null;
+  checkpointIntervalDays: number;
+  concepts: PlanConceptRow[];
+}
+
+export interface PlanConceptRow {
+  conceptId: string;
+  title: string;
+  domain: string | null;
+  bloomCeiling: number;
+  targetBloom: number;
+  masteryOverall: number;
+  atTarget: boolean;
+}
+
+export interface NewPlan {
+  id: string;
+  title: string;
+  domain?: string;
+  course?: string;
+  strategy?: string;
+  learningObjectives?: string;
+  desiredOutcomes?: string;
+  implementationIntention?: string;
+  obstacle?: string;
+  studySchedule?: string;
+  config?: string;
+  checkpointIntervalDays?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Plan CRUD functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert a new plan and its concept associations in a transaction.
+ */
+export function createPlan(plan: NewPlan, conceptIds: string[], targetBloom?: number): void {
+  const db = getDb();
+  const now = new Date().toISOString();
+  const checkpointDays = plan.checkpointIntervalDays ?? 14;
+  const checkpointDate = new Date(Date.now() + checkpointDays * 86400000).toISOString().slice(0, 10);
+
+  db.transaction((tx) => {
+    tx.insert(study_plans).values({
+      id: plan.id,
+      title: plan.title,
+      domain: plan.domain ?? null,
+      course: plan.course ?? null,
+      strategy: plan.strategy ?? 'open',
+      learning_objectives: plan.learningObjectives ?? null,
+      desired_outcomes: plan.desiredOutcomes ?? null,
+      implementation_intention: plan.implementationIntention ?? null,
+      obstacle: plan.obstacle ?? null,
+      study_schedule: plan.studySchedule ?? null,
+      config: plan.config ?? null,
+      checkpoint_interval_days: checkpointDays,
+      next_checkpoint_at: checkpointDate,
+      created_at: now,
+      updated_at: now,
+      status: 'active',
+    }).run();
+
+    for (let i = 0; i < conceptIds.length; i++) {
+      tx.insert(study_plan_concepts).values({
+        plan_id: plan.id,
+        concept_id: conceptIds[i],
+        target_bloom: targetBloom ?? 6,
+        sort_order: i,
+      }).run();
+    }
+  });
+}
+
+/**
+ * Helper: build PlanSummary for a plan row, given its concept join rows.
+ */
+function buildPlanSummary(
+  row: typeof study_plans.$inferSelect,
+  conceptJoins: Array<{ target_bloom: number | null; bloom_ceiling: number | null }>,
+): PlanSummary {
+  const conceptCount = conceptJoins.length;
+  const atTargetCount = conceptJoins.filter(
+    (c) => (c.bloom_ceiling ?? 0) >= (c.target_bloom ?? 6),
+  ).length;
+  const progressPercent = conceptCount === 0 ? 0 : Math.round((atTargetCount / conceptCount) * 100);
+
+  return {
+    id: row.id,
+    title: row.title,
+    domain: row.domain ?? null,
+    course: row.course ?? null,
+    strategy: row.strategy,
+    status: row.status ?? 'active',
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    nextCheckpointAt: row.next_checkpoint_at ?? null,
+    conceptCount,
+    progressPercent,
+  };
+}
+
+/**
+ * List all plans with concept counts and progress percentages.
+ */
+export function getAllPlans(): PlanSummary[] {
+  const db = getDb();
+
+  const planRows = db.select().from(study_plans).orderBy(desc(study_plans.created_at)).all();
+  if (planRows.length === 0) return [];
+
+  const planIds = planRows.map((p) => p.id);
+
+  const joins = db
+    .select({
+      plan_id: study_plan_concepts.plan_id,
+      target_bloom: study_plan_concepts.target_bloom,
+      bloom_ceiling: concepts.bloom_ceiling,
+    })
+    .from(study_plan_concepts)
+    .leftJoin(concepts, eq(study_plan_concepts.concept_id, concepts.id))
+    .where(inArray(study_plan_concepts.plan_id, planIds))
+    .all();
+
+  const joinsByPlan = new Map<string, typeof joins>();
+  for (const j of joins) {
+    if (!joinsByPlan.has(j.plan_id)) joinsByPlan.set(j.plan_id, []);
+    joinsByPlan.get(j.plan_id)!.push(j);
+  }
+
+  return planRows.map((row) => buildPlanSummary(row, joinsByPlan.get(row.id) ?? []));
+}
+
+/**
+ * List active plans only.
+ */
+export function getActivePlans(): PlanSummary[] {
+  const db = getDb();
+
+  const planRows = db
+    .select()
+    .from(study_plans)
+    .where(eq(study_plans.status, 'active'))
+    .orderBy(desc(study_plans.created_at))
+    .all();
+  if (planRows.length === 0) return [];
+
+  const planIds = planRows.map((p) => p.id);
+
+  const joins = db
+    .select({
+      plan_id: study_plan_concepts.plan_id,
+      target_bloom: study_plan_concepts.target_bloom,
+      bloom_ceiling: concepts.bloom_ceiling,
+    })
+    .from(study_plan_concepts)
+    .leftJoin(concepts, eq(study_plan_concepts.concept_id, concepts.id))
+    .where(inArray(study_plan_concepts.plan_id, planIds))
+    .all();
+
+  const joinsByPlan = new Map<string, typeof joins>();
+  for (const j of joins) {
+    if (!joinsByPlan.has(j.plan_id)) joinsByPlan.set(j.plan_id, []);
+    joinsByPlan.get(j.plan_id)!.push(j);
+  }
+
+  return planRows.map((row) => buildPlanSummary(row, joinsByPlan.get(row.id) ?? []));
+}
+
+/**
+ * Full plan detail including concept rows. Returns null if not found.
+ */
+export function getPlanById(id: string): PlanDetail | null {
+  const db = getDb();
+
+  const row = db.select().from(study_plans).where(eq(study_plans.id, id)).get();
+  if (!row) return null;
+
+  const joinRows = db
+    .select({
+      concept_id: study_plan_concepts.concept_id,
+      target_bloom: study_plan_concepts.target_bloom,
+      sort_order: study_plan_concepts.sort_order,
+      title: concepts.title,
+      domain: concepts.domain,
+      bloom_ceiling: concepts.bloom_ceiling,
+      mastery_overall: concepts.mastery_overall,
+    })
+    .from(study_plan_concepts)
+    .leftJoin(concepts, eq(study_plan_concepts.concept_id, concepts.id))
+    .where(eq(study_plan_concepts.plan_id, id))
+    .orderBy(asc(study_plan_concepts.sort_order))
+    .all();
+
+  const conceptRows: PlanConceptRow[] = joinRows.map((j) => {
+    const targetBloom = j.target_bloom ?? 6;
+    const bloomCeiling = j.bloom_ceiling ?? 0;
+    return {
+      conceptId: j.concept_id,
+      title: j.title ?? j.concept_id,
+      domain: j.domain ?? null,
+      bloomCeiling,
+      targetBloom,
+      masteryOverall: j.mastery_overall ?? 0,
+      atTarget: bloomCeiling >= targetBloom,
+    };
+  });
+
+  const summary = buildPlanSummary(
+    row,
+    joinRows.map((j) => ({ target_bloom: j.target_bloom, bloom_ceiling: j.bloom_ceiling })),
+  );
+
+  return {
+    ...summary,
+    learningObjectives: row.learning_objectives ?? null,
+    desiredOutcomes: row.desired_outcomes ?? null,
+    implementationIntention: row.implementation_intention ?? null,
+    obstacle: row.obstacle ?? null,
+    studySchedule: row.study_schedule ?? null,
+    config: row.config ?? null,
+    checkpointIntervalDays: row.checkpoint_interval_days ?? 14,
+    concepts: conceptRows,
+  };
+}
+
+/**
+ * Update arbitrary plan fields. Always sets updated_at to now.
+ */
+export function updatePlan(id: string, updates: Record<string, unknown>): void {
+  const db = getDb();
+  db.update(study_plans)
+    .set({ ...updates, updated_at: new Date().toISOString() })
+    .where(eq(study_plans.id, id))
+    .run();
+}
+
+/**
+ * Returns the concept IDs associated with a plan (used by session builder).
+ */
+export function getPlanConceptIds(planId: string): string[] {
+  const db = getDb();
+  const rows = db
+    .select({ concept_id: study_plan_concepts.concept_id })
+    .from(study_plan_concepts)
+    .where(eq(study_plan_concepts.plan_id, planId))
+    .orderBy(asc(study_plan_concepts.sort_order))
+    .all();
+  return rows.map((r) => r.concept_id);
+}
+
+/**
+ * Batch add concepts to a plan. Skips duplicates via check-before-insert.
+ * New entries are appended after the current max sort_order.
+ */
+export function addConceptsToPlan(planId: string, conceptIds: string[], targetBloom?: number): void {
+  if (conceptIds.length === 0) return;
+  const db = getDb();
+
+  // Get existing concept IDs for this plan
+  const existing = db
+    .select({ concept_id: study_plan_concepts.concept_id })
+    .from(study_plan_concepts)
+    .where(eq(study_plan_concepts.plan_id, planId))
+    .all();
+  const existingSet = new Set(existing.map((r) => r.concept_id));
+
+  // Get current max sort_order
+  const maxRow = db
+    .select({ max_order: sql<number>`coalesce(max(${study_plan_concepts.sort_order}), -1)` })
+    .from(study_plan_concepts)
+    .where(eq(study_plan_concepts.plan_id, planId))
+    .get();
+  let nextOrder = (maxRow?.max_order ?? -1) + 1;
+
+  const toInsert = conceptIds.filter((cid) => !existingSet.has(cid));
+  if (toInsert.length === 0) return;
+
+  db.transaction((tx) => {
+    for (const conceptId of toInsert) {
+      tx.insert(study_plan_concepts).values({
+        plan_id: planId,
+        concept_id: conceptId,
+        target_bloom: targetBloom ?? 6,
+        sort_order: nextOrder++,
+      }).run();
+    }
+  });
+}
+
+/**
+ * Remove a single concept from a plan.
+ */
+export function removeConceptFromPlan(planId: string, conceptId: string): void {
+  const db = getDb();
+  db.delete(study_plan_concepts)
+    .where(
+      and(
+        eq(study_plan_concepts.plan_id, planId),
+        eq(study_plan_concepts.concept_id, conceptId),
+      ),
+    )
+    .run();
 }

--- a/dashboard/src/lib/study-db.ts
+++ b/dashboard/src/lib/study-db.ts
@@ -78,6 +78,7 @@ export interface NewSession {
   sessionType: string;
   preConfidence?: string;
   surface?: string;
+  planId?: string;
 }
 
 function rowToSummary(row: ConceptRow, dueCount: number): ConceptSummary {
@@ -571,6 +572,7 @@ export function createSession(session: NewSession): void {
       session_type: session.sessionType,
       pre_confidence: session.preConfidence ?? null,
       surface: session.surface ?? null,
+      plan_id: session.planId ?? null,
     })
     .run();
 }

--- a/groups/study/CLAUDE.md
+++ b/groups/study/CLAUDE.md
@@ -24,7 +24,7 @@ Your first message from the system contains structured context:
 
 - **Concept title** — the topic being studied
 - **Bloom's level** — the target mastery level (L1-L6)
-- **Method** — the study method to use (feynman, socratic, case_analysis, comparison, synthesis)
+- **Method** — the study method to use (feynman, socratic, case_analysis, comparison, synthesis, plan)
 - **Activity ID** — the activity being completed (needed for IPC)
 - **Previous dialogue context** — optional, for resumed sessions
 
@@ -111,6 +111,41 @@ When no specific method is provided, choose based on the Bloom's level: L2-L3 de
 **Push for position:** Synthesis at L5-L6 requires the student to take a stance — argue for something, evaluate alternatives, propose a framework. A list of related ideas is not synthesis.
 
 **Closing:** Assess whether the student achieved genuine integration. Write `study_complete` with quality reflecting integration depth, not breadth of coverage.
+
+### 3.6 Plan Creation Dialogue (method=plan)
+
+**Goal:** Help the student think through what they want to study and why. You are a learning advisor, not a form filler. The student creates the actual plan via the dashboard — your job is to help them clarify goals, identify the right concepts, and choose an effective strategy.
+
+**Opening:** Ask what they want to focus on. Listen for: domain or course, specific concepts, time pressure (exam date), or general exploration. Let them talk before structuring anything.
+
+**Goal clarification:** Help them articulate what success looks like. "When you're done studying this, what will you be able to do?" (backward design — Wiggins & McTighe). Push for Bloom's-level specificity: "Do you need to recall these models, or apply them to novel cases?"
+
+**Strategy selection:** Based on their goals, recommend one of:
+- `open` — no deadline, mastery-oriented, steady progression
+- `exam-prep` — deadline-driven, coverage-focused, prioritize weak concepts
+- `weekly-review` — recurring, maintenance-oriented
+- `exploration` — curiosity-driven, breadth over depth
+
+**Concept identification:** If they mention a domain, suggest they use the dashboard's concept selector to pick specific concepts. Do NOT fetch concept lists — you don't have DB access. Work from what the student tells you and recommend they finalize selections in the dashboard.
+
+**Optional depth (offer, don't force):** At any natural pause, offer to go deeper on:
+- Learning objectives — what Bloom's level fits each concept
+- Implementation intentions — "When and where will you study?" (Gollwitzer 1999)
+- Obstacles and mitigation — "What's most likely to get in the way?" (WOOP, Oettingen)
+- Study schedule and pacing
+
+If the student doesn't want to go deeper, move to wrap-up. Match their depth preference.
+
+**Wrap-up:** Summarize what you've discussed. Point them to the dashboard form with specific suggestions: "I'd suggest an exam-prep plan titled 'KM Frameworks for BI-2081 Exam', targeting L4 for the models and L5 for synthesis."
+
+**Constraints:**
+- Do NOT create plans via IPC. The dashboard handles plan creation.
+- Do NOT fetch concept lists. Suggest concepts from what the student tells you.
+- Keep it conversational. No numbered checklists. No form-like prompts.
+- Brain-first applies: ask the student what they think first, then offer your perspective.
+- The dialogue can be 2 messages or 20. Match the student's energy.
+- Stay focused on plan structure and concept selection. No exam tips, study technique tutorials, or motivational speeches.
+- Do NOT write `study_complete` for plan dialogues. There is no activity to complete.
 
 ---
 

--- a/src/study/queries.test.ts
+++ b/src/study/queries.test.ts
@@ -30,6 +30,10 @@ import {
   updateStudyPlan,
   addConceptsToPlan,
   getPlanConcepts,
+  getPlanProgress,
+  getActivePlans,
+  removeConceptFromPlan,
+  getPlanConceptIds,
   completeActivity,
   type NewConcept,
   type NewLearningActivity,
@@ -741,5 +745,199 @@ describe('getConceptsAboveBloomCeiling', () => {
     const result = getConceptsAboveBloomCeiling(3);
     expect(result[0].title).toBe('Alpha');
     expect(result[1].title).toBe('Zebra');
+  });
+});
+
+// ============================================================
+// getPlanProgress
+// ============================================================
+
+describe('getPlanProgress', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+  });
+  afterEach(() => _closeDatabase());
+
+  it('returns null for a non-existent plan', () => {
+    const result = getPlanProgress('no-such-plan');
+    expect(result).toBeNull();
+  });
+
+  it('computes progress for a plan with 3 concepts, 1 at target bloom', () => {
+    createStudyPlan(makePlan({ id: 'plan-prog', title: 'Progress Plan' }));
+    // concept-a: bloomCeiling=4, targetBloom=3 → at target (4 >= 3)
+    createConcept(makeConcept({ id: 'c-a', title: 'Alpha', domain: 'math', bloomCeiling: 4, status: 'active' }));
+    // concept-b: bloomCeiling=2, targetBloom=3 → not at target (2 < 3)
+    createConcept(makeConcept({ id: 'c-b', title: 'Beta', domain: 'math', bloomCeiling: 2, status: 'active' }));
+    // concept-c: bloomCeiling=1, targetBloom=4 → not at target (1 < 4)
+    createConcept(makeConcept({ id: 'c-c', title: 'Gamma', domain: 'physics', bloomCeiling: 1, status: 'active' }));
+
+    addConceptsToPlan('plan-prog', ['c-a', 'c-b', 'c-c'], 3);
+    // Override targetBloom for c-c by adding separately — addConceptsToPlan uses same targetBloom for all,
+    // so we set targetBloom=3 for all, then verify the atTarget logic:
+    // c-a: ceiling=4 >= target=3 → true
+    // c-b: ceiling=2 >= target=3 → false
+    // c-c: ceiling=1 >= target=3 → false
+
+    const progress = getPlanProgress('plan-prog');
+    expect(progress).not.toBeNull();
+    expect(progress!.planId).toBe('plan-prog');
+    expect(progress!.totalConcepts).toBe(3);
+    expect(progress!.conceptsAtTarget).toBe(1);
+    expect(progress!.progressPercent).toBe(33); // Math.round(1/3 * 100)
+
+    const details = progress!.conceptDetails;
+    expect(details).toHaveLength(3);
+
+    const alpha = details.find(d => d.conceptId === 'c-a')!;
+    expect(alpha.atTarget).toBe(true);
+    expect(alpha.currentBloomCeiling).toBe(4);
+    expect(alpha.targetBloom).toBe(3);
+    expect(alpha.domain).toBe('math');
+
+    const beta = details.find(d => d.conceptId === 'c-b')!;
+    expect(beta.atTarget).toBe(false);
+    expect(beta.currentBloomCeiling).toBe(2);
+  });
+
+  it('returns progressPercent=0 for a plan with no concepts', () => {
+    createStudyPlan(makePlan({ id: 'plan-empty', title: 'Empty Plan' }));
+    const progress = getPlanProgress('plan-empty');
+    expect(progress).not.toBeNull();
+    expect(progress!.totalConcepts).toBe(0);
+    expect(progress!.conceptsAtTarget).toBe(0);
+    expect(progress!.progressPercent).toBe(0);
+    expect(progress!.conceptDetails).toHaveLength(0);
+  });
+
+  it('returns progressPercent=100 when all concepts are at target', () => {
+    createStudyPlan(makePlan({ id: 'plan-full', title: 'Full Plan' }));
+    createConcept(makeConcept({ id: 'c-x', title: 'X', bloomCeiling: 6, status: 'active' }));
+    createConcept(makeConcept({ id: 'c-y', title: 'Y', bloomCeiling: 5, status: 'active' }));
+    addConceptsToPlan('plan-full', ['c-x', 'c-y'], 4);
+
+    const progress = getPlanProgress('plan-full');
+    expect(progress!.conceptsAtTarget).toBe(2);
+    expect(progress!.progressPercent).toBe(100);
+  });
+});
+
+// ============================================================
+// getActivePlans
+// ============================================================
+
+describe('getActivePlans', () => {
+  beforeEach(() => _initTestDatabase());
+  afterEach(() => _closeDatabase());
+
+  it('returns only active plans, ordered by createdAt desc', () => {
+    createStudyPlan(makePlan({
+      id: 'plan-active-1',
+      title: 'Active Old',
+      status: 'active',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: NOW,
+    }));
+    createStudyPlan(makePlan({
+      id: 'plan-active-2',
+      title: 'Active New',
+      status: 'active',
+      createdAt: '2026-04-01T00:00:00.000Z',
+      updatedAt: NOW,
+    }));
+    createStudyPlan(makePlan({
+      id: 'plan-archived',
+      title: 'Archived',
+      status: 'archived',
+      createdAt: '2026-03-01T00:00:00.000Z',
+      updatedAt: NOW,
+    }));
+
+    const active = getActivePlans();
+    expect(active).toHaveLength(2);
+    const ids = active.map(p => p.id);
+    expect(ids).toContain('plan-active-1');
+    expect(ids).toContain('plan-active-2');
+    expect(ids).not.toContain('plan-archived');
+    // ordered by createdAt desc
+    expect(active[0].id).toBe('plan-active-2');
+    expect(active[1].id).toBe('plan-active-1');
+  });
+
+  it('returns empty array when no active plans exist', () => {
+    createStudyPlan(makePlan({ id: 'plan-arch', status: 'archived', updatedAt: NOW }));
+    const active = getActivePlans();
+    expect(active).toHaveLength(0);
+  });
+});
+
+// ============================================================
+// removeConceptFromPlan
+// ============================================================
+
+describe('removeConceptFromPlan', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    createStudyPlan(makePlan({ id: 'plan-rm', title: 'Remove Plan' }));
+    createConcept(makeConcept({ id: 'c-1', title: 'C1' }));
+    createConcept(makeConcept({ id: 'c-2', title: 'C2' }));
+    createConcept(makeConcept({ id: 'c-3', title: 'C3' }));
+    addConceptsToPlan('plan-rm', ['c-1', 'c-2', 'c-3']);
+  });
+  afterEach(() => _closeDatabase());
+
+  it('removes one concept, leaving the other two', () => {
+    removeConceptFromPlan('plan-rm', 'c-2');
+    const remaining = getPlanConceptIds('plan-rm');
+    expect(remaining).toHaveLength(2);
+    expect(remaining).toContain('c-1');
+    expect(remaining).toContain('c-3');
+    expect(remaining).not.toContain('c-2');
+  });
+
+  it('is a no-op when the concept is not in the plan', () => {
+    expect(() => removeConceptFromPlan('plan-rm', 'does-not-exist')).not.toThrow();
+    const remaining = getPlanConceptIds('plan-rm');
+    expect(remaining).toHaveLength(3);
+  });
+});
+
+// ============================================================
+// getPlanConceptIds
+// ============================================================
+
+describe('getPlanConceptIds', () => {
+  beforeEach(() => {
+    _initTestDatabase();
+    createStudyPlan(makePlan({ id: 'plan-ids', title: 'IDs Plan' }));
+    createConcept(makeConcept({ id: 'c-alpha', title: 'Alpha' }));
+    createConcept(makeConcept({ id: 'c-beta', title: 'Beta' }));
+    createConcept(makeConcept({ id: 'c-gamma', title: 'Gamma' }));
+    addConceptsToPlan('plan-ids', ['c-alpha', 'c-beta', 'c-gamma']);
+  });
+  afterEach(() => _closeDatabase());
+
+  it('returns all concept IDs for the plan', () => {
+    const ids = getPlanConceptIds('plan-ids');
+    expect(ids).toHaveLength(3);
+    expect(ids).toContain('c-alpha');
+    expect(ids).toContain('c-beta');
+    expect(ids).toContain('c-gamma');
+  });
+
+  it('returns empty array for a plan with no concepts', () => {
+    createStudyPlan(makePlan({ id: 'plan-none', title: 'No Concepts' }));
+    const ids = getPlanConceptIds('plan-none');
+    expect(ids).toHaveLength(0);
+  });
+
+  it('does not return concept IDs from a different plan', () => {
+    createStudyPlan(makePlan({ id: 'plan-other', title: 'Other Plan' }));
+    createConcept(makeConcept({ id: 'c-other', title: 'Other' }));
+    addConceptsToPlan('plan-other', ['c-other']);
+
+    const ids = getPlanConceptIds('plan-ids');
+    expect(ids).not.toContain('c-other');
+    expect(ids).toHaveLength(3);
   });
 });

--- a/src/study/queries.ts
+++ b/src/study/queries.ts
@@ -22,6 +22,8 @@ import type {
   BloomLevel,
   MasteryActivityInput,
   MasteryState,
+  PlanProgress,
+  PlanConceptProgress,
 } from './types.js';
 
 // ====================================================================
@@ -404,6 +406,76 @@ export function getPlanConcepts(planId: string): Concept[] {
     .where(eq(schema.studyPlanConcepts.planId, planId))
     .orderBy(asc(schema.studyPlanConcepts.sortOrder))
     .all();
+}
+
+export function getPlanProgress(planId: string): PlanProgress | null {
+  const plan = getStudyPlanById(planId);
+  if (!plan) return null;
+
+  const rows = getDb()
+    .select({
+      conceptId: schema.concepts.id,
+      conceptTitle: schema.concepts.title,
+      domain: schema.concepts.domain,
+      bloomCeiling: schema.concepts.bloomCeiling,
+      masteryOverall: schema.concepts.masteryOverall,
+      targetBloom: schema.studyPlanConcepts.targetBloom,
+    })
+    .from(schema.studyPlanConcepts)
+    .innerJoin(schema.concepts, eq(schema.studyPlanConcepts.conceptId, schema.concepts.id))
+    .where(eq(schema.studyPlanConcepts.planId, planId))
+    .orderBy(asc(schema.studyPlanConcepts.sortOrder))
+    .all();
+
+  const details: PlanConceptProgress[] = rows.map(r => ({
+    conceptId: r.conceptId,
+    conceptTitle: r.conceptTitle,
+    domain: r.domain,
+    currentBloomCeiling: r.bloomCeiling ?? 0,
+    targetBloom: r.targetBloom ?? 6,
+    masteryOverall: r.masteryOverall ?? 0,
+    atTarget: (r.bloomCeiling ?? 0) >= (r.targetBloom ?? 6),
+  }));
+
+  const atTarget = details.filter(d => d.atTarget).length;
+
+  return {
+    planId,
+    totalConcepts: details.length,
+    conceptsAtTarget: atTarget,
+    progressPercent: details.length > 0 ? Math.round((atTarget / details.length) * 100) : 0,
+    conceptDetails: details,
+  };
+}
+
+export function getActivePlans(): StudyPlan[] {
+  return getDb()
+    .select()
+    .from(schema.studyPlans)
+    .where(eq(schema.studyPlans.status, 'active'))
+    .orderBy(desc(schema.studyPlans.createdAt))
+    .all();
+}
+
+export function removeConceptFromPlan(planId: string, conceptId: string): void {
+  getDb()
+    .delete(schema.studyPlanConcepts)
+    .where(
+      and(
+        eq(schema.studyPlanConcepts.planId, planId),
+        eq(schema.studyPlanConcepts.conceptId, conceptId),
+      ),
+    )
+    .run();
+}
+
+export function getPlanConceptIds(planId: string): string[] {
+  return getDb()
+    .select({ conceptId: schema.studyPlanConcepts.conceptId })
+    .from(schema.studyPlanConcepts)
+    .where(eq(schema.studyPlanConcepts.planId, planId))
+    .all()
+    .map(r => r.conceptId);
 }
 
 // ====================================================================

--- a/src/study/session-builder.test.ts
+++ b/src/study/session-builder.test.ts
@@ -3,8 +3,11 @@ import { _initTestDatabase, _closeDatabase } from '../db/index.js';
 import {
   createConcept,
   createActivity,
+  createStudyPlan,
+  addConceptsToPlan,
   type NewConcept,
   type NewLearningActivity,
+  type NewStudyPlan,
 } from './queries.js';
 import { buildDailySession } from './session-builder.js';
 
@@ -553,5 +556,106 @@ describe('buildDailySession', () => {
     expect(result.domainsCovered.length).toBe(
       new Set(result.domainsCovered).size,
     );
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 13. Plan-scoped session contains only plan concept activities
+  // ──────────────────────────────────────────────────────────────────────────
+  it('restricts activities to plan concepts when planId is provided', async () => {
+    const NOW_TS = '2026-04-15T12:00:00.000Z';
+    const TODAY_DATE = '2026-04-15';
+
+    // Concepts A, B, C with due activities
+    createConcept(makeConcept({ id: 'p-ca', title: 'Plan A', bloomCeiling: 2 }));
+    createConcept(makeConcept({ id: 'p-cb', title: 'Plan B', bloomCeiling: 2 }));
+    createConcept(makeConcept({ id: 'p-cc', title: 'Non-Plan C', bloomCeiling: 2 }));
+
+    for (let i = 1; i <= 3; i++) {
+      createActivity(
+        makeActivity({ id: `pa-${i}`, conceptId: 'p-ca', bloomLevel: 3, activityType: 'elaboration' }),
+      );
+      createActivity(
+        makeActivity({ id: `pb-${i}`, conceptId: 'p-cb', bloomLevel: 3, activityType: 'elaboration' }),
+      );
+      createActivity(
+        makeActivity({ id: `pc-${i}`, conceptId: 'p-cc', bloomLevel: 3, activityType: 'elaboration' }),
+      );
+    }
+
+    // Plan P includes concepts A and B only
+    const plan: NewStudyPlan = {
+      id: 'plan-p1',
+      title: 'Test Plan',
+      strategy: 'spaced-repetition',
+      status: 'active',
+      createdAt: NOW_TS,
+      updatedAt: NOW_TS,
+    };
+    createStudyPlan(plan);
+    addConceptsToPlan('plan-p1', ['p-ca', 'p-cb']);
+
+    const result = await buildDailySession({ planId: 'plan-p1' });
+
+    const allActivities = result.blocks.flatMap((b) => b.activities);
+    expect(allActivities.length).toBeGreaterThan(0);
+
+    // All returned activities must belong to concepts A or B
+    for (const act of allActivities) {
+      expect(['p-ca', 'p-cb']).toContain(act.conceptId);
+    }
+    // Concept C must not appear
+    expect(allActivities.every((a) => a.conceptId !== 'p-cc')).toBe(true);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 14. Empty plan returns empty session
+  // ──────────────────────────────────────────────────────────────────────────
+  it('returns empty composition when plan has no concepts', async () => {
+    const NOW_TS = '2026-04-15T12:00:00.000Z';
+
+    // Some activities exist in the DB
+    createConcept(makeConcept({ id: 'ep-c1', title: 'Existing', bloomCeiling: 2 }));
+    createActivity(makeActivity({ id: 'ep-a1', conceptId: 'ep-c1', bloomLevel: 3 }));
+
+    // Plan with no concepts added
+    const plan: NewStudyPlan = {
+      id: 'plan-empty',
+      title: 'Empty Plan',
+      strategy: 'spaced-repetition',
+      status: 'active',
+      createdAt: NOW_TS,
+      updatedAt: NOW_TS,
+    };
+    createStudyPlan(plan);
+
+    const result = await buildDailySession({ planId: 'plan-empty' });
+
+    expect(result.totalActivities).toBe(0);
+    expect(result.blocks).toHaveLength(0);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 15. No planId returns all activities (regression)
+  // ──────────────────────────────────────────────────────────────────────────
+  it('includes activities from all concepts when no planId is provided', async () => {
+    createConcept(makeConcept({ id: 'rg-c1', title: 'C1', bloomCeiling: 2 }));
+    createConcept(makeConcept({ id: 'rg-c2', title: 'C2', bloomCeiling: 2 }));
+    createConcept(makeConcept({ id: 'rg-c3', title: 'C3', bloomCeiling: 2 }));
+
+    for (let i = 1; i <= 2; i++) {
+      createActivity(makeActivity({ id: `rg-c1-${i}`, conceptId: 'rg-c1', bloomLevel: 3 }));
+      createActivity(makeActivity({ id: `rg-c2-${i}`, conceptId: 'rg-c2', bloomLevel: 3 }));
+      createActivity(makeActivity({ id: `rg-c3-${i}`, conceptId: 'rg-c3', bloomLevel: 3 }));
+    }
+
+    const result = await buildDailySession();
+
+    const allActivities = result.blocks.flatMap((b) => b.activities);
+    const conceptIds = new Set(allActivities.map((a) => a.conceptId));
+
+    // All three concepts should be represented
+    expect(conceptIds.has('rg-c1')).toBe(true);
+    expect(conceptIds.has('rg-c2')).toBe(true);
+    expect(conceptIds.has('rg-c3')).toBe(true);
   });
 });

--- a/src/study/session-builder.ts
+++ b/src/study/session-builder.ts
@@ -1,6 +1,8 @@
 import {
   getDueActivities,
   getActiveConcepts,
+  getPlanConceptIds,
+  getStudyPlanById,
   type Concept,
   type LearningActivity,
 } from './queries.js';
@@ -74,7 +76,7 @@ function interleaveByConceptId(
 export function buildDailySession(
   options?: SessionOptions,
 ): SessionComposition {
-  const target = options?.targetActivities ?? 20;
+  let target = options?.targetActivities ?? 20;
 
   // 1. Fetch due activities and active concepts
   const dueActivities = getDueActivities();
@@ -92,9 +94,39 @@ export function buildDailySession(
     activeConcepts.map((c) => [c.id, c]),
   );
 
+  // 1b. Plan concept filtering
+  let activitiesToUse = dueActivities;
+  if (options?.planId) {
+    const planConceptIds = new Set(getPlanConceptIds(options.planId));
+    activitiesToUse = dueActivities.filter((a) =>
+      planConceptIds.has(a.conceptId),
+    );
+  }
+
+  // 1c. Exam-prep: increase target when exam is imminent
+  if (options?.planId) {
+    const plan = getStudyPlanById(options.planId);
+    if (plan?.strategy === 'exam-prep' && plan.config) {
+      try {
+        const config = JSON.parse(plan.config as string);
+        if (config.exam_date) {
+          const daysUntilExam = Math.ceil(
+            (new Date(config.exam_date).getTime() - Date.now()) /
+              (1000 * 60 * 60 * 24),
+          );
+          if (daysUntilExam < 7 && !options.targetActivities) {
+            target = 30;
+          }
+        }
+      } catch {
+        /* ignore invalid config */
+      }
+    }
+  }
+
   // 2. Enrich and filter activities
   let enriched: Array<{ activity: LearningActivity; concept: Concept }> = [];
-  for (const activity of dueActivities) {
+  for (const activity of activitiesToUse) {
     const concept = conceptMap.get(activity.conceptId);
     if (!concept) continue; // silently skip orphaned activities
     enriched.push({ activity, concept });

--- a/src/study/types.ts
+++ b/src/study/types.ts
@@ -130,3 +130,23 @@ export interface SynthesisOpportunity {
   concepts: Array<{ id: string; title: string; bloomCeiling: number }>;
   automatic: boolean; // true for within-subdomain/domain, false for cross-domain
 }
+
+/** Progress summary for a study plan */
+export interface PlanProgress {
+  planId: string;
+  totalConcepts: number;
+  conceptsAtTarget: number;  // concepts where bloomCeiling >= targetBloom
+  progressPercent: number;   // conceptsAtTarget / totalConcepts * 100
+  conceptDetails: PlanConceptProgress[];
+}
+
+/** Per-concept progress within a plan */
+export interface PlanConceptProgress {
+  conceptId: string;
+  conceptTitle: string;
+  domain: string | null;
+  currentBloomCeiling: number;
+  targetBloom: number;
+  masteryOverall: number;
+  atTarget: boolean;
+}

--- a/src/study/types.ts
+++ b/src/study/types.ts
@@ -95,6 +95,7 @@ export interface SessionComposition {
 export interface SessionOptions {
   targetActivities?: number; // default 20
   domainFocus?: string; // filter to specific domain
+  planId?: string; // filter activities to plan concepts only
 }
 
 /** Bloom advancement check result */
@@ -135,8 +136,8 @@ export interface SynthesisOpportunity {
 export interface PlanProgress {
   planId: string;
   totalConcepts: number;
-  conceptsAtTarget: number;  // concepts where bloomCeiling >= targetBloom
-  progressPercent: number;   // conceptsAtTarget / totalConcepts * 100
+  conceptsAtTarget: number; // concepts where bloomCeiling >= targetBloom
+  progressPercent: number; // conceptsAtTarget / totalConcepts * 100
   conceptDetails: PlanConceptProgress[];
 }
 


### PR DESCRIPTION
## Summary

- **Plan CRUD**: Full study plan lifecycle — create, read, update, archive, complete. Plans associate concepts with target Bloom levels, support strategies (open, exam-prep, weekly-review, exploration), and track progress as percentage of concepts at target.
- **Plan-aware sessions**: Session builder filters activities to plan concepts when `planId` is provided. Exam-prep plans with <7 days until deadline increase session size to 30 activities. `plan_id` persisted on `study_sessions` records.
- **Plan UI**: `/study/plan` page with list, create (concept selector grouped by domain), and detail views (concept progress checklist, start plan session, add/remove concepts). Plans section added to `/study` overview.
- **Plan dialogue**: Study agent CLAUDE.md extended with plan creation dialogue instructions — helps students clarify goals and strategy through conversation before creating plans via the dashboard form.
- **Backend queries**: `getPlanProgress`, `getActivePlans`, `removeConceptFromPlan`, `getPlanConceptIds` with 14 new test cases (147 total study tests, 837 total).

## Changes by sprint task

| Task | Files | What |
|------|-------|------|
| S6.1 | `src/study/types.ts`, `queries.ts`, `queries.test.ts` | Plan progress + utility queries |
| S6.2 | `src/study/session-builder.ts`, `types.ts`, `dashboard/src/lib/session-builder.ts` + tests | Plan-aware session builder |
| S6.3 | `dashboard/src/lib/db/schema.ts`, `study-db.ts` | Dashboard plan schema + 8 DB functions |
| S6.4 | `dashboard/src/app/api/study/plans/` (3 files) | Plan CRUD API routes |
| S6.5 | `dashboard/src/app/study/plan/page.tsx`, `page.tsx` | Plan page + overview section |
| S6.6 | `dashboard/src/app/api/study/session/route.ts`, `session/page.tsx`, `study-db.ts` | Wire planId into sessions |
| S6.7 | `groups/study/CLAUDE.md` | Plan dialogue instructions |

## Test plan

- [ ] `npm test` — 837 pass, 0 study-related failures
- [ ] `npm run build` — clean
- [ ] `cd dashboard && npx tsc --noEmit` — clean
- [ ] Navigate to `/study/plan` — empty state renders
- [ ] Create plan with concepts → redirects to detail with progress
- [ ] Start plan session → only plan concept activities shown
- [ ] Archive plan → moves to archived section
- [ ] `/study` overview shows active plans section

🤖 Generated with [Claude Code](https://claude.com/claude-code)