### PR TITLE
feat(study): S8 Analytics + Audio + Polish

### DIFF
--- a/dashboard/src/app/api/study/complete/route.ts
+++ b/dashboard/src/app/api/study/complete/route.ts
@@ -18,6 +18,7 @@ export async function POST(request: Request) {
       responseText: body.responseText,
       responseTimeMs: body.responseTimeMs,
       confidenceRating: body.confidenceRating,
+      scaffoldingLevel: typeof body.scaffoldingLevel === 'number' ? body.scaffoldingLevel : undefined,
       surface: 'dashboard_ui',
     });
 

--- a/dashboard/src/app/api/study/concepts/[id]/route.ts
+++ b/dashboard/src/app/api/study/concepts/[id]/route.ts
@@ -1,0 +1,17 @@
+import { getConceptDetail } from '@/lib/study-db';
+
+export async function GET(
+  _request: Request,
+  ctx: { params: Promise<Record<string, string>> },
+) {
+  try {
+    const { id } = await ctx.params;
+    const concept = getConceptDetail(id);
+    if (!concept) {
+      return Response.json({ error: 'Concept not found' }, { status: 404 });
+    }
+    return Response.json({ concept });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/study/session/route.ts
+++ b/dashboard/src/app/api/study/session/route.ts
@@ -5,6 +5,7 @@ import {
   getActiveSession,
   updateSession,
 } from '@/lib/study-db';
+import { getPrerequisiteWarnings, getStalenessWarnings } from '@/lib/session-warnings';
 
 export async function GET(request: Request) {
   try {
@@ -22,6 +23,8 @@ export async function GET(request: Request) {
             prompt: full.prompt,
             referenceAnswer: full.reference_answer ?? null,
             cardType: full.card_type ?? null,
+            sourceNotePath: full.source_note_path ?? null,
+            generatedAt: full.generated_at,
           };
         })
         .filter(Boolean),
@@ -30,11 +33,32 @@ export async function GET(request: Request) {
       (sum, b) => sum + b.activities.length,
       0,
     );
+
+    // Extract unique concept IDs from session for prerequisite warnings
+    const conceptIds = [
+      ...new Set(enrichedBlocks.flatMap((b) => b.activities.map((a) => a!.conceptId))),
+    ];
+    const prerequisiteWarnings = getPrerequisiteWarnings(conceptIds);
+
+    // Extract activity staleness data
+    const activityData = enrichedBlocks.flatMap((b) =>
+      b.activities.map((a) => ({
+        activityId: a!.activityId,
+        sourceNotePath: a!.sourceNotePath,
+        generatedAt: a!.generatedAt,
+      })),
+    );
+    const staleActivities = getStalenessWarnings(activityData);
+
     return Response.json({
       session: {
         ...composition,
         blocks: enrichedBlocks,
         totalActivities,
+      },
+      warnings: {
+        prerequisites: prerequisiteWarnings,
+        staleActivities,
       },
     });
   } catch (err) {

--- a/dashboard/src/app/api/study/session/route.ts
+++ b/dashboard/src/app/api/study/session/route.ts
@@ -4,8 +4,10 @@ import {
   createSession,
   getActiveSession,
   updateSession,
+  getRecentLogs,
 } from '@/lib/study-db';
 import { getPrerequisiteWarnings, getStalenessWarnings } from '@/lib/session-warnings';
+import { computeScaffoldingLevel, generateHint } from '@/lib/scaffolding';
 
 export async function GET(request: Request) {
   try {
@@ -25,10 +27,30 @@ export async function GET(request: Request) {
             cardType: full.card_type ?? null,
             sourceNotePath: full.source_note_path ?? null,
             generatedAt: full.generated_at,
+            scaffoldingLevel: 0,
+            hint: null as string | null,
           };
         })
         .filter(Boolean),
     }));
+
+    // Compute scaffolding levels per concept (cached to avoid redundant queries)
+    const scaffoldingCache = new Map<string, number>();
+    for (const block of enrichedBlocks) {
+      for (const activity of block.activities) {
+        if (!activity) continue;
+        let level = scaffoldingCache.get(activity.conceptId);
+        if (level === undefined) {
+          const logs = getRecentLogs(activity.conceptId, 10);
+          const qualities = logs.map(l => l.quality);
+          level = computeScaffoldingLevel(qualities, 0);
+          scaffoldingCache.set(activity.conceptId, level);
+        }
+        activity.scaffoldingLevel = level;
+        activity.hint = generateHint(activity.referenceAnswer, level);
+      }
+    }
+
     const totalActivities = enrichedBlocks.reduce(
       (sum, b) => sum + b.activities.length,
       0,

--- a/dashboard/src/app/api/study/stats/route.ts
+++ b/dashboard/src/app/api/study/stats/route.ts
@@ -1,0 +1,42 @@
+import {
+  getRetentionRate,
+  getBloomDistribution,
+  getMethodEffectiveness,
+  getActivityTimeSeries,
+  getCalibrationData,
+} from '@/lib/study-db';
+
+/**
+ * GET /api/study/stats?days=7
+ *
+ * Returns combined analytics for the given time window (defaults to 7 days).
+ */
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const days = Math.max(1, parseInt(searchParams.get('days') ?? '7', 10) || 7);
+
+    const from = new Date(Date.now() - days * 86400000).toISOString();
+    const to = new Date().toISOString();
+
+    const [retentionRate, bloomDistribution, methodEffectiveness, activityTimeSeries, calibration] =
+      await Promise.all([
+        Promise.resolve(getRetentionRate(days)),
+        Promise.resolve(getBloomDistribution(days)),
+        Promise.resolve(getMethodEffectiveness()),
+        Promise.resolve(getActivityTimeSeries(days)),
+        Promise.resolve(getCalibrationData(days)),
+      ]);
+
+    return Response.json({
+      retentionRate,
+      bloomDistribution,
+      methodEffectiveness,
+      activityTimeSeries,
+      calibration,
+      period: { days, from, to },
+    });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/study/stats/route.ts
+++ b/dashboard/src/app/api/study/stats/route.ts
@@ -23,7 +23,7 @@ export async function GET(request: Request) {
       await Promise.all([
         Promise.resolve(getRetentionRate(days)),
         Promise.resolve(getBloomDistribution(days)),
-        Promise.resolve(getMethodEffectiveness()),
+        Promise.resolve(getMethodEffectiveness(days)),
         Promise.resolve(getActivityTimeSeries(days)),
         Promise.resolve(getCalibrationData(days)),
       ]);

--- a/dashboard/src/app/api/study/suggest-activity/route.ts
+++ b/dashboard/src/app/api/study/suggest-activity/route.ts
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+import { NextResponse } from 'next/server';
+
+const projectRoot = path.join(process.cwd(), '..');
+
+function ipcTaskDir(): string {
+  return path.join(projectRoot, 'data', 'ipc', 'study-generator', 'tasks');
+}
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const { conceptId, activityType, prompt, bloomLevel } = body;
+
+  if (!conceptId || !activityType || !prompt || !bloomLevel) {
+    return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+  }
+
+  const validTypes = [
+    'card_review',
+    'elaboration',
+    'self_explain',
+    'concept_map',
+    'synthesis',
+    'socratic',
+    'comparison',
+    'case_analysis',
+  ];
+  if (!validTypes.includes(activityType)) {
+    return NextResponse.json({ error: 'Invalid activity type' }, { status: 400 });
+  }
+
+  if (typeof bloomLevel !== 'number' || bloomLevel < 1 || bloomLevel > 6) {
+    return NextResponse.json({ error: 'Bloom level must be 1-6' }, { status: 400 });
+  }
+
+  const dir = ipcTaskDir();
+  fs.mkdirSync(dir, { recursive: true });
+
+  const payload = {
+    type: 'study_suggest_activity',
+    conceptId,
+    activityType,
+    prompt,
+    bloomLevel,
+    author: 'student',
+  };
+
+  const ts = Date.now();
+  const rand = Math.random().toString(36).slice(2, 8);
+  const filename = `suggest-${ts}-${rand}.json`;
+  fs.writeFileSync(path.join(dir, filename), JSON.stringify(payload));
+
+  return NextResponse.json({ success: true });
+}

--- a/dashboard/src/app/study/concepts/[id]/page.tsx
+++ b/dashboard/src/app/study/concepts/[id]/page.tsx
@@ -1,0 +1,383 @@
+'use client';
+
+import { useState, useEffect, use } from 'react';
+import type { ConceptDetail } from '@/lib/study-db';
+
+const MASTERY_THRESHOLD = 10.0;
+
+const BLOOM_LABELS: Record<number, string> = {
+  1: 'Remember',
+  2: 'Understand',
+  3: 'Apply',
+  4: 'Analyse',
+  5: 'Evaluate',
+  6: 'Create',
+};
+
+function MasteryBar({ value, label }: { value: number; label: string }) {
+  const pct = Math.min(100, Math.round((value / MASTERY_THRESHOLD) * 100));
+  const colorClass =
+    pct >= 70
+      ? 'bg-green-500'
+      : pct >= 30
+        ? 'bg-yellow-400'
+        : 'bg-gray-600';
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className="w-24 text-xs text-gray-400 shrink-0">{label}</span>
+      <div className="flex-1 h-2.5 rounded-full bg-gray-800 overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all ${colorClass}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="w-20 text-xs text-gray-500 text-right shrink-0">
+        {Math.round(value * 10) / 10} / {MASTERY_THRESHOLD}
+      </span>
+    </div>
+  );
+}
+
+function QualityDots({ quality }: { quality: number }) {
+  return (
+    <span className="inline-flex gap-0.5">
+      {Array.from({ length: 5 }, (_, i) => (
+        <span
+          key={i}
+          className={`inline-block w-1.5 h-1.5 rounded-full ${i < quality ? 'bg-green-400' : 'bg-gray-700'}`}
+        />
+      ))}
+    </span>
+  );
+}
+
+function formatDate(iso: string) {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export default function ConceptDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const [concept, setConcept] = useState<ConceptDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/study/concepts/${encodeURIComponent(id)}`)
+      .then((res) => res.json())
+      .then((data: { concept?: ConceptDetail; error?: string }) => {
+        if (data.error) {
+          setError(data.error);
+        } else if (data.concept) {
+          setConcept(data.concept);
+        }
+      })
+      .catch((err: unknown) => setError(String(err)))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-gray-500">Loading...</p>
+      </div>
+    );
+  }
+
+  if (error || !concept) {
+    return (
+      <div className="max-w-5xl space-y-4">
+        <a href="/study" className="text-sm text-blue-400 hover:text-blue-300">← Back to Study</a>
+        <div className="rounded-lg border border-gray-800 bg-gray-900 p-5">
+          <p className="text-sm text-red-400">{error ?? 'Concept not found.'}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const masteryLevels = [
+    { label: `L1 — ${BLOOM_LABELS[1]}`, value: concept.masteryL1 },
+    { label: `L2 — ${BLOOM_LABELS[2]}`, value: concept.masteryL2 },
+    { label: `L3 — ${BLOOM_LABELS[3]}`, value: concept.masteryL3 },
+    { label: `L4 — ${BLOOM_LABELS[4]}`, value: concept.masteryL4 },
+    { label: `L5 — ${BLOOM_LABELS[5]}`, value: concept.masteryL5 },
+    { label: `L6 — ${BLOOM_LABELS[6]}`, value: concept.masteryL6 },
+  ];
+
+  const maxMethodQuality = Math.max(
+    ...concept.methodEffectiveness.map((m) => m.avgQuality),
+    1,
+  );
+
+  return (
+    <div className="max-w-5xl space-y-8">
+      {/* Header */}
+      <div className="space-y-3">
+        <a href="/study" className="text-sm text-blue-400 hover:text-blue-300 transition-colors">
+          ← Back to Study
+        </a>
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-2">
+            <h2 className="text-2xl font-semibold text-gray-100">{concept.title}</h2>
+            <div className="flex flex-wrap items-center gap-2">
+              {concept.domain && (
+                <span className="px-2 py-0.5 rounded-md bg-gray-800 border border-gray-700 text-xs text-gray-300">
+                  {concept.domain}
+                </span>
+              )}
+              {concept.subdomain && (
+                <span className="px-2 py-0.5 rounded-md bg-gray-800 border border-gray-700 text-xs text-gray-400">
+                  {concept.subdomain}
+                </span>
+              )}
+              {concept.course && (
+                <span className="px-2 py-0.5 rounded-md bg-gray-800 border border-gray-700 text-xs text-gray-400">
+                  {concept.course}
+                </span>
+              )}
+              <span className="text-xs text-gray-600">
+                Bloom ceiling: {concept.bloomCeiling > 0 ? `L${concept.bloomCeiling} — ${BLOOM_LABELS[concept.bloomCeiling] ?? `L${concept.bloomCeiling}`}` : '—'}
+              </span>
+            </div>
+          </div>
+          {concept.vaultNotePath && (
+            <a
+              href={`obsidian://open?path=${encodeURIComponent(concept.vaultNotePath)}`}
+              className="shrink-0 px-3 py-1.5 rounded-md bg-gray-800 hover:bg-gray-700 border border-gray-700 text-xs text-gray-300 transition-colors"
+            >
+              Open in Vault
+            </a>
+          )}
+        </div>
+      </div>
+
+      {/* Mastery breakdown */}
+      <section className="space-y-3">
+        <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">Mastery Breakdown</h3>
+        <div className="rounded-lg border border-gray-800 bg-gray-900 p-5 space-y-3">
+          {masteryLevels.map((level, idx) => (
+            <MasteryBar
+              key={idx}
+              label={level.label}
+              value={level.value}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* Activities */}
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">
+            Activities
+            <span className="ml-2 text-gray-600 normal-case font-normal">({concept.totalActivities})</span>
+          </h3>
+          <button
+            onClick={() => alert('Generation requested')}
+            className="px-3 py-1.5 rounded-md bg-blue-700 hover:bg-blue-600 text-white text-xs font-medium transition-colors"
+          >
+            Generate more
+          </button>
+        </div>
+        {concept.activities.length === 0 ? (
+          <div className="rounded-lg border border-gray-800 bg-gray-900 p-5 text-center">
+            <p className="text-sm text-gray-500">No activities generated yet.</p>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-gray-800 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-900 border-b border-gray-800">
+                <tr>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider">Type</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-20">Bloom</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-32">Due</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-28">State</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-24">Author</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-800 bg-gray-950">
+                {concept.activities.map((activity) => (
+                  <tr key={activity.id} className="hover:bg-gray-900 transition-colors">
+                    <td className="px-4 py-3 text-gray-200">{activity.activityType}</td>
+                    <td className="px-4 py-3 text-gray-400">
+                      L{activity.bloomLevel}
+                      {BLOOM_LABELS[activity.bloomLevel] && (
+                        <span className="ml-1 text-gray-600 text-xs">{BLOOM_LABELS[activity.bloomLevel]}</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-gray-400 text-xs">{formatDate(activity.dueAt)}</td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`text-xs px-1.5 py-0.5 rounded ${
+                          activity.masteryState === 'mastered'
+                            ? 'bg-green-900 text-green-300'
+                            : activity.masteryState === 'reviewing'
+                              ? 'bg-blue-900 text-blue-300'
+                              : 'bg-gray-800 text-gray-400'
+                        }`}
+                      >
+                        {activity.masteryState}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-gray-500 text-xs">{activity.author}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* Activity history */}
+      <section className="space-y-3">
+        <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">Activity History</h3>
+        {concept.recentLogs.length === 0 ? (
+          <div className="rounded-lg border border-gray-800 bg-gray-900 p-5 text-center">
+            <p className="text-sm text-gray-500">No history yet.</p>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-gray-800 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-900 border-b border-gray-800">
+                <tr>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-32">Date</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider">Type</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-20">Bloom</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-28">Quality</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider">Method</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-800 bg-gray-950">
+                {concept.recentLogs.map((log) => (
+                  <tr key={log.id} className="hover:bg-gray-900 transition-colors">
+                    <td className="px-4 py-3 text-gray-400 text-xs">{formatDate(log.reviewedAt)}</td>
+                    <td className="px-4 py-3 text-gray-200">{log.activityType}</td>
+                    <td className="px-4 py-3 text-gray-400 text-xs">L{log.bloomLevel}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <QualityDots quality={log.quality} />
+                        <span className="text-xs text-gray-500">{log.quality}/5</span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-gray-500 text-xs">{log.evaluationMethod}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* Method effectiveness */}
+      <section className="space-y-3">
+        <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">Method Effectiveness</h3>
+        {concept.methodEffectiveness.length === 0 ? (
+          <div className="rounded-lg border border-gray-800 bg-gray-900 p-5 text-center">
+            <p className="text-sm text-gray-500">No data yet.</p>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-gray-800 bg-gray-900 p-5 space-y-3">
+            {concept.methodEffectiveness.map((method) => {
+              const pct = Math.round((method.avgQuality / maxMethodQuality) * 100);
+              return (
+                <div key={method.activityType} className="flex items-center gap-3">
+                  <span className="w-36 text-xs text-gray-400 shrink-0 truncate">{method.activityType}</span>
+                  <div className="flex-1 h-2.5 rounded-full bg-gray-800 overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-blue-500 transition-all"
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                  <span className="w-28 text-xs text-gray-500 text-right shrink-0">
+                    {method.avgQuality.toFixed(1)} avg · {method.count} reviews
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      {/* Related concepts */}
+      <section className="space-y-3">
+        <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">Related Concepts</h3>
+        {concept.relatedConcepts.length === 0 ? (
+          <div className="rounded-lg border border-gray-800 bg-gray-900 p-5 text-center">
+            <p className="text-sm text-gray-500">No related concepts found.</p>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-gray-800 bg-gray-900 p-5">
+            <div className="flex flex-wrap gap-2">
+              {concept.relatedConcepts.map((related) => (
+                <a
+                  key={related.id}
+                  href={`/study/concepts/${related.id}`}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-gray-800 hover:bg-gray-700 border border-gray-700 text-sm text-gray-300 hover:text-gray-100 transition-colors"
+                >
+                  {related.title}
+                  <span className="text-xs text-gray-500">{related.role}</span>
+                </a>
+              ))}
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Prerequisites */}
+      <section className="space-y-3">
+        <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">Prerequisites</h3>
+        {concept.prerequisites.length === 0 ? (
+          <div className="rounded-lg border border-gray-800 bg-gray-900 p-5 text-center">
+            <p className="text-sm text-gray-500">No prerequisites defined.</p>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-gray-800 bg-gray-900 p-5 space-y-2">
+            {concept.prerequisites.map((prereq) => {
+              const isWeak = prereq.masteryOverall < 0.3;
+              return (
+                <a
+                  key={prereq.id}
+                  href={`/study/concepts/${prereq.id}`}
+                  className={`flex items-center justify-between px-3 py-2.5 rounded-md border transition-colors ${
+                    isWeak
+                      ? 'border-amber-700 bg-amber-950 hover:bg-amber-900'
+                      : 'border-gray-700 bg-gray-800 hover:bg-gray-700'
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    {isWeak && (
+                      <span className="text-amber-400 text-xs font-medium">Weak</span>
+                    )}
+                    <span className={`text-sm font-medium ${isWeak ? 'text-amber-200' : 'text-gray-200'}`}>
+                      {prereq.title}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3 text-xs text-gray-500">
+                    <span>
+                      Bloom {prereq.bloomCeiling > 0 ? `L${prereq.bloomCeiling}` : '—'}
+                    </span>
+                    <span>
+                      {Math.round(prereq.masteryOverall * 100)}% overall
+                    </span>
+                  </div>
+                </a>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/dashboard/src/app/study/page.tsx
+++ b/dashboard/src/app/study/page.tsx
@@ -14,6 +14,15 @@ const BLOOM_LABELS: Record<number, string> = {
 
 const MASTERY_THRESHOLD = 10.0;
 
+const BLOOM_COLORS: Record<number, string> = {
+  1: 'bg-blue-300',
+  2: 'bg-blue-400',
+  3: 'bg-blue-500',
+  4: 'bg-blue-600',
+  5: 'bg-blue-700',
+  6: 'bg-blue-800',
+};
+
 interface PlanSummary {
   id: string;
   title: string;
@@ -35,6 +44,44 @@ interface SessionPreview {
   domainsCovered: string[];
 }
 
+interface RetentionRate {
+  retentionRate: number;
+  totalReviews: number;
+  correctReviews: number;
+}
+
+interface BloomDistributionItem {
+  bloomLevel: number;
+  count: number;
+  percentage: number;
+}
+
+interface MethodEffectivenessItem {
+  activityType: string;
+  avgQuality: number;
+  count: number;
+}
+
+interface ActivityTimeSeriesItem {
+  date: string;
+  count: number;
+  avgQuality: number;
+}
+
+interface Calibration {
+  calibrationScore: number | null;
+  dataPoints: number;
+}
+
+interface StudyStats {
+  retentionRate: RetentionRate;
+  bloomDistribution: BloomDistributionItem[];
+  methodEffectiveness: MethodEffectivenessItem[];
+  activityTimeSeries: ActivityTimeSeriesItem[];
+  calibration: Calibration;
+  period: { days: number; from: string; to: string };
+}
+
 export default function StudyPage() {
   const [concepts, setConcepts] = useState<ConceptSummary[]>([]);
   const [pendingGroups, setPendingGroups] = useState<PendingGroup[]>([]);
@@ -43,6 +90,10 @@ export default function StudyPage() {
   const [streak, setStreak] = useState<number>(0);
   const [activePlans, setActivePlans] = useState<PlanSummary[]>([]);
   const [loading, setLoading] = useState(true);
+
+  const [analyticsPeriod, setAnalyticsPeriod] = useState<7 | 30 | 9999>(7);
+  const [analyticsData, setAnalyticsData] = useState<StudyStats | null>(null);
+  const [analyticsLoading, setAnalyticsLoading] = useState(false);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -78,9 +129,26 @@ export default function StudyPage() {
     }
   }, []);
 
+  const fetchAnalytics = useCallback(async (days: number) => {
+    setAnalyticsLoading(true);
+    try {
+      const res = await fetch(`/api/study/stats?days=${days}`);
+      const data = await res.json() as StudyStats;
+      setAnalyticsData(data);
+    } catch {
+      // silently fail
+    } finally {
+      setAnalyticsLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  useEffect(() => {
+    fetchAnalytics(analyticsPeriod);
+  }, [fetchAnalytics, analyticsPeriod]);
 
   const approveDomain = useCallback(async (domain: string) => {
     await fetch('/api/study/concepts/approve', {
@@ -118,6 +186,36 @@ export default function StudyPage() {
       }
     }
   }
+
+  // Compute analytics summary values
+  const totalActivities = analyticsData
+    ? analyticsData.activityTimeSeries.reduce((sum, d) => sum + d.count, 0)
+    : 0;
+
+  const avgQuality = analyticsData && analyticsData.activityTimeSeries.length > 0
+    ? analyticsData.activityTimeSeries.reduce((sum, d) => sum + d.avgQuality * d.count, 0) /
+      Math.max(1, totalActivities)
+    : null;
+
+  const retentionPct = analyticsData ? Math.round(analyticsData.retentionRate.retentionRate * 100) : null;
+  const calibrationPct = analyticsData?.calibration.calibrationScore != null
+    ? Math.round(analyticsData.calibration.calibrationScore * 100)
+    : null;
+
+  const retentionColor =
+    retentionPct == null
+      ? 'text-gray-400'
+      : retentionPct > 80
+        ? 'text-green-400'
+        : retentionPct > 60
+          ? 'text-yellow-400'
+          : 'text-red-400';
+
+  const PERIOD_OPTIONS: Array<{ label: string; value: 7 | 30 | 9999 }> = [
+    { label: '7 days', value: 7 },
+    { label: '30 days', value: 30 },
+    { label: 'All time', value: 9999 },
+  ];
 
   return (
     <div className="max-w-5xl space-y-8">
@@ -212,7 +310,133 @@ export default function StudyPage() {
         )}
       </section>
 
-      {/* Section 2 — Pending Approval */}
+      {/* Section 2 — Analytics */}
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">Analytics</h3>
+          <div className="flex gap-1">
+            {PERIOD_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => setAnalyticsPeriod(opt.value)}
+                className={`text-xs px-3 py-1 rounded-md transition-colors ${
+                  analyticsPeriod === opt.value
+                    ? 'bg-blue-700 text-white'
+                    : 'bg-gray-800 text-gray-400 hover:text-gray-300'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {analyticsLoading ? (
+          <div className="rounded-lg border border-gray-800 bg-gray-900 p-8 text-center">
+            <p className="text-sm text-gray-500">Loading analytics...</p>
+          </div>
+        ) : analyticsData ? (
+          <div className="space-y-4">
+            {/* Summary cards */}
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
+                <p className="text-xs text-gray-500 mb-1">Retention rate</p>
+                <p className={`text-2xl font-semibold ${retentionColor}`}>
+                  {retentionPct != null ? `${retentionPct}%` : '—'}
+                </p>
+                <p className="text-xs text-gray-600 mt-0.5">
+                  {analyticsData.retentionRate.correctReviews}/{analyticsData.retentionRate.totalReviews} reviews
+                </p>
+              </div>
+
+              <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
+                <p className="text-xs text-gray-500 mb-1">Activities</p>
+                <p className="text-2xl font-semibold text-gray-100">{totalActivities}</p>
+                <p className="text-xs text-gray-600 mt-0.5">this period</p>
+              </div>
+
+              <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
+                <p className="text-xs text-gray-500 mb-1">Avg quality</p>
+                <p className="text-2xl font-semibold text-gray-100">
+                  {avgQuality != null ? `${avgQuality.toFixed(1)} / 5` : '—'}
+                </p>
+                <p className="text-xs text-gray-600 mt-0.5">per activity</p>
+              </div>
+
+              <div className="rounded-lg border border-gray-800 bg-gray-900 p-4">
+                <p className="text-xs text-gray-500 mb-1">Calibration</p>
+                <p className="text-2xl font-semibold text-gray-100">
+                  {calibrationPct != null ? `${calibrationPct}%` : '—'}
+                </p>
+                <p className="text-xs text-gray-600 mt-0.5">
+                  {analyticsData.calibration.dataPoints} data pts
+                </p>
+              </div>
+            </div>
+
+            {/* Bloom's distribution */}
+            {analyticsData.bloomDistribution.length > 0 && (
+              <div className="rounded-lg border border-gray-800 bg-gray-900 p-4 space-y-2">
+                <p className="text-xs text-gray-500 uppercase tracking-wider">Bloom&apos;s distribution</p>
+                <div className="flex h-5 rounded overflow-hidden">
+                  {analyticsData.bloomDistribution.map((item) => (
+                    <div
+                      key={item.bloomLevel}
+                      className={`${BLOOM_COLORS[item.bloomLevel] ?? 'bg-blue-500'}`}
+                      style={{ width: `${item.percentage}%` }}
+                      title={`L${item.bloomLevel}: ${item.count} (${Math.round(item.percentage)}%)`}
+                    />
+                  ))}
+                </div>
+                <div className="flex">
+                  {analyticsData.bloomDistribution.map((item) => (
+                    <div
+                      key={item.bloomLevel}
+                      style={{ width: `${item.percentage}%` }}
+                      className="text-center overflow-hidden"
+                    >
+                      <span className="text-xs text-gray-500 whitespace-nowrap">
+                        {item.percentage >= 8 ? `L${item.bloomLevel} ${Math.round(item.percentage)}%` : ''}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Method effectiveness */}
+            {analyticsData.methodEffectiveness.length > 0 && (
+              <div className="rounded-lg border border-gray-800 bg-gray-900 p-4 space-y-3">
+                <p className="text-xs text-gray-500 uppercase tracking-wider">Method effectiveness</p>
+                <div className="space-y-2">
+                  {analyticsData.methodEffectiveness.map((method) => (
+                    <div key={method.activityType} className="space-y-1">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs text-gray-300">{method.activityType}</span>
+                        <span className="text-xs text-gray-500">
+                          {method.avgQuality.toFixed(1)} / 5 · {method.count} activities
+                        </span>
+                      </div>
+                      <div className="h-1.5 bg-gray-800 rounded-full overflow-hidden">
+                        <div
+                          className="h-full bg-blue-600 rounded-full"
+                          style={{ width: `${(method.avgQuality / 5) * 100}%` }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="rounded-lg border border-gray-800 bg-gray-900 p-8 text-center">
+            <p className="text-sm text-gray-500">No analytics data available.</p>
+          </div>
+        )}
+      </section>
+
+      {/* Section 3 — Pending Approval */}
       {pendingGroups.length > 0 && (
         <section className="space-y-4">
           <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">Pending Approval</h3>
@@ -254,7 +478,7 @@ export default function StudyPage() {
         </section>
       )}
 
-      {/* Section 3 — Active Concepts */}
+      {/* Section 4 — Active Concepts */}
       <section className="space-y-4">
         <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">Active Concepts</h3>
         {concepts.length === 0 ? (
@@ -286,7 +510,12 @@ export default function StudyPage() {
                   return (
                     <tr key={concept.id} className="hover:bg-gray-900 transition-colors">
                       <td className="px-4 py-3 text-gray-100">
-                        <span className="font-medium">{concept.title}</span>
+                        <a
+                          href={`/study/concepts/${concept.id}`}
+                          className="font-medium text-blue-400 hover:text-blue-300 transition-colors"
+                        >
+                          {concept.title}
+                        </a>
                         {concept.subdomain && (
                           <span className="ml-1.5 text-xs text-gray-500">{concept.subdomain}</span>
                         )}

--- a/dashboard/src/app/study/session/page.tsx
+++ b/dashboard/src/app/study/session/page.tsx
@@ -240,6 +240,16 @@ function StudySessionInner() {
   const evalPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const evalTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Suggestion prompt (student-generated activities)
+  const [showSuggestionPrompt, setShowSuggestionPrompt] = useState(false);
+  const [showSuggestionForm, setShowSuggestionForm] = useState(false);
+  const [suggestionSubmitting, setSuggestionSubmitting] = useState(false);
+  const [suggestionDismissed, setSuggestionDismissed] = useState(false);
+  const [suggestionSuccess, setSuggestionSuccess] = useState(false);
+  const [suggestionActivityType, setSuggestionActivityType] = useState('card_review');
+  const [suggestionPromptText, setSuggestionPromptText] = useState('');
+  const [suggestionBloomLevel, setSuggestionBloomLevel] = useState(1);
+
   // POST_SESSION
   const [reflection, setReflection] = useState('');
   const [reflectLoading, setReflectLoading] = useState(false);
@@ -417,6 +427,36 @@ function StudySessionInner() {
         qualities: newQualities,
       };
     });
+
+    // Show suggestion prompt for struggle (0-2) or mastery (5)
+    if (quality <= 2 || quality === 5) {
+      setSuggestionBloomLevel(flat.activity.bloomLevel);
+      setSuggestionActivityType('card_review');
+      setSuggestionPromptText('');
+      setShowSuggestionPrompt(true);
+    }
+  }
+
+  async function handleSuggestionSubmit() {
+    const flat = flatActivities[currentIndex];
+    if (!flat) return;
+    setSuggestionSubmitting(true);
+    try {
+      await fetch('/api/study/suggest-activity', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          conceptId: flat.activity.conceptId,
+          activityType: suggestionActivityType,
+          prompt: suggestionPromptText,
+          bloomLevel: suggestionBloomLevel,
+        }),
+      });
+      setSuggestionSuccess(true);
+      setShowSuggestionForm(false);
+    } finally {
+      setSuggestionSubmitting(false);
+    }
   }
 
   async function handleSkip() {
@@ -469,6 +509,11 @@ function StudySessionInner() {
       setEvaluationMode(null);
       setAiFeedback('');
       setAiQuality(null);
+      setShowSuggestionPrompt(false);
+      setShowSuggestionForm(false);
+      setSuggestionDismissed(false);
+      setSuggestionSuccess(false);
+      setSuggestionPromptText('');
       activityStartTime.current = Date.now();
     }
   }
@@ -1054,16 +1099,137 @@ function StudySessionInner() {
                           </div>
                         </div>
                       ) : (
-                        <div className="flex items-center justify-between">
-                          <p className="text-sm text-gray-400">
-                            Rated <span className="text-blue-400 font-medium">{selectedQuality}</span> — {QUALITY_LABELS[selectedQuality]}
-                          </p>
-                          <button
-                            onClick={advanceToNext}
-                            className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
-                          >
-                            Next
-                          </button>
+                        <div className="space-y-3">
+                          <div className="flex items-center justify-between">
+                            <p className="text-sm text-gray-400">
+                              Rated <span className="text-blue-400 font-medium">{selectedQuality}</span> — {QUALITY_LABELS[selectedQuality]}
+                            </p>
+                            {(!showSuggestionPrompt || suggestionDismissed || suggestionSuccess) && (
+                              <button
+                                onClick={advanceToNext}
+                                className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+                              >
+                                Next
+                              </button>
+                            )}
+                          </div>
+
+                          {/* Suggestion prompt */}
+                          {showSuggestionPrompt && !suggestionDismissed && !suggestionSuccess && !showSuggestionForm && (
+                            <div className="bg-gray-800 border border-gray-700 rounded-lg p-3 space-y-2">
+                              <p className="text-sm text-gray-300">
+                                {selectedQuality !== null && selectedQuality <= 2
+                                  ? `This was a tough one. Want to create your own question about "${activity.conceptTitle}" to practice later?`
+                                  : `Great work! Want to capture what made this click as a study question?`}
+                              </p>
+                              <div className="flex gap-2">
+                                <button
+                                  onClick={() => setShowSuggestionForm(true)}
+                                  className="px-3 py-1.5 rounded-lg text-xs font-medium bg-blue-700 hover:bg-blue-600 text-white transition-colors"
+                                >
+                                  Yes, create one
+                                </button>
+                                <button
+                                  onClick={() => setSuggestionDismissed(true)}
+                                  className="px-3 py-1.5 rounded-lg text-xs font-medium bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors"
+                                >
+                                  No thanks
+                                </button>
+                              </div>
+                            </div>
+                          )}
+
+                          {/* Suggestion form */}
+                          {showSuggestionForm && !suggestionSuccess && (
+                            <div className="bg-gray-800 border border-gray-700 rounded-lg p-4 space-y-3">
+                              <p className="text-xs text-gray-500 uppercase tracking-wider">Create a study question</p>
+
+                              <div className="space-y-1">
+                                <label className="text-xs text-gray-400">Activity type</label>
+                                <select
+                                  value={suggestionActivityType}
+                                  onChange={(e) => setSuggestionActivityType(e.target.value)}
+                                  className="w-full bg-gray-950 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:border-gray-500"
+                                >
+                                  <option value="card_review">Card Review</option>
+                                  <option value="elaboration">Elaboration</option>
+                                  <option value="self_explain">Self Explain</option>
+                                  <option value="comparison">Comparison</option>
+                                </select>
+                              </div>
+
+                              <div className="space-y-1">
+                                <label className="text-xs text-gray-400">Your study question</label>
+                                <textarea
+                                  value={suggestionPromptText}
+                                  onChange={(e) => setSuggestionPromptText(e.target.value)}
+                                  placeholder="Your study question..."
+                                  rows={3}
+                                  className="w-full bg-gray-950 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 resize-none focus:outline-none focus:border-gray-500"
+                                />
+                              </div>
+
+                              <div className="space-y-1">
+                                <label className="text-xs text-gray-400">Bloom&apos;s level</label>
+                                <div className="flex gap-1.5">
+                                  {([1, 2, 3, 4, 5, 6] as const).map((lvl) => (
+                                    <button
+                                      key={lvl}
+                                      onClick={() => setSuggestionBloomLevel(lvl)}
+                                      className={`flex-1 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                                        suggestionBloomLevel === lvl
+                                          ? 'bg-blue-600 text-white'
+                                          : 'bg-gray-700 text-gray-400 hover:bg-gray-600 hover:text-gray-200'
+                                      }`}
+                                    >
+                                      L{lvl}
+                                    </button>
+                                  ))}
+                                </div>
+                              </div>
+
+                              <div className="flex gap-2 pt-1">
+                                <button
+                                  onClick={handleSuggestionSubmit}
+                                  disabled={suggestionSubmitting || !suggestionPromptText.trim()}
+                                  className="flex-1 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white transition-colors"
+                                >
+                                  {suggestionSubmitting ? 'Saving...' : 'Submit'}
+                                </button>
+                                <button
+                                  onClick={() => { setShowSuggestionForm(false); setSuggestionDismissed(true); }}
+                                  className="px-4 py-2 rounded-lg text-sm text-gray-500 hover:text-gray-300 bg-gray-700 hover:bg-gray-600 transition-colors"
+                                >
+                                  Cancel
+                                </button>
+                              </div>
+                            </div>
+                          )}
+
+                          {/* Success message */}
+                          {suggestionSuccess && (
+                            <div className="flex items-center justify-between">
+                              <p className="text-sm text-green-400">Activity created!</p>
+                              <button
+                                onClick={advanceToNext}
+                                className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+                              >
+                                Next
+                              </button>
+                            </div>
+                          )}
+
+                          {/* Next button when suggestion was dismissed */}
+                          {suggestionDismissed && (
+                            <div className="flex justify-end">
+                              <button
+                                onClick={advanceToNext}
+                                className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+                              >
+                                Next
+                              </button>
+                            </div>
+                          )}
                         </div>
                       )}
                     </>

--- a/dashboard/src/app/study/session/page.tsx
+++ b/dashboard/src/app/study/session/page.tsx
@@ -21,6 +21,8 @@ interface EnrichedActivity {
   sourceNotePath: string | null;
   generatedAt: string;
   staleReason?: string;
+  scaffoldingLevel: number;
+  hint: string | null;
 }
 
 interface EnrichedBlock {
@@ -240,6 +242,9 @@ function StudySessionInner() {
   const evalPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const evalTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Hint display
+  const [showHint, setShowHint] = useState(false);
+
   // Suggestion prompt (student-generated activities)
   const [showSuggestionPrompt, setShowSuggestionPrompt] = useState(false);
   const [showSuggestionForm, setShowSuggestionForm] = useState(false);
@@ -411,6 +416,7 @@ function StudySessionInner() {
         sessionId,
         responseText,
         responseTimeMs,
+        scaffoldingLevel: flat.activity.scaffoldingLevel ?? 0,
       }),
     });
     const result = (await res.json()) as CompletionResult;
@@ -475,6 +481,7 @@ function StudySessionInner() {
         sessionId,
         responseText: '',
         responseTimeMs,
+        scaffoldingLevel: flat.activity.scaffoldingLevel ?? 0,
       }),
     });
 
@@ -514,6 +521,7 @@ function StudySessionInner() {
       setSuggestionDismissed(false);
       setSuggestionSuccess(false);
       setSuggestionPromptText('');
+      setShowHint(false);
       activityStartTime.current = Date.now();
     }
   }
@@ -919,6 +927,28 @@ function StudySessionInner() {
 
           {/* Prompt */}
           <p className="text-gray-100 text-base leading-relaxed">{activity.prompt}</p>
+
+          {/* Scaffolding hint */}
+          {activity.scaffoldingLevel >= 1 && activity.hint && !submitted && (
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => setShowHint((v) => !v)}
+                  className="text-xs text-blue-400 hover:text-blue-300"
+                >
+                  {showHint ? 'Hide hint' : 'Need a hint?'}
+                </button>
+                <span className="text-xs px-2 py-0.5 rounded bg-gray-700 text-gray-400">
+                  L{activity.scaffoldingLevel}
+                </span>
+              </div>
+              {showHint && (
+                <p className="mt-2 p-3 rounded-lg bg-gray-800/50 text-sm text-gray-300 italic">
+                  {activity.hint}
+                </p>
+              )}
+            </div>
+          )}
 
           {/* Socratic: redirect instead of in-session activity */}
           {isSocratic ? (

--- a/dashboard/src/app/study/session/page.tsx
+++ b/dashboard/src/app/study/session/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Suspense } from 'react';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useSearchParams } from 'next/navigation';
 
@@ -17,6 +18,9 @@ interface EnrichedActivity {
   prompt: string;
   referenceAnswer: string | null;
   cardType: string | null;
+  sourceNotePath: string | null;
+  generatedAt: string;
+  staleReason?: string;
 }
 
 interface EnrichedBlock {
@@ -29,6 +33,26 @@ interface SessionData {
   totalActivities: number;
   estimatedMinutes: number;
   domainsCovered: string[];
+}
+
+interface PrerequisiteWarning {
+  conceptId: string;
+  conceptTitle: string;
+  weakPrerequisites: Array<{
+    id: string;
+    title: string;
+    masteryOverall: number;
+  }>;
+}
+
+interface StalenessWarning {
+  activityId: string;
+  staleReason: 'source_deleted' | 'source_modified';
+}
+
+interface SessionWarnings {
+  prerequisites: PrerequisiteWarning[];
+  staleActivities: StalenessWarning[];
 }
 
 type Phase = 'loading' | 'pre_session' | 'in_progress' | 'post_session' | 'complete';
@@ -175,7 +199,7 @@ function isAiEvalEligible(bloomLevel: number, activityType: string): boolean {
 // Page component
 // ---------------------------------------------------------------------------
 
-export default function StudySessionPage() {
+function StudySessionInner() {
   const searchParams = useSearchParams();
   const planId = searchParams.get('planId');
 
@@ -183,6 +207,10 @@ export default function StudySessionPage() {
   const [sessionData, setSessionData] = useState<SessionData | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [planTitle, setPlanTitle] = useState<string | null>(null);
+
+  // Warnings
+  const [warnings, setWarnings] = useState<SessionWarnings>({ prerequisites: [], staleActivities: [] });
+  const [prereqWarningDismissed, setPrereqWarningDismissed] = useState(false);
 
   // PRE_SESSION
   const [preConfidence, setPreConfidence] = useState<Record<string, number>>({});
@@ -268,7 +296,7 @@ export default function StudySessionPage() {
     const url = planId ? `/api/study/session?planId=${planId}` : '/api/study/session';
     fetch(url)
       .then((r) => r.json())
-      .then((data: { session?: SessionData; error?: string }) => {
+      .then((data: { session?: SessionData; warnings?: SessionWarnings; error?: string }) => {
         if (data.error) {
           setLoadError(data.error);
           return;
@@ -278,7 +306,23 @@ export default function StudySessionPage() {
           // No activities — stay on loading phase but show empty state
           setSessionData({ blocks: [], totalActivities: 0, estimatedMinutes: 0, domainsCovered: [] });
         } else {
-          setSessionData(session);
+          // Apply staleReason to activities from warnings
+          const sessionWarnings = data.warnings ?? { prerequisites: [], staleActivities: [] };
+          const staleMap = new Map(
+            sessionWarnings.staleActivities.map((w) => [w.activityId, w.staleReason]),
+          );
+          const sessionWithStale: SessionData = {
+            ...session,
+            blocks: session.blocks.map((block) => ({
+              ...block,
+              activities: block.activities.map((a) => ({
+                ...a,
+                staleReason: staleMap.get(a.activityId),
+              })),
+            })),
+          };
+          setSessionData(sessionWithStale);
+          setWarnings(sessionWarnings);
           setPhase('pre_session');
         }
       })
@@ -618,6 +662,41 @@ export default function StudySessionPage() {
           </div>
         )}
 
+        {/* Prerequisite warning banner */}
+        {!prereqWarningDismissed && warnings.prerequisites.length > 0 && (
+          <div className="rounded-lg border border-amber-800/50 bg-amber-900/20 p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-1.5 flex-1">
+                <div className="flex items-center gap-2">
+                  <svg className="h-4 w-4 text-amber-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                  </svg>
+                  <span className="text-sm font-medium text-amber-300">Prerequisite gaps detected</span>
+                </div>
+                {warnings.prerequisites.map((w) =>
+                  w.weakPrerequisites.map((prereq) => (
+                    <p key={`${w.conceptId}-${prereq.id}`} className="text-sm text-amber-200/80 ml-6">
+                      <span className="font-medium">{w.conceptTitle}</span> depends on{' '}
+                      <span className="font-medium">{prereq.title}</span>{' '}
+                      <span className="text-amber-400">(mastery: {Math.round(prereq.masteryOverall * 100)}%)</span>
+                      {' '}— consider reviewing first
+                    </p>
+                  )),
+                )}
+              </div>
+              <button
+                onClick={() => setPrereqWarningDismissed(true)}
+                className="text-amber-500 hover:text-amber-300 transition-colors shrink-0 mt-0.5"
+                aria-label="Dismiss warning"
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        )}
+
         {/* Header */}
         <div>
           <h2 className="text-xl font-semibold text-gray-100 mb-1">Today&apos;s Session</h2>
@@ -703,6 +782,41 @@ export default function StudySessionPage() {
           </div>
         )}
 
+        {/* Prerequisite warning banner */}
+        {!prereqWarningDismissed && warnings.prerequisites.length > 0 && (
+          <div className="rounded-lg border border-amber-800/50 bg-amber-900/20 p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-1.5 flex-1">
+                <div className="flex items-center gap-2">
+                  <svg className="h-4 w-4 text-amber-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                  </svg>
+                  <span className="text-sm font-medium text-amber-300">Prerequisite gaps detected</span>
+                </div>
+                {warnings.prerequisites.map((w) =>
+                  w.weakPrerequisites.map((prereq) => (
+                    <p key={`${w.conceptId}-${prereq.id}`} className="text-sm text-amber-200/80 ml-6">
+                      <span className="font-medium">{w.conceptTitle}</span> depends on{' '}
+                      <span className="font-medium">{prereq.title}</span>{' '}
+                      <span className="text-amber-400">(mastery: {Math.round(prereq.masteryOverall * 100)}%)</span>
+                      {' '}— consider reviewing first
+                    </p>
+                  )),
+                )}
+              </div>
+              <button
+                onClick={() => setPrereqWarningDismissed(true)}
+                className="text-amber-500 hover:text-amber-300 transition-colors shrink-0 mt-0.5"
+                aria-label="Dismiss warning"
+              >
+                <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        )}
+
         {/* Progress bar */}
         <div>
           <div className="flex justify-between text-xs text-gray-500 mb-1">
@@ -746,6 +860,16 @@ export default function StudySessionPage() {
             <span className="text-xs px-2 py-0.5 rounded bg-gray-800 text-gray-400 border border-gray-700">
               {ACTIVITY_TYPE_LABELS[activity.activityType] ?? activity.activityType}
             </span>
+            {activity.staleReason === 'source_deleted' && (
+              <span className="text-xs px-2 py-0.5 rounded bg-amber-900/50 text-amber-400">
+                Source deleted
+              </span>
+            )}
+            {activity.staleReason === 'source_modified' && (
+              <span className="text-xs px-2 py-0.5 rounded bg-amber-900/50 text-amber-400">
+                Source updated
+              </span>
+            )}
           </div>
 
           {/* Prompt */}
@@ -1091,4 +1215,16 @@ export default function StudySessionPage() {
 
   // Fallback (shouldn't reach)
   return null;
+}
+
+export default function StudySessionPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-gray-500">Loading session...</p>
+      </div>
+    }>
+      <StudySessionInner />
+    </Suspense>
+  );
 }

--- a/dashboard/src/lib/__tests__/analytics.test.ts
+++ b/dashboard/src/lib/__tests__/analytics.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { pearsonCorrelation } from '../study-db';
+
+// ---------------------------------------------------------------------------
+// pearsonCorrelation
+// ---------------------------------------------------------------------------
+
+describe('pearsonCorrelation', () => {
+  it('returns 1 for perfectly positively correlated data', () => {
+    const pts = [
+      { confidence: 1, quality: 1 },
+      { confidence: 2, quality: 2 },
+      { confidence: 3, quality: 3 },
+      { confidence: 4, quality: 4 },
+      { confidence: 5, quality: 5 },
+    ];
+    expect(pearsonCorrelation(pts)).toBeCloseTo(1, 5);
+  });
+
+  it('returns -1 for perfectly negatively correlated data', () => {
+    const pts = [
+      { confidence: 1, quality: 5 },
+      { confidence: 2, quality: 4 },
+      { confidence: 3, quality: 3 },
+      { confidence: 4, quality: 2 },
+      { confidence: 5, quality: 1 },
+    ];
+    expect(pearsonCorrelation(pts)).toBeCloseTo(-1, 5);
+  });
+
+  it('returns 0 for constant X values (no variance)', () => {
+    const pts = [
+      { confidence: 3, quality: 1 },
+      { confidence: 3, quality: 2 },
+      { confidence: 3, quality: 3 },
+      { confidence: 3, quality: 4 },
+      { confidence: 3, quality: 5 },
+    ];
+    expect(pearsonCorrelation(pts)).toBe(0);
+  });
+
+  it('returns a value in [-1, 1] for real-world-style data', () => {
+    const pts = [
+      { confidence: 2, quality: 3 },
+      { confidence: 4, quality: 4 },
+      { confidence: 3, quality: 2 },
+      { confidence: 5, quality: 5 },
+      { confidence: 1, quality: 1 },
+      { confidence: 4, quality: 3 },
+    ];
+    const r = pearsonCorrelation(pts);
+    expect(r).toBeGreaterThanOrEqual(-1);
+    expect(r).toBeLessThanOrEqual(1);
+    // Positive correlation expected
+    expect(r).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gap-filling logic (time series)
+// ---------------------------------------------------------------------------
+// We test the gap-filling logic in isolation without hitting the database by
+// re-implementing the same deterministic algorithm used in getActivityTimeSeries.
+
+function fillGaps(
+  resultMap: Map<string, { count: number; avgQuality: number }>,
+  days: number,
+): Array<{ date: string; count: number; avgQuality: number }> {
+  const msPerDay = 86400000;
+  const today = new Date('2026-04-16T00:00:00.000Z');
+  const series: Array<{ date: string; count: number; avgQuality: number }> = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(today.getTime() - i * msPerDay);
+    const dateStr = d.toISOString().slice(0, 10);
+    const existing = resultMap.get(dateStr);
+    series.push({
+      date: dateStr,
+      count: existing?.count ?? 0,
+      avgQuality: existing?.avgQuality ?? 0,
+    });
+  }
+  return series;
+}
+
+describe('getActivityTimeSeries gap-filling', () => {
+  it('produces an entry for every day in the window', () => {
+    const map = new Map<string, { count: number; avgQuality: number }>();
+    map.set('2026-04-14', { count: 3, avgQuality: 4 });
+    const result = fillGaps(map, 3);
+    expect(result).toHaveLength(3);
+    expect(result.map((r) => r.date)).toEqual(['2026-04-14', '2026-04-15', '2026-04-16']);
+  });
+
+  it('fills days with no data as count=0, avgQuality=0', () => {
+    const map = new Map<string, { count: number; avgQuality: number }>();
+    map.set('2026-04-16', { count: 5, avgQuality: 3.5 });
+    const result = fillGaps(map, 3);
+    const emptyDays = result.filter((r) => r.count === 0);
+    expect(emptyDays).toHaveLength(2);
+    for (const d of emptyDays) {
+      expect(d.avgQuality).toBe(0);
+    }
+  });
+
+  it('preserves existing data for days that have activity', () => {
+    const map = new Map<string, { count: number; avgQuality: number }>();
+    map.set('2026-04-15', { count: 7, avgQuality: 3.8 });
+    const result = fillGaps(map, 3);
+    const active = result.find((r) => r.date === '2026-04-15');
+    expect(active?.count).toBe(7);
+    expect(active?.avgQuality).toBeCloseTo(3.8);
+  });
+
+  it('returns a single-day series for days=1', () => {
+    const map = new Map<string, { count: number; avgQuality: number }>();
+    const result = fillGaps(map, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0].date).toBe('2026-04-16');
+    expect(result[0].count).toBe(0);
+  });
+});

--- a/dashboard/src/lib/__tests__/scaffolding.test.ts
+++ b/dashboard/src/lib/__tests__/scaffolding.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { computeScaffoldingLevel, generateHint } from '../scaffolding';
+
+describe('computeScaffoldingLevel', () => {
+  it('returns currentLevel when fewer than 3 data points', () => {
+    expect(computeScaffoldingLevel([], 2)).toBe(2);
+    expect(computeScaffoldingLevel([5], 1)).toBe(1);
+    expect(computeScaffoldingLevel([3, 4], 3)).toBe(3);
+  });
+
+  it('decreases level when success rate > 85%', () => {
+    // 9/10 successes = 90% > 85% → level decreases
+    const qualities = [5, 5, 5, 5, 4, 5, 5, 5, 5, 5];
+    expect(computeScaffoldingLevel(qualities, 1)).toBe(0);
+    expect(computeScaffoldingLevel(qualities, 3)).toBe(2);
+  });
+
+  it('never decreases below 0', () => {
+    const qualities = [5, 5, 5, 5, 4, 5, 5, 5, 5, 5];
+    expect(computeScaffoldingLevel(qualities, 0)).toBe(0);
+  });
+
+  it('increases level when success rate < 70%', () => {
+    // 1/10 success (only quality=3) = 10% < 70% → level increases
+    const qualities = [1, 2, 1, 2, 3, 1, 2, 1, 2, 1];
+    expect(computeScaffoldingLevel(qualities, 1)).toBe(2);
+    expect(computeScaffoldingLevel(qualities, 0)).toBe(1);
+  });
+
+  it('never increases above 5', () => {
+    const qualities = [1, 2, 1, 2, 3, 1, 2, 1, 2, 1];
+    expect(computeScaffoldingLevel(qualities, 5)).toBe(5);
+  });
+
+  it('maintains level when success rate is between 70% and 85%', () => {
+    // 7/10 successes = 70% — on boundary, maintained
+    const qualities = [3, 4, 5, 2, 3, 4, 1, 3, 4, 3];
+    // 7 out of 10 are >= 3: 3,4,5,3,4,3,4,3 — let's count: 3✓,4✓,5✓,2✗,3✓,4✓,1✗,3✓,4✓,3✓ = 8/10 = 80%
+    // That's within 70-85% range, so level stays
+    expect(computeScaffoldingLevel(qualities, 2)).toBe(2);
+    expect(computeScaffoldingLevel(qualities, 0)).toBe(0);
+  });
+
+  it('handles exactly 3 data points', () => {
+    // 3/3 successes = 100% > 85%
+    expect(computeScaffoldingLevel([3, 4, 5], 2)).toBe(1);
+    // 0/3 successes = 0% < 70%
+    expect(computeScaffoldingLevel([0, 1, 2], 1)).toBe(2);
+  });
+});
+
+describe('generateHint', () => {
+  it('returns null for level 0', () => {
+    expect(generateHint('Some answer text.', 0)).toBeNull();
+  });
+
+  it('returns null when referenceAnswer is null', () => {
+    expect(generateHint(null, 3)).toBeNull();
+  });
+
+  it('returns null when referenceAnswer is empty string', () => {
+    expect(generateHint('', 1)).toBeNull();
+  });
+
+  it('level 1: returns first sentence as contextual hint', () => {
+    const hint = generateHint('First sentence. Second sentence.', 1);
+    expect(hint).toBe('Hint: Think about "First sentence..."');
+  });
+
+  it('level 2: returns structural summary', () => {
+    const hint = generateHint('Point one. Point two. Point three.', 2);
+    expect(hint).toBe('Hint: The answer covers 3 key points.');
+  });
+
+  it('level 2: uses singular "point" for single sentence', () => {
+    const hint = generateHint('Just one point here', 2);
+    expect(hint).toBe('Hint: The answer covers 1 key point.');
+  });
+
+  it('level 3: returns ~30% of answer', () => {
+    const answer = 'A'.repeat(100);
+    const hint = generateHint(answer, 3);
+    expect(hint).toBe('A'.repeat(30) + '...');
+  });
+
+  it('level 4: returns ~60% of answer', () => {
+    const answer = 'A'.repeat(100);
+    const hint = generateHint(answer, 4);
+    expect(hint).toBe('A'.repeat(60) + '...');
+  });
+
+  it('level 5: returns full answer', () => {
+    const answer = 'The complete and full reference answer.';
+    expect(generateHint(answer, 5)).toBe(answer);
+  });
+
+  it('level 3 uses minimum cutoff of 20 for very short answers', () => {
+    const shortAnswer = 'Short answer text.'; // 18 chars
+    const hint = generateHint(shortAnswer, 3);
+    // cutoff = max(20, floor(18 * 0.3)) = max(20, 5) = 20
+    // but answer is only 18 chars, so slice(0,20) = full answer
+    expect(hint).toBe(shortAnswer + '...');
+  });
+});

--- a/dashboard/src/lib/db/schema.ts
+++ b/dashboard/src/lib/db/schema.ts
@@ -1,4 +1,4 @@
-import { integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { integer, primaryKey, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { sql } from 'drizzle-orm';
 
 export const ingestion_jobs = sqliteTable('ingestion_jobs', {
@@ -129,3 +129,18 @@ export const study_plan_concepts = sqliteTable('study_plan_concepts', {
   target_bloom: integer('target_bloom').default(6),
   sort_order: integer('sort_order').default(0),
 });
+
+export const concept_prerequisites = sqliteTable('concept_prerequisites', {
+  concept_id: text('concept_id').notNull(),
+  prerequisite_id: text('prerequisite_id').notNull(),
+}, (table) => [
+  primaryKey({ columns: [table.concept_id, table.prerequisite_id] }),
+]);
+
+export const activity_concepts = sqliteTable('activity_concepts', {
+  activity_id: text('activity_id').notNull(),
+  concept_id: text('concept_id').notNull(),
+  role: text('role').default('related'),
+}, (table) => [
+  primaryKey({ columns: [table.activity_id, table.concept_id] }),
+]);

--- a/dashboard/src/lib/scaffolding.ts
+++ b/dashboard/src/lib/scaffolding.ts
@@ -1,0 +1,59 @@
+/**
+ * Compute recommended scaffolding level for a concept based on
+ * rolling success rate (last 10 attempts).
+ *
+ * Scaffolding levels:
+ *   0: No hints (prompt only)
+ *   1: Contextual hint ("Think about concept X")
+ *   2: Structural hint ("The answer involves three components...")
+ *   3: Partial solution ("The first step is...")
+ *   4: Worked example with similar problem
+ *   5: Full explanation + answer (last resort)
+ *
+ * Target: 70-85% success rate
+ *   > 85% success → decrease level (min 0)
+ *   < 70% success → increase level (max 5)
+ *   70-85% → maintain current level
+ */
+export function computeScaffoldingLevel(
+  recentQualities: number[],
+  currentLevel: number,
+): number {
+  if (recentQualities.length < 3) return currentLevel;
+  const successRate = recentQualities.filter(q => q >= 3).length / recentQualities.length;
+  if (successRate > 0.85) return Math.max(0, currentLevel - 1);
+  if (successRate < 0.70) return Math.min(5, currentLevel + 1);
+  return currentLevel;
+}
+
+/**
+ * Generate a hint based on the scaffolding level and reference answer.
+ * Levels 1-2: derived from reference answer
+ * Levels 3-5: progressive reveal of reference answer
+ */
+export function generateHint(referenceAnswer: string | null, level: number): string | null {
+  if (!referenceAnswer || level <= 0) return null;
+
+  if (level === 1) {
+    // First sentence only
+    const firstSentence = referenceAnswer.split(/[.!?]/)[0];
+    return firstSentence ? `Hint: Think about "${firstSentence.trim()}..."` : null;
+  }
+  if (level === 2) {
+    // Structural summary
+    const sentences = referenceAnswer.split(/[.!?]/).filter(s => s.trim());
+    return `Hint: The answer covers ${sentences.length} key point${sentences.length !== 1 ? 's' : ''}.`;
+  }
+  if (level === 3) {
+    // 30% reveal
+    const cutoff = Math.max(20, Math.floor(referenceAnswer.length * 0.3));
+    return referenceAnswer.slice(0, cutoff) + '...';
+  }
+  if (level === 4) {
+    // 60% reveal
+    const cutoff = Math.max(20, Math.floor(referenceAnswer.length * 0.6));
+    return referenceAnswer.slice(0, cutoff) + '...';
+  }
+  // Level 5: full answer
+  return referenceAnswer;
+}

--- a/dashboard/src/lib/session-warnings.ts
+++ b/dashboard/src/lib/session-warnings.ts
@@ -101,6 +101,8 @@ export function getStalenessWarnings(
     if (!activity.sourceNotePath) continue;
 
     const absolutePath = path.resolve(vaultDir, activity.sourceNotePath);
+    const resolvedVaultDir = path.resolve(vaultDir);
+    if (!absolutePath.startsWith(resolvedVaultDir + path.sep) && absolutePath !== resolvedVaultDir) continue;
 
     try {
       const stat = fs.statSync(absolutePath);

--- a/dashboard/src/lib/session-warnings.ts
+++ b/dashboard/src/lib/session-warnings.ts
@@ -1,0 +1,126 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { inArray } from 'drizzle-orm';
+import { getDb } from './db/index';
+import { concepts, concept_prerequisites } from './db/schema';
+
+const WEAK_PREREQUISITE_THRESHOLD = 0.3;
+
+export interface PrerequisiteWarning {
+  conceptId: string;
+  conceptTitle: string;
+  weakPrerequisites: Array<{
+    id: string;
+    title: string;
+    masteryOverall: number;
+  }>;
+}
+
+export interface StalenessWarning {
+  activityId: string;
+  staleReason: 'source_deleted' | 'source_modified';
+}
+
+export function getPrerequisiteWarnings(conceptIds: string[]): PrerequisiteWarning[] {
+  if (conceptIds.length === 0) return [];
+
+  const db = getDb();
+
+  // Fetch all prerequisite relationships for the given concept IDs
+  const prereqRows = db
+    .select()
+    .from(concept_prerequisites)
+    .where(inArray(concept_prerequisites.concept_id, conceptIds))
+    .all();
+
+  if (prereqRows.length === 0) return [];
+
+  // Collect all unique prerequisite IDs to look up mastery
+  const prereqIds = [...new Set(prereqRows.map((r) => r.prerequisite_id))];
+
+  // Fetch concept details for both the session concepts and their prerequisites
+  const allRelevantIds = [...new Set([...conceptIds, ...prereqIds])];
+  const conceptRows = db
+    .select({
+      id: concepts.id,
+      title: concepts.title,
+      mastery_overall: concepts.mastery_overall,
+    })
+    .from(concepts)
+    .where(inArray(concepts.id, allRelevantIds))
+    .all();
+
+  const conceptMap = new Map(conceptRows.map((c) => [c.id, c]));
+
+  const warnings: PrerequisiteWarning[] = [];
+
+  for (const conceptId of conceptIds) {
+    const concept = conceptMap.get(conceptId);
+    if (!concept) continue;
+
+    const prereqIdsForConcept = prereqRows
+      .filter((r) => r.concept_id === conceptId)
+      .map((r) => r.prerequisite_id);
+
+    const weakPrerequisites = prereqIdsForConcept
+      .map((prereqId) => conceptMap.get(prereqId))
+      .filter(
+        (prereq): prereq is NonNullable<typeof prereq> =>
+          prereq !== undefined &&
+          (prereq.mastery_overall ?? 0) < WEAK_PREREQUISITE_THRESHOLD,
+      )
+      .map((prereq) => ({
+        id: prereq.id,
+        title: prereq.title,
+        masteryOverall: prereq.mastery_overall ?? 0,
+      }));
+
+    if (weakPrerequisites.length > 0) {
+      warnings.push({
+        conceptId: concept.id,
+        conceptTitle: concept.title,
+        weakPrerequisites,
+      });
+    }
+  }
+
+  return warnings;
+}
+
+export function getStalenessWarnings(
+  activities: Array<{
+    activityId: string;
+    sourceNotePath: string | null;
+    generatedAt: string;
+  }>,
+): StalenessWarning[] {
+  const vaultDir = process.env.VAULT_DIR || './vault';
+  const warnings: StalenessWarning[] = [];
+
+  for (const activity of activities) {
+    if (!activity.sourceNotePath) continue;
+
+    const absolutePath = path.resolve(vaultDir, activity.sourceNotePath);
+
+    try {
+      const stat = fs.statSync(absolutePath);
+      const generatedAt = new Date(activity.generatedAt);
+      if (stat.mtime > generatedAt) {
+        warnings.push({
+          activityId: activity.activityId,
+          staleReason: 'source_modified',
+        });
+      }
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+        warnings.push({
+          activityId: activity.activityId,
+          staleReason: 'source_deleted',
+        });
+      }
+      // Other errors: skip (treat as fresh)
+    }
+  }
+
+  return warnings;
+}

--- a/dashboard/src/lib/study-db.ts
+++ b/dashboard/src/lib/study-db.ts
@@ -9,7 +9,7 @@
 
 import { eq, and, lte, asc, desc, count, sql, inArray, isNull, gte } from 'drizzle-orm';
 import { getDb } from './db/index';
-import { concepts, learning_activities, study_sessions, activity_log, study_plans, study_plan_concepts } from './db/schema';
+import { concepts, learning_activities, study_sessions, activity_log, study_plans, study_plan_concepts, concept_prerequisites, activity_concepts } from './db/schema';
 import {
   sm2,
   computeDueDate,
@@ -1234,4 +1234,233 @@ export function pearsonCorrelation(
   const den = Math.sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY));
   if (den === 0) return 0;
   return num / den;
+}
+
+// ---------------------------------------------------------------------------
+// Concept detail
+// ---------------------------------------------------------------------------
+
+export interface ConceptDetail {
+  id: string;
+  title: string;
+  domain: string | null;
+  subdomain: string | null;
+  course: string | null;
+  vaultNotePath: string | null;
+  status: string;
+  bloomCeiling: number;
+  masteryOverall: number;
+  masteryL1: number;
+  masteryL2: number;
+  masteryL3: number;
+  masteryL4: number;
+  masteryL5: number;
+  masteryL6: number;
+  createdAt: string;
+  lastActivityAt: string | null;
+  dueCount: number;
+  totalActivities: number;
+  activities: Array<{
+    id: string;
+    activityType: string;
+    bloomLevel: number;
+    dueAt: string;
+    masteryState: string;
+    author: string;
+  }>;
+  recentLogs: Array<{
+    id: string;
+    activityType: string;
+    bloomLevel: number;
+    quality: number;
+    evaluationMethod: string;
+    reviewedAt: string;
+  }>;
+  methodEffectiveness: Array<{
+    activityType: string;
+    avgQuality: number;
+    count: number;
+  }>;
+  relatedConcepts: Array<{
+    id: string;
+    title: string;
+    role: string;
+  }>;
+  prerequisites: Array<{
+    id: string;
+    title: string;
+    bloomCeiling: number;
+    masteryOverall: number;
+  }>;
+}
+
+/**
+ * Full concept detail including mastery breakdown, activity history, method
+ * effectiveness, related concepts, and prerequisites. Returns null if not found.
+ */
+export function getConceptDetail(id: string): ConceptDetail | null {
+  const db = getDb();
+
+  // 1. Concept row
+  const concept = db
+    .select()
+    .from(concepts)
+    .where(eq(concepts.id, id))
+    .get();
+  if (!concept) return null;
+
+  // 2. All activities for this concept
+  const activityRows = db
+    .select()
+    .from(learning_activities)
+    .where(eq(learning_activities.concept_id, id))
+    .orderBy(asc(learning_activities.bloom_level))
+    .all();
+
+  // 3. Due count
+  const today = new Date().toISOString();
+  const dueRow = db
+    .select({ cnt: count(learning_activities.id) })
+    .from(learning_activities)
+    .where(
+      and(
+        eq(learning_activities.concept_id, id),
+        lte(learning_activities.due_at, today),
+      ),
+    )
+    .get();
+  const dueCount = dueRow?.cnt ?? 0;
+
+  // 4. Recent logs (last 20)
+  const logRows = db
+    .select()
+    .from(activity_log)
+    .where(eq(activity_log.concept_id, id))
+    .orderBy(desc(activity_log.reviewed_at))
+    .limit(20)
+    .all();
+
+  // 5. Method effectiveness: group activity_log by activity_type
+  const methodRows = db
+    .select({
+      activityType: activity_log.activity_type,
+      avgQuality: sql<number>`avg(${activity_log.quality})`,
+      cnt: count(),
+    })
+    .from(activity_log)
+    .where(eq(activity_log.concept_id, id))
+    .groupBy(activity_log.activity_type)
+    .orderBy(desc(sql<number>`avg(${activity_log.quality})`))
+    .all();
+
+  // 6. Related concepts: activity_ids for this concept → activity_concepts → concepts
+  const activityIds = activityRows.map((a) => a.id);
+  let relatedConcepts: ConceptDetail['relatedConcepts'] = [];
+  if (activityIds.length > 0) {
+    const acRows = db
+      .select({
+        concept_id: activity_concepts.concept_id,
+        role: activity_concepts.role,
+      })
+      .from(activity_concepts)
+      .where(inArray(activity_concepts.activity_id, activityIds))
+      .all();
+
+    const relatedIds = acRows
+      .map((r) => r.concept_id)
+      .filter((cid) => cid !== id);
+
+    if (relatedIds.length > 0) {
+      const roleMap = new Map<string, string>();
+      for (const r of acRows) {
+        if (r.concept_id !== id) roleMap.set(r.concept_id, r.role ?? 'related');
+      }
+
+      const relatedRows = db
+        .select({ id: concepts.id, title: concepts.title })
+        .from(concepts)
+        .where(inArray(concepts.id, relatedIds))
+        .all();
+
+      relatedConcepts = relatedRows.map((r) => ({
+        id: r.id,
+        title: r.title,
+        role: roleMap.get(r.id) ?? 'related',
+      }));
+    }
+  }
+
+  // 7. Prerequisites: concept_prerequisites → concepts
+  const prereqLinks = db
+    .select({ prerequisite_id: concept_prerequisites.prerequisite_id })
+    .from(concept_prerequisites)
+    .where(eq(concept_prerequisites.concept_id, id))
+    .all();
+
+  let prerequisites: ConceptDetail['prerequisites'] = [];
+  if (prereqLinks.length > 0) {
+    const prereqIds = prereqLinks.map((r) => r.prerequisite_id);
+    const prereqRows = db
+      .select({
+        id: concepts.id,
+        title: concepts.title,
+        bloom_ceiling: concepts.bloom_ceiling,
+        mastery_overall: concepts.mastery_overall,
+      })
+      .from(concepts)
+      .where(inArray(concepts.id, prereqIds))
+      .all();
+
+    prerequisites = prereqRows.map((r) => ({
+      id: r.id,
+      title: r.title,
+      bloomCeiling: r.bloom_ceiling ?? 0,
+      masteryOverall: r.mastery_overall ?? 0,
+    }));
+  }
+
+  return {
+    id: concept.id,
+    title: concept.title,
+    domain: concept.domain ?? null,
+    subdomain: concept.subdomain ?? null,
+    course: concept.course ?? null,
+    vaultNotePath: concept.vault_note_path ?? null,
+    status: concept.status ?? 'active',
+    bloomCeiling: concept.bloom_ceiling ?? 0,
+    masteryOverall: concept.mastery_overall ?? 0,
+    masteryL1: concept.mastery_L1 ?? 0,
+    masteryL2: concept.mastery_L2 ?? 0,
+    masteryL3: concept.mastery_L3 ?? 0,
+    masteryL4: concept.mastery_L4 ?? 0,
+    masteryL5: concept.mastery_L5 ?? 0,
+    masteryL6: concept.mastery_L6 ?? 0,
+    createdAt: concept.created_at,
+    lastActivityAt: concept.last_activity_at ?? null,
+    dueCount,
+    totalActivities: activityRows.length,
+    activities: activityRows.map((a) => ({
+      id: a.id,
+      activityType: a.activity_type,
+      bloomLevel: a.bloom_level,
+      dueAt: a.due_at,
+      masteryState: a.mastery_state ?? 'new',
+      author: a.author ?? 'system',
+    })),
+    recentLogs: logRows.map((l) => ({
+      id: l.id,
+      activityType: l.activity_type,
+      bloomLevel: l.bloom_level,
+      quality: l.quality,
+      evaluationMethod: l.evaluation_method ?? 'self_rated',
+      reviewedAt: l.reviewed_at,
+    })),
+    methodEffectiveness: methodRows.map((m) => ({
+      activityType: m.activityType,
+      avgQuality: m.avgQuality,
+      count: m.cnt,
+    })),
+    relatedConcepts,
+    prerequisites,
+  };
 }

--- a/dashboard/src/lib/study-db.ts
+++ b/dashboard/src/lib/study-db.ts
@@ -1023,3 +1023,215 @@ export function removeConceptFromPlan(planId: string, conceptId: string): void {
     )
     .run();
 }
+
+// ---------------------------------------------------------------------------
+// Analytics queries
+// ---------------------------------------------------------------------------
+
+export interface RetentionRate {
+  retentionRate: number;
+  totalReviews: number;
+  correctReviews: number;
+}
+
+/**
+ * Fraction of activity_log entries in the last `days` days with quality >= 3.
+ */
+export function getRetentionRate(days: number): RetentionRate {
+  const db = getDb();
+  const cutoff = new Date(Date.now() - days * 86400000).toISOString();
+
+  const rows = db
+    .select({
+      quality: activity_log.quality,
+    })
+    .from(activity_log)
+    .where(gte(activity_log.reviewed_at, cutoff))
+    .all();
+
+  const totalReviews = rows.length;
+  const correctReviews = rows.filter((r) => r.quality >= 3).length;
+  const retentionRate = totalReviews === 0 ? 0 : correctReviews / totalReviews;
+
+  return { retentionRate, totalReviews, correctReviews };
+}
+
+export interface BloomDistributionItem {
+  bloomLevel: number;
+  count: number;
+  percentage: number;
+}
+
+/**
+ * Count of activity_log entries grouped by bloom_level for the last `days` days.
+ */
+export function getBloomDistribution(days: number): BloomDistributionItem[] {
+  const db = getDb();
+  const cutoff = new Date(Date.now() - days * 86400000).toISOString();
+
+  const rows = db
+    .select({
+      bloomLevel: activity_log.bloom_level,
+      cnt: count(),
+    })
+    .from(activity_log)
+    .where(gte(activity_log.reviewed_at, cutoff))
+    .groupBy(activity_log.bloom_level)
+    .orderBy(asc(activity_log.bloom_level))
+    .all();
+
+  const total = rows.reduce((sum, r) => sum + r.cnt, 0);
+
+  return rows.map((r) => ({
+    bloomLevel: r.bloomLevel,
+    count: r.cnt,
+    percentage: total === 0 ? 0 : r.cnt / total,
+  }));
+}
+
+export interface MethodEffectivenessItem {
+  activityType: string;
+  avgQuality: number;
+  count: number;
+}
+
+/**
+ * Average quality and count of reviews grouped by activity_type, ordered by
+ * average quality descending.
+ */
+export function getMethodEffectiveness(): MethodEffectivenessItem[] {
+  const db = getDb();
+
+  const rows = db
+    .select({
+      activityType: activity_log.activity_type,
+      avgQuality: sql<number>`avg(${activity_log.quality})`,
+      cnt: count(),
+    })
+    .from(activity_log)
+    .groupBy(activity_log.activity_type)
+    .orderBy(desc(sql<number>`avg(${activity_log.quality})`))
+    .all();
+
+  return rows.map((r) => ({
+    activityType: r.activityType,
+    avgQuality: r.avgQuality,
+    count: r.cnt,
+  }));
+}
+
+export interface TimeSeriesItem {
+  date: string;
+  count: number;
+  avgQuality: number;
+}
+
+/**
+ * Daily activity counts and average quality for the last `days` days.
+ * Days with no activity are filled with zero-count entries.
+ */
+export function getActivityTimeSeries(days: number): TimeSeriesItem[] {
+  const db = getDb();
+  const cutoff = new Date(Date.now() - days * 86400000).toISOString();
+
+  const rows = db
+    .select({
+      date: sql<string>`date(${activity_log.reviewed_at})`,
+      cnt: count(),
+      avgQuality: sql<number>`avg(${activity_log.quality})`,
+    })
+    .from(activity_log)
+    .where(gte(activity_log.reviewed_at, cutoff))
+    .groupBy(sql`date(${activity_log.reviewed_at})`)
+    .orderBy(asc(sql`date(${activity_log.reviewed_at})`))
+    .all();
+
+  // Build a map of existing results
+  const resultMap = new Map<string, { count: number; avgQuality: number }>();
+  for (const r of rows) {
+    resultMap.set(r.date, { count: r.cnt, avgQuality: r.avgQuality });
+  }
+
+  // Fill gaps: produce one entry per day from cutoff to today
+  const msPerDay = 86400000;
+  const today = new Date();
+  const series: TimeSeriesItem[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(today.getTime() - i * msPerDay);
+    const dateStr = d.toISOString().slice(0, 10);
+    const existing = resultMap.get(dateStr);
+    series.push({
+      date: dateStr,
+      count: existing?.count ?? 0,
+      avgQuality: existing?.avgQuality ?? 0,
+    });
+  }
+
+  return series;
+}
+
+export interface CalibrationData {
+  calibrationScore: number | null;
+  dataPoints: number;
+}
+
+/**
+ * Pearson correlation between confidence_rating and quality for the last
+ * `days` days. Returns null calibrationScore when fewer than 5 data points.
+ */
+export function getCalibrationData(days: number): CalibrationData {
+  const db = getDb();
+  const cutoff = new Date(Date.now() - days * 86400000).toISOString();
+
+  const rows = db
+    .select({
+      confidence: activity_log.confidence_rating,
+      quality: activity_log.quality,
+    })
+    .from(activity_log)
+    .where(
+      and(
+        gte(activity_log.reviewed_at, cutoff),
+        sql`${activity_log.confidence_rating} IS NOT NULL`,
+      ),
+    )
+    .all();
+
+  // Filter out any null confidence_rating values that may have slipped through
+  const pts = rows.filter((r) => r.confidence !== null) as {
+    confidence: number;
+    quality: number;
+  }[];
+
+  if (pts.length < 5) {
+    return { calibrationScore: null, dataPoints: pts.length };
+  }
+
+  return { calibrationScore: pearsonCorrelation(pts), dataPoints: pts.length };
+}
+
+/**
+ * Compute Pearson r between confidence and quality for the given data points.
+ * Exported for unit testing.
+ */
+export function pearsonCorrelation(
+  pts: { confidence: number; quality: number }[],
+): number {
+  const n = pts.length;
+  let sumX = 0,
+    sumY = 0,
+    sumXY = 0,
+    sumX2 = 0,
+    sumY2 = 0;
+  for (const { confidence: x, quality: y } of pts) {
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumX2 += x * x;
+    sumY2 += y * y;
+  }
+  const num = n * sumXY - sumX * sumY;
+  const den = Math.sqrt((n * sumX2 - sumX * sumX) * (n * sumY2 - sumY * sumY));
+  if (den === 0) return 0;
+  return num / den;
+}

--- a/dashboard/src/lib/study-db.ts
+++ b/dashboard/src/lib/study-db.ts
@@ -262,6 +262,7 @@ export interface CompleteActivityInput {
   responseText?: string;
   responseTimeMs?: number;
   confidenceRating?: number;
+  scaffoldingLevel?: number;
   surface?: string;
 }
 
@@ -354,6 +355,7 @@ export function completeActivity(input: CompleteActivityInput): CompleteActivity
         response_text: input.responseText ?? null,
         response_time_ms: input.responseTimeMs ?? null,
         confidence_rating: input.confidenceRating ?? null,
+        scaffolding_level: input.scaffoldingLevel ?? 0,
         evaluation_method: 'self_rated',
         ai_quality: null,
         ai_feedback: null,

--- a/dashboard/src/lib/study-db.ts
+++ b/dashboard/src/lib/study-db.ts
@@ -1087,7 +1087,7 @@ export function getBloomDistribution(days: number): BloomDistributionItem[] {
   return rows.map((r) => ({
     bloomLevel: r.bloomLevel,
     count: r.cnt,
-    percentage: total === 0 ? 0 : r.cnt / total,
+    percentage: total === 0 ? 0 : (r.cnt / total) * 100,
   }));
 }
 
@@ -1099,10 +1099,11 @@ export interface MethodEffectivenessItem {
 
 /**
  * Average quality and count of reviews grouped by activity_type, ordered by
- * average quality descending.
+ * average quality descending. Filtered to the last `days` days.
  */
-export function getMethodEffectiveness(): MethodEffectivenessItem[] {
+export function getMethodEffectiveness(days: number): MethodEffectivenessItem[] {
   const db = getDb();
+  const cutoff = new Date(Date.now() - days * 86400000).toISOString();
 
   const rows = db
     .select({
@@ -1111,6 +1112,7 @@ export function getMethodEffectiveness(): MethodEffectivenessItem[] {
       cnt: count(),
     })
     .from(activity_log)
+    .where(gte(activity_log.reviewed_at, cutoff))
     .groupBy(activity_log.activity_type)
     .orderBy(desc(sql<number>`avg(${activity_log.quality})`))
     .all();

--- a/docs/superpowers/plans/2026-04-16-s8a-analytics-polish.md
+++ b/docs/superpowers/plans/2026-04-16-s8a-analytics-polish.md
@@ -1,0 +1,512 @@
+# S8a: Analytics + Concept Detail + Polish — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Your role:** You are the engineer implementing this. The plan tells you *what* to build and *why*. You decide *how* within the stated constraints. If you disagree with an approach or see a better alternative, flag it before implementing — don't silently deviate and don't silently comply with something you think is wrong.
+
+**Goal:** Add learning analytics (API + dashboard visualization), a concept detail page, prerequisite awareness warnings, and staleness detection — surfacing the data the study system already collects into actionable insights and quality signals.
+
+**Architecture:** S8a is entirely about data presentation and awareness. No new LLM integration, no new IPC handlers, no container changes. Analytics queries run against the existing `activity_log` and `concepts` tables in dashboard-side Drizzle. The concept detail page is a new dashboard route reading existing data. Prerequisite and staleness warnings enrich the session API response and session UI. All work is dashboard queries + API routes + UI.
+
+**Tech Stack:** TypeScript/Node.js (backend queries), Next.js + React (dashboard), Drizzle ORM + SQLite (storage), Vitest (tests), CSS-based visualizations (no charting library — follow existing mastery bar pattern on `/study` page)
+
+**Branch:** Create `feat/s8a-analytics-polish` off `main`.
+
+**Spec:** `docs/superpowers/specs/2026-04-12-multi-method-study-system-design.md` (Sections 7.5, 10)
+
+**Master plan:** `docs/superpowers/plans/2026-04-13-study-system-master-plan.md` (S8.1, S8.2, S8.7, S8.8)
+
+---
+
+## Codebase Conventions (Hard Constraints)
+
+These apply to **every task**. Subagents must follow these — they're not obvious from context alone.
+
+1. **`.js` extensions on all relative imports in `src/`.** The backend uses Node ESM resolution. Write `import { foo } from './bar.js'`, not `'./bar'`. **Exception:** Dashboard (`dashboard/src/`) does NOT use `.js` extensions — Next.js handles resolution.
+2. **Dashboard schema uses snake_case.** `dashboard/src/lib/db/schema.ts` defines tables with snake_case column names (e.g., `activity_log.bloom_level`, `concepts.mastery_L1`). This differs from the backend schema which uses camelCase Drizzle properties.
+3. **Dashboard API routes must map snake_case DB → camelCase JSON responses.** All `study-db.ts` query functions return snake_case from Drizzle, and the API routes (or the query functions themselves) transform to camelCase for the frontend. Follow the existing `rowToSummary()` pattern in `study-db.ts`.
+4. **Drizzle query builder operators** (`eq`, `and`, `lte`, `desc`, `asc`, `count`, `sql`, `inArray`, `gte`) — not raw SQL strings. Exception: `sql` template tag for computed expressions Drizzle can't express natively.
+5. **Commit messages** use conventional commits: `feat(study):`, `feat(dashboard):`.
+6. **Test file locations:** Backend tests are colocated: `src/study/foo.test.ts`. Dashboard tests go in `dashboard/src/**/*.test.ts` (or `__tests__/`). Use `_initTestDatabase()` from `../db/index.js` for backend test DBs.
+7. **Study query functions** for the dashboard live in `dashboard/src/lib/study-db.ts`. Backend study queries live in `src/study/queries.ts`.
+8. **Dashboard UI style:** Dark theme, Tailwind CSS. Gray-900/950 backgrounds, gray-800 borders, blue-700 buttons, green-500 for progress bars. Follow existing component patterns in `dashboard/src/app/study/page.tsx`.
+9. **No charting library.** Use CSS-based bars/visualizations. The existing mastery bars use `div` elements with percentage `width` styling. Follow this pattern for analytics visualizations.
+
+---
+
+## Spec Deviations
+
+- **Deferred: time-to-level and decay rate metrics.** The spec (Section 10.1) lists "time to level" and "decay rate" as analytics metrics. These require historical bloom_ceiling tracking that doesn't currently exist (bloom_ceiling is overwritten, not logged historically). **Deferred to post-S8** when activity_log provides enough longitudinal data to derive these retroactively. S8a implements the 5 metrics that are computable from current schema.
+- **Deferred: scaffolding dependency metric.** The spec lists "scaffolding dependency" as a metric. Scaffolding isn't implemented until S8b (S8.6). The `scaffolding_level` column exists but is always 0. Metric deferred until S8b ships.
+- **Staleness uses file mtime, not chunk hash comparison.** The spec envisions comparing `source_chunk_hash` against current vault content. However, the hash is of an arbitrary chunk selected by the generator agent — there's no reliable way to re-derive the same chunk boundary at detection time. S8a uses file modification time (`mtime > generated_at`) as the staleness signal instead. This catches all meaningful staleness (source content changed after generation) without the chunk-matching complexity. The `source_chunk_hash` column remains available for future precision improvements.
+- **Prerequisite data is read-only in S8a.** The `concept_prerequisites` table exists but has no population mechanism yet (no UI to add prerequisites, no auto-detection). S8a adds the query + display infrastructure. Prerequisites can be populated manually via SQL or added through a future UI. The display works correctly with zero prerequisites (shows nothing).
+
+---
+
+## Key Decisions
+
+### D1: Analytics queries live in dashboard study-db.ts, not backend queries.ts
+Analytics are only consumed by dashboard API routes. Adding them to the backend `src/study/queries.ts` would add unused code to the main process. Dashboard queries go in `dashboard/src/lib/study-db.ts` following the established pattern.
+
+**Why not a separate analytics-db.ts?** The established pattern puts all study queries in `study-db.ts`. The file is currently ~1025 lines and will grow to ~1200 with analytics + concept detail additions. This is large but acceptable — all functions share the same DB connection and schema imports. Splitting by feature (analytics vs. CRUD) would duplicate imports and break the single-file convention. If it becomes unwieldy later, extraction is straightforward.
+
+### D2: Analytics are computed on-read, not cached
+Each `/api/study/stats` request runs the analytics queries fresh. With a single-user SQLite database under 10K rows, these queries complete in <10ms. No caching layer needed.
+
+**Tradeoff:** If the dataset grows to 100K+ activity_log entries, some queries (especially the time-series aggregation) may need caching. Acceptable for now — the student would need years of daily study to reach that scale.
+
+### D3: Concept detail page uses dynamic route, not a modal
+The concept detail is a separate page at `/study/concepts/[id]`, not an expand-in-place component on the overview page. This matches the master plan's file map and provides a stable URL for linking from session UI, chat, and Telegram.
+
+### D4: Staleness detection runs at session build time
+When the session API (`GET /api/study/session`) builds the session composition, it checks each activity's `source_note_path` against the filesystem. Stale activities get a `stale: true` flag in the response. The session UI displays a warning badge.
+
+**Why not a background job?** The single-user system has <100 activities per session. File stat operations are ~0.1ms each. Running at request time is simpler and guarantees fresh results.
+
+### D5: Prerequisite warnings use a configurable weakness threshold
+A prerequisite is "weak" when its concept's `mastery_overall` is below 0.3 (30% of maximum). This threshold is a constant in `study-db.ts` — easy to tune after observing real data. The warning is advisory, not blocking.
+
+---
+
+## Essential Reading
+
+> **For coordinators:** Extract relevant patterns from these files and inline them into subagent prompts. Subagents won't read the files themselves.
+
+| File | Why |
+|------|-----|
+| `dashboard/src/lib/study-db.ts` | All existing dashboard study queries. S8a adds analytics + concept detail + prereq functions here. Follow `getActiveConcepts()` and `rowToSummary()` patterns. |
+| `dashboard/src/lib/db/schema.ts` | Dashboard Drizzle schema — **snake_case** column names. Key tables: `concepts`, `learning_activities`, `activity_log`, `study_sessions`, `study_plans`. |
+| `dashboard/src/app/study/page.tsx` | Current overview page. S8a.4 adds analytics section here. Follow UI patterns (dark theme, section headers, CSS bars). |
+| `dashboard/src/app/study/session/page.tsx` | Session UI. S8a.3 adds prerequisite + staleness warnings here. |
+| `dashboard/src/app/api/study/session/route.ts` | Session API. S8a.3 enriches the GET response with warnings. |
+| `dashboard/src/app/api/study/concepts/route.ts` | Existing concepts list API. S8a.2 creates a sibling `[id]/route.ts`. |
+| `dashboard/src/lib/session-builder.ts` | Session composition builder. S8a.3 may need to pass through extra fields. |
+| `src/study/queries.ts` | Backend query functions. Reference only — S8a does not modify this file. |
+| `src/db/schema/study.ts` | Backend Drizzle schema — **camelCase** properties. Reference for column names. Has `conceptPrerequisites` and `activityConcepts` tables that need dashboard-side equivalents. |
+
+---
+
+## Task Numbering
+
+| Plan task | Master plan items | What |
+|-----------|-------------------|------|
+| S8a.1 | S8.1 | Analytics queries + API route |
+| S8a.2 | S8.2 | Concept detail queries + API + page |
+| S8a.3 | S8.7, S8.8 | Prerequisite awareness + staleness detection (session enrichment + UI) |
+| S8a.4 | S8.1 (dashboard) | Analytics dashboard section on `/study` + concept links |
+| S8a.5 | — | Tests + verification |
+
+---
+
+## Parallelization & Model Recommendations
+
+**Dependencies:**
+- S8a.1 is independent (adds to study-db.ts + creates stats route)
+- S8a.2 depends on S8a.1 (both modify `study-db.ts` — must run sequentially)
+- S8a.3 depends on S8a.2 (needs `concept_prerequisites` and `activity_concepts` tables added to dashboard schema by S8a.2)
+- S8a.4 depends on S8a.1 (calls `/api/study/stats`) and S8a.2 (links to concept detail page)
+- S8a.5 depends on all
+
+**Execution order:** S8a.1 → S8a.2 → S8a.3 → S8a.4 → S8a.5. Limited parallelism — the tasks form a dependency chain through `study-db.ts` and `dashboard/src/lib/db/schema.ts`. S8a.4 can run after S8a.2 (in parallel with S8a.3) since it only reads the stats API and links to concept pages.
+
+**Parallel opportunities:**
+- **Wave 1:** S8a.1 (only independent task)
+- **Wave 2:** S8a.2 (depends on S8a.1 for study-db.ts)
+- **Wave 3:** S8a.3 + S8a.4 (S8a.3 uses schema from S8a.2; S8a.4 uses APIs from S8a.1 + pages from S8a.2 — no file overlap between S8a.3 and S8a.4)
+- **Wave 4:** S8a.5 (verification)
+
+| Task | Can parallel with | Model | Rationale |
+|------|-------------------|-------|-----------|
+| S8a.1 | — | Sonnet | Mechanical Drizzle queries + API route |
+| S8a.2 | — | Sonnet | Queries + API + page creation (follows patterns) |
+| S8a.3 | S8a.4 | Sonnet | Query + session enrichment + UI badges |
+| S8a.4 | S8a.3 | Sonnet | UI section following existing patterns |
+| S8a.5 | — | Sonnet | Mechanical verification |
+
+**File ownership for Wave 3 parallel agents:**
+- **S8a.3 agent:** Owns `dashboard/src/lib/session-warnings.ts` (create), `dashboard/src/app/api/study/session/route.ts` (modify GET handler), `dashboard/src/app/study/session/page.tsx` (add warning UI). Imports `concept_prerequisites` and `activity_concepts` from `dashboard/src/lib/db/schema.ts` (added by S8a.2). Do NOT touch the `/study` overview page, stats route, or concept detail page.
+- **S8a.4 agent:** Owns `dashboard/src/app/study/page.tsx` (add analytics section + concept links). Do NOT touch session routes, session page, study-db.ts, or schema files.
+
+---
+
+## S8a.1: Analytics Queries + API Route
+
+**Files:** Modify `dashboard/src/lib/study-db.ts` (add analytics functions), create `dashboard/src/app/api/study/stats/route.ts`
+
+**Parallelizable with S8a.3.**
+
+### Analytics functions to add to study-db.ts
+
+Add these functions at the end of `dashboard/src/lib/study-db.ts`, after the existing plan functions. Each returns a camelCase response object.
+
+**1. `getRetentionRate(days: number)`**
+Query `activity_log` for entries where `reviewed_at >= date('now', '-N days')`. Compute: `count(quality >= 3) / count(*)`. Return `{ retentionRate: number, totalReviews: number, correctReviews: number }`.
+
+Dashboard schema columns: `activity_log.reviewed_at`, `activity_log.quality`.
+
+**2. `getBloomDistribution(days: number)`**
+Query `activity_log` where `reviewed_at >= date('now', '-N days')`, group by `bloom_level`. Return `Array<{ bloomLevel: number, count: number, percentage: number }>`.
+
+Dashboard schema columns: `activity_log.bloom_level`, `activity_log.reviewed_at`.
+
+**3. `getMethodEffectiveness()`**
+Query `activity_log`, group by `activity_type`. For each type: `avg(quality)`, `count(*)`. Return `Array<{ activityType: string, avgQuality: number, count: number }>`. Order by avgQuality desc.
+
+Dashboard schema columns: `activity_log.activity_type`, `activity_log.quality`.
+
+**4. `getActivityTimeSeries(days: number)`**
+Query `activity_log` where `reviewed_at >= date('now', '-N days')`, group by date (truncate reviewed_at to date). Return `Array<{ date: string, count: number, avgQuality: number }>`. Fill gaps with zero-count entries for days with no activity.
+
+Dashboard schema columns: `activity_log.reviewed_at`, `activity_log.quality`.
+
+**5. `getCalibrationData(days: number)`**
+Query `activity_log` where `reviewed_at >= date('now', '-N days')` AND `confidence_rating IS NOT NULL`. Return `{ calibrationScore: number | null, dataPoints: number }`. Calibration = Pearson correlation between `confidence_rating` and `quality`. Return null if fewer than 5 data points.
+
+Dashboard schema columns: `activity_log.confidence_rating`, `activity_log.quality`, `activity_log.reviewed_at`.
+
+### API route
+
+Create `dashboard/src/app/api/study/stats/route.ts`:
+
+```typescript
+// GET /api/study/stats?days=7
+// Returns all analytics metrics for the given time window
+```
+
+Query param `days` defaults to 7. Calls all 5 analytics functions and returns a combined response:
+```typescript
+{
+  retentionRate: { retentionRate, totalReviews, correctReviews },
+  bloomDistribution: [...],
+  methodEffectiveness: [...],
+  activityTimeSeries: [...],
+  calibration: { calibrationScore, dataPoints },
+  period: { days, from, to }
+}
+```
+
+**Agent discretion:** Pearson correlation implementation (inline helper or import a tiny utility), gap-filling strategy for time series, exact Drizzle `sql` template syntax for date arithmetic.
+
+### Tests
+
+The Drizzle analytics queries are thin wrappers around SQL — testing them requires a real DB. Test the pure computation helpers instead:
+
+Create `dashboard/src/lib/__tests__/analytics.test.ts` that tests:
+1. **Pearson correlation helper:** Known dataset with expected r-value, edge case with < 5 points returns null
+2. **Gap-filling for time series:** Date range with missing days filled with zero-count entries
+3. **Retention rate computation:** Mixed quality values (0-5) — verify threshold at quality >= 3
+
+The dashboard test infrastructure runs via `cd dashboard && npm test` (Vitest).
+
+- [ ] **Step 1:** Add the 5 analytics query functions to `dashboard/src/lib/study-db.ts`
+- [ ] **Step 2:** Create `dashboard/src/app/api/study/stats/route.ts` with GET handler
+- [ ] **Step 3:** Run `cd dashboard && npm run build` — verify clean
+- [ ] **Step 4:** Create `dashboard/src/lib/__tests__/analytics.test.ts` with Pearson correlation test
+- [ ] **Step 5:** Run `cd dashboard && npm test` — verify pass
+- [ ] **Step 6:** Run `npm test` (root) — no regressions
+- [ ] **Step 7:** Commit: `feat(dashboard): add analytics queries and /api/study/stats endpoint (S8a.1)`
+
+---
+
+## S8a.2: Concept Detail Queries + API + Page
+
+**Files:** Modify `dashboard/src/lib/study-db.ts` (add concept detail function), create `dashboard/src/app/api/study/concepts/[id]/route.ts`, create `dashboard/src/app/study/concepts/[id]/page.tsx`
+
+**Depends on:** S8a.1 (both modify study-db.ts — run after S8a.1 commits).
+
+### Concept detail query
+
+Add `getConceptDetail(id: string)` to `dashboard/src/lib/study-db.ts`. Returns a rich object:
+
+```typescript
+interface ConceptDetail {
+  // Core concept data (same as ConceptSummary)
+  id: string;
+  title: string;
+  domain: string | null;
+  subdomain: string | null;
+  course: string | null;
+  vaultNotePath: string | null;
+  status: string;
+  bloomCeiling: number;
+  masteryOverall: number;
+  masteryL1: number; masteryL2: number; masteryL3: number;
+  masteryL4: number; masteryL5: number; masteryL6: number;
+  createdAt: string;
+  lastActivityAt: string | null;
+
+  // Enrichment
+  dueCount: number;
+  totalActivities: number;
+  activities: Array<{
+    id: string;
+    activityType: string;
+    bloomLevel: number;
+    dueAt: string;
+    masteryState: string;
+    author: string;
+  }>;
+  recentLogs: Array<{
+    id: string;
+    activityType: string;
+    bloomLevel: number;
+    quality: number;
+    evaluationMethod: string;
+    reviewedAt: string;
+  }>;
+  methodEffectiveness: Array<{
+    activityType: string;
+    avgQuality: number;
+    count: number;
+  }>;
+  relatedConcepts: Array<{
+    id: string;
+    title: string;
+    role: string;
+  }>;
+  prerequisites: Array<{
+    id: string;
+    title: string;
+    bloomCeiling: number;
+    masteryOverall: number;
+  }>;
+}
+```
+
+**Queries needed:**
+1. Concept row from `concepts` table (existing `getActiveConcepts` pattern)
+2. Activities from `learning_activities` where `concept_id = id`, ordered by `bloom_level` asc
+3. Due count: subset of activities where `due_at <= today`
+4. Recent logs from `activity_log` where `concept_id = id`, limit 20, order by `reviewed_at` desc
+5. Method effectiveness: `activity_log` where `concept_id = id`, group by `activity_type`
+6. Related concepts via `activity_concepts` join table. **Join path:** `learning_activities WHERE concept_id = id` → `activity_concepts WHERE activity_id IN those activity IDs` → `concepts WHERE id = activity_concepts.concept_id AND id != original concept_id`. Note: only multi-concept activities (comparisons, synthesis) create `activity_concepts` entries. This will be empty for concepts that haven't reached L4+ — that's expected, not a bug.
+7. Prerequisites from `concept_prerequisites` where `concept_id = id`, joined with concepts table for title + mastery
+
+Dashboard schema columns for `concept_prerequisites`: This table is defined in the backend schema (`src/db/schema/study.ts`) as `conceptPrerequisites` with columns `concept_id` and `prerequisite_id`. **The dashboard schema (`dashboard/src/lib/db/schema.ts`) does NOT yet have this table defined.** S8a.2 must add it.
+
+### Dashboard schema addition
+
+Add to `dashboard/src/lib/db/schema.ts`:
+```typescript
+import { primaryKey } from 'drizzle-orm/sqlite-core';
+
+export const concept_prerequisites = sqliteTable('concept_prerequisites', {
+  concept_id: text('concept_id').notNull(),
+  prerequisite_id: text('prerequisite_id').notNull(),
+}, (table) => [
+  primaryKey({ columns: [table.concept_id, table.prerequisite_id] }),
+]);
+
+export const activity_concepts = sqliteTable('activity_concepts', {
+  activity_id: text('activity_id').notNull(),
+  concept_id: text('concept_id').notNull(),
+  role: text('role').default('related'),
+}, (table) => [
+  primaryKey({ columns: [table.activity_id, table.concept_id] }),
+]);
+```
+
+These tables exist in the DB (created by backend migrations) but weren't exposed in the dashboard schema because no dashboard feature needed them until now. The primary keys match the backend schema in `src/db/schema/study.ts`.
+
+### API route
+
+Create `dashboard/src/app/api/study/concepts/[id]/route.ts`:
+
+```typescript
+// GET /api/study/concepts/abc123
+// Returns full concept detail
+```
+
+Returns `{ concept: ConceptDetail }` or `{ error: 'Concept not found' }` with 404.
+
+### Concept detail page
+
+Create `dashboard/src/app/study/concepts/[id]/page.tsx`:
+
+**Layout (top to bottom):**
+1. **Header:** Concept title, domain/subdomain badge, vault link (if `vaultNotePath` set)
+2. **Mastery section:** 6-level horizontal bar chart (L1-L6). Each bar shows mastery evidence / threshold, color-coded by level (green = mastered, yellow = progressing, gray = untouched). Current `bloomCeiling` highlighted.
+3. **Activities section:** Table of all activities for this concept: type, Bloom level, due date, mastery state, author (system/student). "Generate more" button at bottom.
+4. **Activity history:** Recent activity log entries: date, type, Bloom level, quality score, evaluation method. Limited to 20 most recent.
+5. **Method effectiveness:** Small CSS bar chart showing avg quality per method type used for this concept.
+6. **Related concepts:** List of concepts linked via multi-concept activities (comparisons, synthesis). Each is a link to its detail page.
+7. **Prerequisites:** List of prerequisite concepts with their mastery status. Weak prerequisites (mastery_overall < 0.3) highlighted in amber.
+
+**"Generate more activities" button:** For S8a, this is a placeholder — clicking shows a toast "Generation requested" with no actual API call. Wiring it to the generator (via IPC to the existing `study_generation_request` handler) is S8b work. Do NOT POST to `/api/study/evaluate` — that endpoint is for AI evaluation, not generation.
+
+**Agent discretion:** Exact layout proportions, color choices within the dark theme palette, whether to use tabs or scroll sections, "Generate more" button behavior.
+
+- [ ] **Step 1:** Add `concept_prerequisites` and `activity_concepts` tables to `dashboard/src/lib/db/schema.ts`
+- [ ] **Step 2:** Add `getConceptDetail(id)` function to `dashboard/src/lib/study-db.ts`
+- [ ] **Step 3:** Create `dashboard/src/app/api/study/concepts/[id]/route.ts`
+- [ ] **Step 4:** Create `dashboard/src/app/study/concepts/[id]/page.tsx`
+- [ ] **Step 5:** Run `cd dashboard && npm run build` — verify clean
+- [ ] **Step 6:** Run `npm test` (root) — no regressions
+- [ ] **Step 7:** Commit: `feat(dashboard): add concept detail page with mastery breakdown and activity history (S8a.2)`
+
+---
+
+## S8a.3: Prerequisite Awareness + Staleness Detection
+
+**Files:** Create `dashboard/src/lib/session-warnings.ts`, modify `dashboard/src/app/api/study/session/route.ts` (enrich GET response), modify `dashboard/src/app/study/session/page.tsx` (add warning UI)
+
+**Parallelizable with S8a.1** (no file overlap — S8a.3 creates a new utility file and modifies session-specific files only).
+
+### Session warnings utility
+
+Create `dashboard/src/lib/session-warnings.ts`. This file contains two functions:
+
+**1. `getPrerequisiteWarnings(conceptIds: string[])`**
+
+For each concept ID in the session, query `concept_prerequisites` to find prerequisite concepts, then check if any prerequisite has `mastery_overall < WEAK_PREREQUISITE_THRESHOLD` (0.3).
+
+Returns:
+```typescript
+Array<{
+  conceptId: string;
+  conceptTitle: string;
+  weakPrerequisites: Array<{
+    id: string;
+    title: string;
+    masteryOverall: number;
+  }>;
+}>
+```
+
+Only returns entries where `weakPrerequisites.length > 0`.
+
+Dashboard schema columns:
+- `concept_prerequisites.concept_id`, `concept_prerequisites.prerequisite_id`
+- `concepts.id`, `concepts.title`, `concepts.mastery_overall`
+
+**Note:** Import the `concept_prerequisites` table from `dashboard/src/lib/db/schema.ts` — added by S8a.2 which runs before S8a.3.
+
+**2. `getStalenessWarnings(activities: Array<{ activityId: string, sourceNotePath: string | null, generatedAt: string }>)`**
+
+For each activity with a non-null `sourceNotePath`:
+1. Resolve the path relative to the vault directory (use `process.env.VAULT_DIR || './vault'`)
+2. Call `fs.statSync()` to get the file's mtime
+3. If file doesn't exist → stale (source deleted)
+4. If file mtime > activity's `generatedAt` → stale (source modified)
+5. Otherwise → fresh
+
+Returns:
+```typescript
+Array<{
+  activityId: string;
+  staleReason: 'source_deleted' | 'source_modified';
+}>
+```
+
+**Constraint:** Use `fs.statSync()` (synchronous) since this runs in a Next.js API route on Node.js. Wrap in try/catch — `ENOENT` = deleted, other errors = skip (treat as fresh).
+
+### Session API enrichment
+
+Modify `dashboard/src/app/api/study/session/route.ts` GET handler:
+
+After building the session composition, call both warning functions and include results in the response:
+
+```typescript
+{
+  session: { blocks, totalActivities, estimatedMinutes, domainsCovered },
+  warnings: {
+    prerequisites: [...],  // from getPrerequisiteWarnings
+    staleActivities: [...] // from getStalenessWarnings
+  }
+}
+```
+
+To call `getStalenessWarnings`, the enriched activities need `sourceNotePath` and `generatedAt`. The current enrichment step in the GET handler (lines 14-27) reads `getActivityById()` which returns the full `ActivityRow` including `source_note_path` and `generated_at`, but these are not mapped through. **You must add them:** in the enrichment `.map()`, add `sourceNotePath: full.source_note_path ?? null` and `generatedAt: full.generated_at` alongside the existing `prompt`, `referenceAnswer`, and `cardType` mappings.
+
+### Session UI warnings
+
+Modify `dashboard/src/app/study/session/page.tsx`:
+
+**Prerequisite warnings:** Show a dismissible amber banner at the top of the session when any concept has weak prerequisites. Format: "Note: [Concept Title] depends on [Prerequisite Title] (mastery: 23%) — consider reviewing it first." Non-blocking — the student can dismiss and continue.
+
+**Staleness badges:** On individual activity cards, if the activity is stale, show a small amber badge: "Source updated" or "Source deleted". Add a "Regenerate" button next to stale activities that calls `POST /api/study/concepts/approve` with the concept ID (triggers re-generation in the existing approval flow). Agent discretion on exact UI placement.
+
+**Constraint:** Both warning types are advisory, not blocking. The session continues normally regardless. Follow the spec's "suggest strongly, enforce nothing" principle.
+
+- [ ] **Step 1:** Create `dashboard/src/lib/session-warnings.ts` with `getPrerequisiteWarnings()` and `getStalenessWarnings()`
+- [ ] **Step 2:** Modify `dashboard/src/app/api/study/session/route.ts` GET handler to include warnings
+- [ ] **Step 3:** Add prerequisite warning banner to `dashboard/src/app/study/session/page.tsx`
+- [ ] **Step 4:** Add staleness badge + regenerate button to activity cards in session page
+- [ ] **Step 5:** Run `cd dashboard && npm run build` — verify clean
+- [ ] **Step 6:** Run `npm test` (root) — no regressions
+- [ ] **Step 7:** Commit: `feat(dashboard): add prerequisite awareness and staleness detection to study sessions (S8a.3)`
+
+---
+
+## S8a.4: Analytics Dashboard Section + Concept Links
+
+**Files:** Modify `dashboard/src/app/study/page.tsx`
+
+**Depends on:** S8a.1 (stats API must exist), S8a.2 (concept detail page must exist for links).
+
+### Analytics section
+
+Add a new "Analytics" section to the `/study` overview page, between the "Plans" section and "Pending Approval" section. The section fetches from `GET /api/study/stats?days=7` and displays:
+
+**1. Summary cards row (4 cards):**
+- Retention rate: percentage, colored green/yellow/red based on threshold (>80% green, >60% yellow, <60% red)
+- Activities this week: count + daily average
+- Average quality: 0-5 scale
+- Calibration accuracy: percentage (or "—" if insufficient data)
+
+**2. Bloom's distribution bar:** Single horizontal stacked bar showing the percentage of activities at each Bloom's level, color-coded (L1=lighter, L6=darker blue). Small label below each segment.
+
+**3. Method effectiveness:** Small table or horizontal bars showing avg quality per method type. Only show methods with > 0 activities.
+
+**4. Time period toggle:** Buttons for "7 days" / "30 days" / "All time" that re-fetch stats with different `days` parameter.
+
+### Concept links
+
+Update the Active Concepts table to make concept titles clickable links to `/study/concepts/[id]`. The concept title cell becomes an `<a>` tag with `href={/study/concepts/${concept.id}}`.
+
+**Agent discretion:** Exact card layout (grid vs flex), color thresholds for retention rate, whether to show the time series as a sparkline or just the summary, period toggle implementation.
+
+- [ ] **Step 1:** Add analytics state and fetch to the existing `fetchData()` in `/study` page
+- [ ] **Step 2:** Add Analytics section UI with summary cards
+- [ ] **Step 3:** Add Bloom's distribution bar
+- [ ] **Step 4:** Add method effectiveness display
+- [ ] **Step 5:** Add time period toggle
+- [ ] **Step 6:** Update concept titles to be clickable links to detail page
+- [ ] **Step 7:** Run `cd dashboard && npm run build` — verify clean
+- [ ] **Step 8:** Start dashboard dev server, visually verify the analytics section renders
+- [ ] **Step 9:** Commit: `feat(dashboard): add analytics section to study overview and concept detail links (S8a.4)`
+
+---
+
+## S8a.5: Verification
+
+**Depends on:** All previous tasks.
+
+- [ ] **Step 1:** Run `npm test` — all pass, no regressions
+- [ ] **Step 2:** Run `cd dashboard && npm run build` — clean
+- [ ] **Step 3:** Run `npm run build` (root) — clean
+- [ ] **Step 4:** Start dashboard dev server (`cd dashboard && npm run dev`)
+- [ ] **Step 5:** Navigate to `/study` — verify analytics section shows (may show zeros if no data)
+- [ ] **Step 6:** Click a concept title — verify concept detail page loads
+- [ ] **Step 7:** Navigate to `/study/session` — verify no crashes (prerequisite/staleness warnings may be empty)
+- [ ] **Step 8:** Verify all new files use correct import conventions (no `.js` in dashboard, `.js` in src/)
+- [ ] **Step 9:** Commit: `chore(study): verify S8a analytics + concept detail + polish end-to-end (S8a.5)`
+
+---
+
+## Acceptance Criteria
+
+From master plan S8 (non-negotiable):
+
+- [ ] `GET /api/study/stats` returns: retention rate, Bloom's distribution, method effectiveness, activity time series, calibration data
+- [ ] Analytics section on `/study` page displays meaningful learning data with period toggle
+- [ ] Concept detail page at `/study/concepts/[id]` shows: Bloom's level mastery bars (6-level), activity history, method effectiveness, related concepts, vault source link
+- [ ] Concept titles on overview page link to detail page
+- [ ] Session API includes prerequisite warnings for concepts with weak prerequisites
+- [ ] Session API includes staleness warnings for activities whose source notes changed
+- [ ] Session UI shows prerequisite warning banner (dismissible, non-blocking)
+- [ ] Session UI shows staleness badge on affected activities
+- [ ] Dashboard schema includes `concept_prerequisites` and `activity_concepts` tables
+- [ ] All existing tests pass (`npm test`)
+- [ ] Dashboard builds cleanly (`cd dashboard && npm run build`)
+- [ ] No regressions in existing dashboard pages

--- a/docs/superpowers/plans/2026-04-16-s8b-audio-scaffolding.md
+++ b/docs/superpowers/plans/2026-04-16-s8b-audio-scaffolding.md
@@ -1,0 +1,505 @@
+# S8b: Audio + Student Activities + Scaffolding — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Your role:** You are the engineer implementing this. The plan tells you *what* to build and *why*. You decide *how* within the stated constraints. If you disagree with an approach or see a better alternative, flag it before implementing — don't silently deviate and don't silently comply with something you think is wrong.
+
+**Goal:** Add audio/podcast generation pipeline with TTS, Telegram podcast delivery, student-generated activity prompting in the dashboard, and an adaptive scaffolding hint system — completing the study system's feature set.
+
+**Architecture:** S8b introduces two new capabilities: (1) an audio pipeline that generates conversational scripts via the generator agent, converts to audio via Mistral TTS API, and delivers via Telegram; (2) a scaffolding system that adapts hint levels based on rolling success rate. Student-generated activities leverage the existing `study_suggest_activity` IPC handler (S5.9) — S8b adds the dashboard UX for prompting at key moments.
+
+**Tech Stack:** TypeScript/Node.js (backend), Next.js + React (dashboard), Mistral API (TTS), NanoClaw task scheduler (cron), Telegram grammY (audio delivery), Vitest (tests)
+
+**Branch:** Create `feat/s8b-audio-scaffolding` off the branch where S8a was merged (or off `main` if S8a is already merged).
+
+**Note:** Master plan S8.7 (prerequisite awareness), S8.8 (staleness detection), and S8.9 (monthly scheduled task) are NOT in this plan — S8.7 and S8.8 are covered by S8a, and S8.9 was already implemented in S7 (`study-monthly-mastery` scheduled task).
+
+**Spec:** `docs/superpowers/specs/2026-04-12-multi-method-study-system-design.md` (Sections 4.4, 6.4, 8)
+
+**Master plan:** `docs/superpowers/plans/2026-04-13-study-system-master-plan.md` (S8.3, S8.4, S8.5, S8.6)
+
+---
+
+## Codebase Conventions (Hard Constraints)
+
+These apply to **every task**. Subagents must follow these — they're not obvious from context alone.
+
+1. **`.js` extensions on all relative imports in `src/`.** The backend uses Node ESM resolution. Write `import { foo } from './bar.js'`, not `'./bar'`. **Exception:** Dashboard (`dashboard/src/`) does NOT use `.js` extensions — Next.js handles resolution.
+2. **camelCase Drizzle properties in `src/db/schema/*.ts`**, snake_case SQL column names. Dashboard schema (`dashboard/src/lib/db/schema.ts`) uses snake_case properties.
+3. **Drizzle query builder operators** — not raw SQL strings.
+4. **Commit messages** use conventional commits: `feat(study):`, `feat(dashboard):`.
+5. **Test file locations:** Backend tests are colocated: `src/study/foo.test.ts`. Use `_initTestDatabase()` from `../db/index.js`.
+6. **IPC handlers** go in the `processTaskIpc` switch/case in `src/ipc.ts`. Follow existing patterns.
+7. **Mr. Rogers CLAUDE.md** is at `groups/telegram_main/CLAUDE.md`. Telegram formatting: `*bold*`, `_italic_`, `•` bullets. No `##` headings or `**double stars**`.
+8. **Generator CLAUDE.md** is at `groups/study-generator/CLAUDE.md`.
+9. **Container agent dispatch** uses the existing task scheduler + IPC infrastructure. New generation jobs follow the `study_generation_request` IPC pattern (S3.8).
+
+---
+
+## Spec Deviations
+
+- **TTS via OpenAI API, not Mistral.** The spec says "TTS via Mistral API, already configured" but Mistral does not offer a TTS endpoint. S8b uses OpenAI's TTS API (`https://api.openai.com/v1/audio/speech`, model `tts-1`) instead. The `OPENAI_API_KEY` is available via OneCLI. The `MISTRAL_API_KEY` env var exists for STT (transcription) — not TTS.
+- **Audio storage is filesystem-based, not DB-linked.** The spec envisions "audio files linked to concepts" in the database. S8b stores audio files in `data/audio/` with filename convention `{contentType}-{conceptIds}-{timestamp}.mp3` and no new DB table. The file path is passed to Telegram for delivery. A future sprint can add a DB tracking table if audio management becomes complex.
+- **Student activity prompting is dashboard-side only.** The spec mentions prompting "during dashboard chat after an illuminating exchange." S8b adds prompting on the session page (post-struggle, post-insight detection). Chat-based prompting requires study agent CLAUDE.md changes that are better addressed as a targeted follow-up.
+- **Scaffolding hint content is AI-generated, not pre-stored.** The spec describes 5 fixed scaffolding levels. S8b implements the level selection logic (adaptive, targeting 70-85% success) but generates hint content dynamically via the study agent rather than pre-storing hints per activity. This is more flexible and avoids doubling the storage for every activity.
+- **Scaffolding adjustment thresholds tightened from spec.** The spec (Section 4.4) uses `> 90%` to decrease and `< 50%` to increase scaffolding. S8b tightens these to `> 85%` / `< 70%` to keep students more consistently in the ZPD. The spec's 50% lower bound is too permissive — at 55% success a student is essentially guessing and needs help. The tighter window (70-85%) provides a more responsive adaptive system.
+
+---
+
+## Key Decisions
+
+### D1: Audio pipeline is a two-stage process
+Stage 1: Generator agent produces a conversational script (text). Stage 2: Mistral TTS API converts script to audio (mp3). This is two separate operations because: (a) the script can be reviewed/edited before synthesis, (b) TTS failures don't lose the script work, (c) script generation is free (Claude Max) while TTS has API cost.
+
+### D2: TTS client is a thin wrapper in src/study/audio.ts
+The OpenAI TTS API call is a simple HTTP POST. No SDK needed — use `fetch()` directly. The `OPENAI_API_KEY` is available via OneCLI (same as how Claude API keys are managed). The audio file is written to `data/audio/` and the file path returned.
+
+### D3: Scaffolding level is computed per-concept from rolling window
+The scaffolding level for a concept is derived from the last 10 activity completions for that concept. Success rate = quality >= 3 / total. If success rate > 85%, decrease scaffolding level. If < 70%, increase it. If 70-85%, maintain. This runs at session build time — the session composition includes recommended scaffolding levels.
+
+**Why per-concept, not per-activity?** A student struggling with Cognitive Load Theory at L3 should get hints for all L3 CLT activities, not just the specific one they failed. The concept is the unit of struggle.
+
+### D4: Student activity suggestion is a UI prompt, not automatic
+After completing an activity with quality <= 2 (struggle) or quality = 5 (mastery), the session UI shows a prompt: "Want to create your own study question for this concept?" If yes, a form appears. The form POSTs to `/api/study/suggest-activity` which writes an IPC file for the `study_suggest_activity` handler (already implemented in S5.9).
+
+### D5: Telegram audio delivery uses existing sendVoice
+The Telegram channel already has `sendVoice()` via grammY. Audio delivery is triggered by a new scheduled task or on-demand IPC. Mr. Rogers sends the audio file with a brief description of the content.
+
+---
+
+## Essential Reading
+
+> **For coordinators:** Extract relevant patterns from these files and inline them into subagent prompts. Subagents won't read the files themselves.
+
+| File | Why |
+|------|-----|
+| `src/study/generator.ts` | Activity generation pipeline. S8b.1 adds audio script generation alongside it. |
+| `groups/study-generator/CLAUDE.md` | Generator agent prompt. S8b.1 adds audio script generation instructions. |
+| `src/ipc.ts:738-756` | `study_generation_request` handler. S8b.1 adds `study_audio_script` handler nearby. |
+| `src/ipc.ts:911-985` | `study_suggest_activity` handler. S8b.4 triggers this from the dashboard. |
+| `src/study/scheduled.ts` | Existing scheduled tasks. S8b.3 adds audio delivery task. |
+| `groups/telegram_main/CLAUDE.md` | Mr. Rogers prompt. S8b.3 adds audio delivery instructions. |
+| `dashboard/src/app/study/session/page.tsx` | Session UI. S8b.4 adds student activity prompt, S8b.5 adds hint button. |
+| `dashboard/src/lib/study-db.ts` | Dashboard queries. S8b.5 adds scaffolding level computation. |
+| `dashboard/src/app/api/study/complete/route.ts` | Activity completion. S8b.5 adds scaffolding_level to completion payload. |
+
+---
+
+## Task Numbering
+
+| Plan task | Master plan items | What |
+|-----------|-------------------|------|
+| S8b.1 | S8.3 | Audio pipeline: script generation + TTS + IPC handler |
+| S8b.2 | S8.4 | Telegram podcast delivery: scheduled task + Mr. Rogers CLAUDE.md |
+| S8b.3 | S8.5 | Student-generated activities: dashboard prompt + API route |
+| S8b.4 | S8.6 | Scaffolding hint system: level computation + session enrichment + UI |
+| S8b.5 | — | Tests + verification |
+
+---
+
+## Parallelization & Model Recommendations
+
+**Dependencies:**
+- S8b.1 is independent (new audio.ts file, new IPC handler, generator CLAUDE.md update)
+- S8b.2 depends on S8b.1 (audio files must exist for delivery)
+- S8b.3 is independent (dashboard session page + new API route)
+- S8b.4 is independent of S8b.1-S8b.2 BUT modifies session page (conflicts with S8b.3)
+- S8b.5 depends on all
+
+**Parallel opportunities:**
+- **Wave 1:** S8b.1 + S8b.3 (independent: audio is backend + IPC; student activities is dashboard)
+- **Wave 2:** S8b.2 + S8b.4 (S8b.2 depends on S8b.1; S8b.4 depends on S8b.3 for session page changes — or run S8b.4 in Wave 1 if session page edits don't overlap with S8b.3)
+- **Wave 3:** S8b.5 (verification)
+
+| Task | Can parallel with | Model | Rationale |
+|------|-------------------|-------|-----------|
+| S8b.1 | S8b.3 | Sonnet | Pipeline implementation follows existing generation pattern |
+| S8b.2 | S8b.4 | Sonnet | Small: scheduled task + CLAUDE.md update |
+| S8b.3 | S8b.1 | Sonnet | Dashboard form + API route |
+| S8b.4 | S8b.2 | Sonnet | Query + session enrichment + UI component |
+| S8b.5 | — | Sonnet | Mechanical verification |
+
+**File ownership for Wave 1 parallel agents:**
+- **S8b.1 agent:** Owns `src/study/audio.ts` (create), `src/study/audio.test.ts` (create), `src/ipc.ts` (add `study_audio_script` case), `groups/study-generator/CLAUDE.md` (add audio section). Do NOT touch dashboard files, session page, or `scheduled.ts`.
+- **S8b.3 agent:** Owns `dashboard/src/app/study/session/page.tsx` (add suggestion prompt), `dashboard/src/app/api/study/suggest-activity/route.ts` (create). Do NOT touch `src/` backend files, IPC handlers, or generator CLAUDE.md.
+
+---
+
+## S8b.1: Audio Pipeline — Script Generation + TTS
+
+**Files:** Create `src/study/audio.ts`, create `src/study/audio.test.ts`, modify `src/ipc.ts` (add `study_audio_script` handler), modify `groups/study-generator/CLAUDE.md` (add audio script section)
+
+**Parallelizable with S8b.3.**
+
+### Audio module: src/study/audio.ts
+
+This module orchestrates the two-stage audio pipeline:
+
+**Stage 1: Script generation**
+```typescript
+generateAudioScript(options: AudioScriptOptions): Promise<void>
+```
+
+`AudioScriptOptions`:
+```typescript
+interface AudioScriptOptions {
+  conceptIds: string[];
+  contentType: 'summary' | 'review_primer' | 'weekly_digest';
+  targetDurationMinutes?: number; // default: 5 for summary, 3 for primer, 10 for digest
+}
+```
+
+This function:
+1. Fetches concept data from DB (titles, domains, mastery levels)
+2. Builds a generation prompt for the generator agent
+3. Dispatches via the existing task scheduler (same pattern as `study_generation_request`)
+4. The generator agent returns the script via `study_audio_script` IPC
+
+**Stage 2: TTS synthesis**
+```typescript
+synthesizeAudio(script: string, outputPath: string): Promise<string>
+```
+
+This function:
+1. Calls the Mistral TTS API with the script text
+2. Writes the audio response to `outputPath`
+3. Returns the file path
+
+**OpenAI TTS API call:**
+```typescript
+const response = await fetch('https://api.openai.com/v1/audio/speech', {
+  method: 'POST',
+  headers: {
+    'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({
+    model: 'tts-1',
+    input: script,
+    voice: 'alloy', // or configurable
+    response_format: 'mp3',
+  }),
+  signal: AbortSignal.timeout(60_000), // 60s timeout for long scripts
+});
+if (!response.ok) {
+  throw new Error(`TTS API failed: ${response.status} ${await response.text()}`);
+}
+// Write to temp file then rename for atomicity
+const tempPath = outputPath + '.tmp';
+const audioBuffer = await response.arrayBuffer();
+fs.writeFileSync(tempPath, Buffer.from(audioBuffer));
+fs.renameSync(tempPath, outputPath);
+```
+
+**Error handling:** Wrap `synthesizeAudio()` in try/catch. On failure: log the error, clean up any temp files (`*.tmp`), and don't leave partial audio files on disk. The IPC handler should catch TTS errors and write an error response file (not crash the process).
+
+### IPC handler: study_audio_script
+
+Add to `src/ipc.ts` switch/case:
+
+**Input:**
+```typescript
+{
+  type: 'study_audio_script',
+  conceptIds: string[],
+  script: string,
+  contentType: 'summary' | 'review_primer' | 'weekly_digest'
+}
+```
+
+**Handler behavior:**
+1. Validate: `conceptIds` is non-empty array, `script` is non-empty string, `contentType` is valid
+2. Generate output path: `data/audio/${contentType}-${Date.now()}.mp3`
+3. Call `synthesizeAudio(script, outputPath)`
+4. Write response file to IPC responses dir with the audio file path
+5. Log success
+
+### Generator CLAUDE.md update
+
+Add an "Audio Script Generation" section to `groups/study-generator/CLAUDE.md`. Instructions:
+- When the prompt asks for audio script generation, produce a conversational narrative script
+- Script should be written for text-to-speech (no markdown, no bullet points, natural spoken language)
+- Content types: "summary" (overview of concept relationships), "review_primer" (quick recap of key points), "weekly_digest" (synthesis of the week's learning)
+- Target word count: ~150 words per minute of target duration
+- Include transitions, emphasis cues, and conceptual bridges
+- Output via `study_audio_script` IPC with the script text
+
+### Tests
+
+Test `synthesizeAudio()` with a mocked fetch (don't call real API in tests). Verify:
+1. Correct API call format (URL, headers, body)
+2. Audio file written to disk
+3. Error handling for API failures (non-200 response)
+
+- [ ] **Step 1:** Create `src/study/audio.ts` with `generateAudioScript()` and `synthesizeAudio()`
+- [ ] **Step 2:** Add `study_audio_script` IPC handler to `src/ipc.ts`
+- [ ] **Step 3:** Add audio script generation section to `groups/study-generator/CLAUDE.md`
+- [ ] **Step 4:** Create `src/study/audio.test.ts` with mocked TTS test
+- [ ] **Step 5:** Run `npm test` — verify pass
+- [ ] **Step 6:** Run `npm run build` — verify clean
+- [ ] **Step 7:** Commit: `feat(study): add audio pipeline with TTS synthesis and IPC handler (S8b.1)`
+
+---
+
+## S8b.2: Telegram Podcast Delivery
+
+**Files:** Modify `src/study/scheduled.ts` (add audio delivery task), modify `groups/telegram_main/CLAUDE.md` (add audio delivery section)
+
+**Depends on:** S8b.1 (audio files must be generatable).
+
+### Scheduled task for audio delivery
+
+Add a new task definition to `getStudyTaskDefinitions()` in `src/study/scheduled.ts`:
+
+**Audio review primer task (`study-audio-primer`)**
+- **Cron:** `0 6 * * *` (06:00 daily, before the morning study task at 07:00)
+- **Group:** `telegram_main`
+- **Prompt:** Instruct Mr. Rogers to:
+  1. Check if there are due activities for today
+  2. If yes, trigger audio script generation for a review primer of today's concepts
+  3. Wait for the audio file to be generated (check `data/audio/` for recent files)
+  4. Send the audio file via Telegram with a brief message: "Here's a quick audio review of today's concepts. Listen while you get ready!"
+
+**On-demand audio:** Mr. Rogers can also generate audio on request. When the student asks "generate a podcast about [topic]", Mr. Rogers:
+1. Identifies relevant concept IDs
+2. Writes a `study_audio_script` IPC request
+3. Waits for the audio file
+4. Sends via Telegram
+
+### Mr. Rogers CLAUDE.md update
+
+Add an "Audio/Podcast Delivery" subsection to the existing "Study System Integration" section in `groups/telegram_main/CLAUDE.md`:
+
+Content:
+- How to trigger audio generation (write IPC file with `study_audio_script` type... actually, Mr. Rogers triggers generation by writing a `study_generation_request` IPC with a special audio flag, or directly dispatches the generator)
+- Where audio files are stored (`/workspace/project/data/audio/`)
+- How to send audio via Telegram (use the bash command to send voice message, or the built-in voice capability)
+- When to proactively offer audio: before morning study sessions, before weekly reviews
+
+**Agent discretion:** Exact prompt wording, how Mr. Rogers discovers and sends audio files, whether to use a two-step process (generate then send) or combine.
+
+- [ ] **Step 1:** Add audio primer task definition to `src/study/scheduled.ts`
+- [ ] **Step 2:** Add audio delivery section to `groups/telegram_main/CLAUDE.md`
+- [ ] **Step 3:** Run `npm run build` — verify clean
+- [ ] **Step 4:** Run `npm test` — update task count in scheduled.test.ts if needed
+- [ ] **Step 5:** Commit: `feat(study): add Telegram podcast delivery scheduled task (S8b.2)`
+
+---
+
+## S8b.3: Student-Generated Activities — Dashboard Prompting
+
+**Files:** Modify `dashboard/src/app/study/session/page.tsx` (add suggestion prompt), create `dashboard/src/app/api/study/suggest-activity/route.ts`
+
+**Parallelizable with S8b.1.**
+
+### When to prompt
+
+After each activity completion, check the quality score:
+- **Quality 0-2 (struggle):** Show prompt: "This was a tough one. Want to create your own question about [concept title] to practice later?"
+- **Quality 5 (mastery):** Show prompt: "Great work! Want to capture what made this click as a study question?"
+- **Quality 3-4:** No prompt (normal performance, don't interrupt flow)
+
+The prompt appears as a collapsible section below the completion feedback, not as a modal. It should not disrupt the session flow.
+
+### Suggestion form
+
+When the student clicks "Yes" on the prompt:
+1. Show a form with:
+   - Activity type dropdown (card_review, elaboration, self_explain, comparison)
+   - Prompt text area (the question they want to study)
+   - Bloom's level selector (1-6, default to current activity's level)
+2. On submit, POST to `/api/study/suggest-activity`
+
+### API route
+
+Create `dashboard/src/app/api/study/suggest-activity/route.ts`:
+
+```typescript
+// POST /api/study/suggest-activity
+// Body: { conceptId, activityType, prompt, bloomLevel }
+```
+
+This route writes an IPC file to `data/ipc/study-generator/tasks/suggest_{timestamp}.json`:
+```json
+{
+  "type": "study_suggest_activity",
+  "conceptId": "abc123",
+  "activityType": "elaboration",
+  "prompt": "Why does dual coding theory predict better retention?",
+  "bloomLevel": 3,
+  "author": "student"
+}
+```
+
+The existing `study_suggest_activity` IPC handler (line ~911 in `src/ipc.ts`) picks this up and creates the activity.
+
+**Constraint:** Follow the exact IPC file-write pattern from `dashboard/src/lib/generation-trigger.ts` — same `ipcTaskDir()` helper function, same directory structure (`data/ipc/study-generator/tasks/`), same filename convention. The `study-generator` group folder is registered and the IPC watcher scans `data/ipc/{groupFolder}/tasks/` for new files. Do NOT use `data/ipc/study/tasks/` — no group named `study` exists in the registered groups.
+
+**IPC file path:** `data/ipc/study-generator/tasks/suggest_${Date.now()}.json`.
+
+**Dashboard schema columns used by the IPC handler for `study_suggest_activity`:**
+- `learning_activities.id` (generated UUID)
+- `learning_activities.concept_id` (from request)
+- `learning_activities.activity_type` (from request, validated against: card_review, elaboration, self_explain, concept_map, synthesis, socratic, comparison, case_analysis)
+- `learning_activities.prompt` (from request)
+- `learning_activities.bloom_level` (from request, integer 1-6)
+- `learning_activities.author` ('student')
+- `learning_activities.due_at` (set to today)
+- `learning_activities.generated_at` (now)
+- `learning_activities.ease_factor` (2.5 default)
+- `learning_activities.interval_days` (1 default)
+- `learning_activities.repetitions` (0 default)
+- `learning_activities.mastery_state` ('new')
+
+- [ ] **Step 1:** Add suggestion prompt UI to session page (appears after quality 0-2 or 5)
+- [ ] **Step 2:** Add suggestion form (activity type, prompt text, bloom level)
+- [ ] **Step 3:** Create `dashboard/src/app/api/study/suggest-activity/route.ts`
+- [ ] **Step 4:** Wire form submission to API route
+- [ ] **Step 5:** Run `cd dashboard && npm run build` — verify clean
+- [ ] **Step 6:** Run `npm test` — no regressions
+- [ ] **Step 7:** Commit: `feat(dashboard): add student-generated activity prompting in study sessions (S8b.3)`
+
+---
+
+## S8b.4: Scaffolding Hint System
+
+**Files:** Create `dashboard/src/lib/scaffolding.ts`, modify `dashboard/src/app/api/study/session/route.ts` (add scaffolding levels), modify `dashboard/src/app/study/session/page.tsx` (add hint button + display), modify `dashboard/src/app/api/study/complete/route.ts` (record scaffolding level)
+
+**Depends on:** S8b.3 (if S8b.3 modified session page; otherwise independent). Recommended: run after S8b.3 to avoid merge conflicts on session page.
+
+### Scaffolding level computation
+
+Create `dashboard/src/lib/scaffolding.ts`:
+
+```typescript
+/**
+ * Compute recommended scaffolding level for a concept based on
+ * rolling success rate (last 10 attempts).
+ *
+ * Scaffolding levels (spec Section 4.4):
+ *   0: No hints (prompt only)
+ *   1: Contextual hint ("Think about concept X")
+ *   2: Structural hint ("The answer involves three components...")
+ *   3: Partial solution ("The first step is...")
+ *   4: Worked example with similar problem
+ *   5: Full explanation + answer (last resort)
+ *
+ * Target: 70-85% success rate (Vygotsky's ZPD)
+ *   > 85% success → decrease level (min 0)
+ *   < 70% success → increase level (max 5)
+ *   70-85% → maintain current level
+ */
+export function computeScaffoldingLevel(
+  recentQualities: number[], // last 10 quality scores for this concept
+  currentLevel: number,      // current scaffolding level (0-5)
+): number
+```
+
+The function:
+1. Computes success rate: `recentQualities.filter(q => q >= 3).length / recentQualities.length`
+2. If fewer than 3 data points, return `currentLevel` (not enough data to adjust)
+3. If success rate > 0.85, return `Math.max(0, currentLevel - 1)`
+4. If success rate < 0.70, return `Math.min(5, currentLevel + 1)`
+5. Otherwise return `currentLevel`
+
+### Session enrichment
+
+Modify the session API (`GET /api/study/session`) to include recommended scaffolding level per activity. For each activity in the session composition:
+1. Get the concept ID
+2. Use the existing `getRecentLogs(conceptId, 10)` function from `study-db.ts` (~line 548) — it already queries `activity_log` ordered by `reviewed_at` desc with a limit. Do NOT create a duplicate query function.
+3. Extract quality scores from the returned logs
+4. Call `computeScaffoldingLevel(qualities, 0)` (default level 0 if no history)
+5. Include `scaffoldingLevel: number` in the enriched activity object
+
+Dashboard schema columns:
+- `activity_log.concept_id`, `activity_log.quality`, `activity_log.reviewed_at` (for rolling window)
+- `activity_log.scaffolding_level` (already exists, default 0)
+
+### Hint generation
+
+When the student clicks "Need a hint?", the hint content is generated based on the scaffolding level:
+
+- **Level 0:** No hint button shown
+- **Level 1-2:** Hint is derived from the activity's `reference_answer` — the API returns a truncated/abstracted version. Level 1 = first sentence of the reference answer. Level 2 = structural summary ("The answer covers N points: [first words of each]").
+- **Level 3-5:** Hint requires the study agent (AI-generated). For S8b, levels 3-5 show the reference answer with progressively more revealed (level 3 = 30%, level 4 = 60%, level 5 = 100%).
+
+**Why not AI hints?** AI hint generation requires a container agent round-trip (1-3 seconds). For levels 1-2, reference-answer-derived hints are instant and sufficient. For levels 3-5, progressive reveal of the reference answer is pragmatic — full AI scaffolding can be a post-S8 enhancement.
+
+### Session UI changes
+
+Add to each activity card in `/study/session`:
+1. **Hint button:** "Need a hint?" — only shown if scaffolding level >= 1
+2. **Hint display:** Collapsible section below the prompt showing the hint text
+3. **Hint level indicator:** Small badge showing the scaffolding level (e.g., "Scaffolding: L2")
+
+### Completion recording
+
+Modify three files to wire scaffolding level through the completion flow:
+1. **`dashboard/src/lib/study-db.ts`:** Add `scaffoldingLevel?: number` to the `CompleteActivityInput` interface (~line 258). In the `completeActivity()` function (~line 299), pass `scaffolding_level: input.scaffoldingLevel ?? 0` to the `activity_log` insert.
+2. **`dashboard/src/app/api/study/complete/route.ts`:** Accept `scaffoldingLevel` from the request body and pass it to `processCompletion()`.
+3. **`dashboard/src/app/study/session/page.tsx`:** Include the current scaffolding level in the completion POST request body.
+
+Dashboard schema column: `activity_log.scaffolding_level` (integer, default 0) — already exists, just not wired.
+
+- [ ] **Step 1:** Create `dashboard/src/lib/scaffolding.ts` with `computeScaffoldingLevel()`
+- [ ] **Step 2:** Write tests for scaffolding computation in `dashboard/src/lib/__tests__/scaffolding.test.ts`
+- [ ] **Step 3:** Run `cd dashboard && npm test` — verify pass
+- [ ] **Step 4:** Modify session API to include scaffolding levels per activity
+- [ ] **Step 5:** Add hint button and display to session page
+- [ ] **Step 6:** Modify complete API to record scaffolding level
+- [ ] **Step 7:** Run `cd dashboard && npm run build` — verify clean
+- [ ] **Step 8:** Run `npm test` (root) — no regressions
+- [ ] **Step 9:** Commit: `feat(dashboard): add adaptive scaffolding hint system with rolling success targeting (S8b.4)`
+
+---
+
+## S8b.5: Verification
+
+**Depends on:** All previous tasks.
+
+- [ ] **Step 1:** Run `npm test` — all pass, no regressions
+- [ ] **Step 2:** Run `cd dashboard && npm run build` — clean
+- [ ] **Step 3:** Run `npm run build` (root) — clean
+- [ ] **Step 4:** Start dashboard dev server and main process
+- [ ] **Step 5:** Verify `/study/session` shows hint buttons when scaffolding level > 0
+- [ ] **Step 6:** Verify student suggestion prompt appears after low/high quality completions
+- [ ] **Step 7:** Verify `src/study/audio.ts` exists and exports `generateAudioScript` and `synthesizeAudio`
+- [ ] **Step 8:** Verify `study_audio_script` IPC handler exists in `src/ipc.ts`
+- [ ] **Step 9:** Verify `groups/study-generator/CLAUDE.md` includes audio script section
+- [ ] **Step 10:** Verify `groups/telegram_main/CLAUDE.md` includes audio delivery section
+- [ ] **Step 11:** Verify all new files use correct import conventions
+- [ ] **Step 12:** Commit: `chore(study): verify S8b audio + student activities + scaffolding end-to-end (S8b.5)`
+
+---
+
+## Acceptance Criteria
+
+From master plan S8 (non-negotiable):
+
+**Audio (S8.3, S8.4):**
+- [ ] `src/study/audio.ts` exports `generateAudioScript()` and `synthesizeAudio()`
+- [ ] Audio scripts generated via generator agent with IPC
+- [ ] TTS synthesis calls Mistral (or OpenAI fallback) API and writes mp3 to `data/audio/`
+- [ ] `study_audio_script` IPC handler validates and triggers TTS
+- [ ] Generator CLAUDE.md includes audio script generation instructions
+- [ ] Scheduled audio primer task registered at 06:00 daily
+- [ ] Mr. Rogers CLAUDE.md includes audio delivery instructions
+
+**Student Activities (S8.5):**
+- [ ] Session page prompts student to create activities after quality 0-2 or 5
+- [ ] Suggestion form accepts activity type, prompt, bloom level
+- [ ] Form submission writes IPC file for `study_suggest_activity` handler
+- [ ] Created activities have `author = 'student'` and are scheduled for today
+
+**Scaffolding (S8.6):**
+- [ ] `computeScaffoldingLevel()` targets 70-85% success rate from rolling 10-attempt window
+- [ ] Session API includes scaffolding level per activity
+- [ ] Hint button shown when scaffolding level >= 1
+- [ ] Hints derived from reference answer (levels 1-2: truncated; levels 3-5: progressive reveal)
+- [ ] Scaffolding level recorded in `activity_log.scaffolding_level` on completion
+- [ ] Scaffolding computation has unit tests
+
+**General:**
+- [ ] All existing tests pass (`npm test`)
+- [ ] Dashboard builds cleanly (`cd dashboard && npm run build`)
+- [ ] No regressions in existing dashboard pages or study session flow

--- a/groups/study-generator/CLAUDE.md
+++ b/groups/study-generator/CLAUDE.md
@@ -489,3 +489,28 @@ Follow this sequence when generating activities:
 5. Exit after writing the file.
 
 The IPC watcher on the host will pick up the file automatically. Your job is complete when the file is written.
+
+---
+
+## Audio Script Generation
+
+When the prompt requests audio script generation, produce a conversational narrative script suitable for text-to-speech.
+
+Guidelines:
+- Write in natural spoken language — no markdown, no bullet points, no headers
+- Use transitions between concepts: "Now let's turn to...", "Building on that idea..."
+- Include emphasis cues: pauses (use "..."), rhetorical questions, summarizing restatements
+- Target word count: ~150 words per minute of desired duration
+- For review primers: focus on key definitions and relationships, quick pace
+- For summaries: explain concepts and connections, moderate pace
+- For weekly digests: synthesize the week's themes, slower reflective pace
+
+Output the script via study_audio_script IPC:
+```json
+{
+  "type": "study_audio_script",
+  "conceptIds": ["concept-id-1", "concept-id-2"],
+  "script": "Welcome back. Today we're going to review...",
+  "contentType": "review_primer"
+}
+```

--- a/groups/telegram_main/CLAUDE.md
+++ b/groups/telegram_main/CLAUDE.md
@@ -452,6 +452,26 @@ When mentioning new pending concepts in the morning message, direct Simon to the
 
 For "why does X work?" style questions: look up in vault via RAG, provide a concise explanation, and mention the current Bloom's level if the concept is in the study system.
 
+*Audio/Podcast Delivery*
+
+Audio files are stored at /workspace/project/data/audio/ as .mp3 files.
+
+*Scheduled delivery (06:00 daily):*
+The audio primer task generates review scripts for today's due concepts. If a recent audio file exists, send it with a brief intro message.
+
+*On-demand generation:*
+When Simon asks for a podcast or audio summary about a topic:
+• Identify the relevant concept IDs from the database
+• Write a conversational script (~150 words per minute of desired length)
+• Output via IPC: echo '{"type":"study_audio_script","conceptIds":[...],"script":"...","contentType":"summary"}' > /workspace/ipc/tasks/audio_$(date +%s).json
+• Wait briefly, then check /workspace/project/data/audio/ for new files
+• Send the audio file to the chat
+
+Content types:
+• review_primer — quick recap of key points (2-3 min)
+• summary — overview of concept relationships (5-10 min)
+• weekly_digest — synthesis of the week's learning (10-15 min)
+
 *Constraints*
 
 • Do NOT create study plans via Telegram — that is a dashboard feature

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -41,6 +41,7 @@ import {
   computeOverallMastery,
 } from './study/mastery.js';
 import { RegisteredGroup } from './types.js';
+import { synthesizeAudio } from './study/audio.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -332,6 +333,9 @@ export async function processTaskIpc(
     // For study_session
     limit?: number;
     preferredTypes?: string[];
+    // For study_audio_script
+    conceptIds?: string[];
+    contentType?: string;
   },
   sourceGroup: string, // Verified identity from IPC directory
   isMain: boolean, // Verified from directory path
@@ -751,6 +755,59 @@ export async function processTaskIpc(
         logger.error(
           { err, conceptId: data.conceptId, bloomLevel },
           'study_generation_request: generateActivities threw',
+        );
+      }
+      break;
+    }
+
+    case 'study_audio_script': {
+      if (!Array.isArray(data.conceptIds) || data.conceptIds.length === 0) {
+        logger.error(
+          { sourceGroup },
+          'study_audio_script: missing or empty conceptIds',
+        );
+        break;
+      }
+      if (!data.script || typeof data.script !== 'string') {
+        logger.error(
+          { sourceGroup },
+          'study_audio_script: missing script',
+        );
+        break;
+      }
+      const validContentTypes = ['summary', 'review_primer', 'weekly_digest'];
+      const contentType =
+        data.contentType != null && validContentTypes.includes(data.contentType)
+          ? data.contentType
+          : 'summary';
+
+      const audioDir = path.join(DATA_DIR, 'audio');
+      fs.mkdirSync(audioDir, { recursive: true });
+      const outputPath = path.join(
+        audioDir,
+        `${contentType}-${Date.now()}.mp3`,
+      );
+
+      try {
+        await synthesizeAudio(data.script, outputPath);
+        const responsesDir = path.join(DATA_DIR, 'ipc', sourceGroup, 'responses');
+        fs.mkdirSync(responsesDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(responsesDir, `audio-${Date.now()}.json`),
+          JSON.stringify({
+            type: 'audio_ready',
+            audioPath: outputPath,
+            contentType,
+          }),
+        );
+        logger.info(
+          { outputPath, contentType },
+          'study_audio_script: TTS synthesis complete',
+        );
+      } catch (err) {
+        logger.error(
+          { err, contentType },
+          'study_audio_script: TTS synthesis failed',
         );
       }
       break;

--- a/src/ipc.ts
+++ b/src/ipc.ts
@@ -769,10 +769,7 @@ export async function processTaskIpc(
         break;
       }
       if (!data.script || typeof data.script !== 'string') {
-        logger.error(
-          { sourceGroup },
-          'study_audio_script: missing script',
-        );
+        logger.error({ sourceGroup }, 'study_audio_script: missing script');
         break;
       }
       const validContentTypes = ['summary', 'review_primer', 'weekly_digest'];
@@ -790,7 +787,12 @@ export async function processTaskIpc(
 
       try {
         await synthesizeAudio(data.script, outputPath);
-        const responsesDir = path.join(DATA_DIR, 'ipc', sourceGroup, 'responses');
+        const responsesDir = path.join(
+          DATA_DIR,
+          'ipc',
+          sourceGroup,
+          'responses',
+        );
         fs.mkdirSync(responsesDir, { recursive: true });
         fs.writeFileSync(
           path.join(responsesDir, `audio-${Date.now()}.json`),

--- a/src/study/audio.test.ts
+++ b/src/study/audio.test.ts
@@ -22,11 +22,14 @@ describe('synthesizeAudio', () => {
   it('writes audio to the correct path and returns it on success', async () => {
     const audioData = new Uint8Array([0x49, 0x44, 0x33]).buffer; // fake MP3 bytes
 
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      arrayBuffer: async () => audioData,
-    }));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => audioData,
+      }),
+    );
 
     const outputPath = path.join(tmpDir, 'test-output.mp3');
     const result = await synthesizeAudio('Hello world', outputPath);
@@ -38,11 +41,14 @@ describe('synthesizeAudio', () => {
   });
 
   it('throws on API failure and does not leave a temp file', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-      ok: false,
-      status: 400,
-      text: async () => 'Bad Request',
-    }));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: async () => 'Bad Request',
+      }),
+    );
 
     const outputPath = path.join(tmpDir, 'fail-output.mp3');
     await expect(synthesizeAudio('test', outputPath)).rejects.toThrow('400');

--- a/src/study/audio.test.ts
+++ b/src/study/audio.test.ts
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { synthesizeAudio } from './audio.js';
+
+describe('synthesizeAudio', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'audio-test-'));
+    process.env.OPENAI_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes audio to the correct path and returns it on success', async () => {
+    const audioData = new Uint8Array([0x49, 0x44, 0x33]).buffer; // fake MP3 bytes
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => audioData,
+    }));
+
+    const outputPath = path.join(tmpDir, 'test-output.mp3');
+    const result = await synthesizeAudio('Hello world', outputPath);
+
+    expect(result).toBe(outputPath);
+    expect(fs.existsSync(outputPath)).toBe(true);
+    const written = fs.readFileSync(outputPath);
+    expect(written).toEqual(Buffer.from(audioData));
+  });
+
+  it('throws on API failure and does not leave a temp file', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => 'Bad Request',
+    }));
+
+    const outputPath = path.join(tmpDir, 'fail-output.mp3');
+    await expect(synthesizeAudio('test', outputPath)).rejects.toThrow('400');
+
+    expect(fs.existsSync(outputPath)).toBe(false);
+    expect(fs.existsSync(outputPath + '.tmp')).toBe(false);
+  });
+
+  it('calls the OpenAI TTS API with the correct arguments', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => new ArrayBuffer(0),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const outputPath = path.join(tmpDir, 'args-check.mp3');
+    await synthesizeAudio('Check me', outputPath);
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe('https://api.openai.com/v1/audio/speech');
+    expect((init.headers as Record<string, string>)['Authorization']).toBe(
+      'Bearer test-key',
+    );
+
+    const body = JSON.parse(init.body as string);
+    expect(body.model).toBe('tts-1');
+    expect(body.input).toBe('Check me');
+    expect(body.voice).toBe('alloy');
+    expect(body.response_format).toBe('mp3');
+  });
+});

--- a/src/study/audio.ts
+++ b/src/study/audio.ts
@@ -1,0 +1,134 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { DATA_DIR } from '../config.js';
+import { logger } from '../logger.js';
+import { getConceptById } from './queries.js';
+
+// ====================================================================
+// Types
+// ====================================================================
+
+export interface AudioScriptOptions {
+  conceptIds: string[];
+  contentType: 'summary' | 'review_primer' | 'weekly_digest';
+  targetDurationMinutes?: number;
+}
+
+// ====================================================================
+// generateAudioScript
+// ====================================================================
+
+export async function generateAudioScript(
+  options: AudioScriptOptions,
+): Promise<void> {
+  const { conceptIds, contentType, targetDurationMinutes = 5 } = options;
+
+  // Fetch concept data for each ID
+  const concepts = conceptIds
+    .map((id) => getConceptById(id))
+    .filter((c): c is NonNullable<ReturnType<typeof getConceptById>> => c != null);
+
+  const conceptSummaries = concepts
+    .map((c) => {
+      const overallMastery = Math.max(
+        c.masteryL1 ?? 0,
+        c.masteryL2 ?? 0,
+        c.masteryL3 ?? 0,
+        c.masteryL4 ?? 0,
+        c.masteryL5 ?? 0,
+        c.masteryL6 ?? 0,
+      );
+      return `- ${c.title} (domain: ${c.domain ?? 'unknown'}, mastery: ${overallMastery.toFixed(2)})`;
+    })
+    .join('\n');
+
+  const prompt = [
+    `Generate a conversational audio script about these concepts for a ${contentType.replace(/_/g, ' ')} of approximately ${targetDurationMinutes} minutes.`,
+    '',
+    'Concepts:',
+    conceptSummaries,
+    '',
+    'Write in natural spoken language suitable for text-to-speech. No markdown, no bullet points, no headers.',
+    'Use smooth transitions between concepts and include rhetorical questions where appropriate.',
+    `Target word count: ~${Math.round(targetDurationMinutes * 150)} words.`,
+  ].join('\n');
+
+  const tasksDir = path.join(
+    DATA_DIR,
+    'ipc',
+    'study-generator',
+    'tasks',
+  );
+  fs.mkdirSync(tasksDir, { recursive: true });
+
+  const taskFile = path.join(tasksDir, `audio_script_${Date.now()}.json`);
+  fs.writeFileSync(
+    taskFile,
+    JSON.stringify({
+      type: 'study_generation_request',
+      promptOverride: true,
+      audioScript: true,
+      conceptIds,
+      contentType,
+      prompt,
+    }),
+  );
+
+  logger.info(
+    { taskFile, conceptIds, contentType },
+    'generateAudioScript: IPC task written',
+  );
+}
+
+// ====================================================================
+// synthesizeAudio
+// ====================================================================
+
+export async function synthesizeAudio(
+  script: string,
+  outputPath: string,
+): Promise<string> {
+  const tempPath = outputPath + '.tmp';
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/audio/speech', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'tts-1',
+        input: script,
+        voice: 'alloy',
+        response_format: 'mp3',
+      }),
+      signal: AbortSignal.timeout(60_000),
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '(unreadable)');
+      throw new Error(
+        `TTS API error ${response.status}: ${body}`,
+      );
+    }
+
+    const audioBuffer = await response.arrayBuffer();
+    fs.writeFileSync(tempPath, Buffer.from(audioBuffer));
+    fs.renameSync(tempPath, outputPath);
+
+    logger.info({ outputPath }, 'synthesizeAudio: audio written');
+    return outputPath;
+  } catch (err) {
+    // Clean up temp file if it exists
+    try {
+      if (fs.existsSync(tempPath)) {
+        fs.unlinkSync(tempPath);
+      }
+    } catch {
+      // ignore cleanup errors
+    }
+    throw err;
+  }
+}

--- a/src/study/audio.ts
+++ b/src/study/audio.ts
@@ -33,15 +33,7 @@ export async function generateAudioScript(
 
   const conceptSummaries = concepts
     .map((c) => {
-      const overallMastery = Math.max(
-        c.masteryL1 ?? 0,
-        c.masteryL2 ?? 0,
-        c.masteryL3 ?? 0,
-        c.masteryL4 ?? 0,
-        c.masteryL5 ?? 0,
-        c.masteryL6 ?? 0,
-      );
-      return `- ${c.title} (domain: ${c.domain ?? 'unknown'}, mastery: ${overallMastery.toFixed(2)})`;
+      return `- ${c.title} (domain: ${c.domain ?? 'unknown'}, mastery: ${(c.masteryOverall ?? 0).toFixed(2)})`;
     })
     .join('\n');
 

--- a/src/study/audio.ts
+++ b/src/study/audio.ts
@@ -27,7 +27,9 @@ export async function generateAudioScript(
   // Fetch concept data for each ID
   const concepts = conceptIds
     .map((id) => getConceptById(id))
-    .filter((c): c is NonNullable<ReturnType<typeof getConceptById>> => c != null);
+    .filter(
+      (c): c is NonNullable<ReturnType<typeof getConceptById>> => c != null,
+    );
 
   const conceptSummaries = concepts
     .map((c) => {
@@ -54,12 +56,7 @@ export async function generateAudioScript(
     `Target word count: ~${Math.round(targetDurationMinutes * 150)} words.`,
   ].join('\n');
 
-  const tasksDir = path.join(
-    DATA_DIR,
-    'ipc',
-    'study-generator',
-    'tasks',
-  );
+  const tasksDir = path.join(DATA_DIR, 'ipc', 'study-generator', 'tasks');
   fs.mkdirSync(tasksDir, { recursive: true });
 
   const taskFile = path.join(tasksDir, `audio_script_${Date.now()}.json`);
@@ -109,9 +106,7 @@ export async function synthesizeAudio(
 
     if (!response.ok) {
       const body = await response.text().catch(() => '(unreadable)');
-      throw new Error(
-        `TTS API error ${response.status}: ${body}`,
-      );
+      throw new Error(`TTS API error ${response.status}: ${body}`);
     }
 
     const audioBuffer = await response.arrayBuffer();

--- a/src/study/queries.test.ts
+++ b/src/study/queries.test.ts
@@ -766,11 +766,35 @@ describe('getPlanProgress', () => {
   it('computes progress for a plan with 3 concepts, 1 at target bloom', () => {
     createStudyPlan(makePlan({ id: 'plan-prog', title: 'Progress Plan' }));
     // concept-a: bloomCeiling=4, targetBloom=3 → at target (4 >= 3)
-    createConcept(makeConcept({ id: 'c-a', title: 'Alpha', domain: 'math', bloomCeiling: 4, status: 'active' }));
+    createConcept(
+      makeConcept({
+        id: 'c-a',
+        title: 'Alpha',
+        domain: 'math',
+        bloomCeiling: 4,
+        status: 'active',
+      }),
+    );
     // concept-b: bloomCeiling=2, targetBloom=3 → not at target (2 < 3)
-    createConcept(makeConcept({ id: 'c-b', title: 'Beta', domain: 'math', bloomCeiling: 2, status: 'active' }));
+    createConcept(
+      makeConcept({
+        id: 'c-b',
+        title: 'Beta',
+        domain: 'math',
+        bloomCeiling: 2,
+        status: 'active',
+      }),
+    );
     // concept-c: bloomCeiling=1, targetBloom=4 → not at target (1 < 4)
-    createConcept(makeConcept({ id: 'c-c', title: 'Gamma', domain: 'physics', bloomCeiling: 1, status: 'active' }));
+    createConcept(
+      makeConcept({
+        id: 'c-c',
+        title: 'Gamma',
+        domain: 'physics',
+        bloomCeiling: 1,
+        status: 'active',
+      }),
+    );
 
     addConceptsToPlan('plan-prog', ['c-a', 'c-b', 'c-c'], 3);
     // Override targetBloom for c-c by adding separately — addConceptsToPlan uses same targetBloom for all,
@@ -789,13 +813,13 @@ describe('getPlanProgress', () => {
     const details = progress!.conceptDetails;
     expect(details).toHaveLength(3);
 
-    const alpha = details.find(d => d.conceptId === 'c-a')!;
+    const alpha = details.find((d) => d.conceptId === 'c-a')!;
     expect(alpha.atTarget).toBe(true);
     expect(alpha.currentBloomCeiling).toBe(4);
     expect(alpha.targetBloom).toBe(3);
     expect(alpha.domain).toBe('math');
 
-    const beta = details.find(d => d.conceptId === 'c-b')!;
+    const beta = details.find((d) => d.conceptId === 'c-b')!;
     expect(beta.atTarget).toBe(false);
     expect(beta.currentBloomCeiling).toBe(2);
   });
@@ -812,8 +836,12 @@ describe('getPlanProgress', () => {
 
   it('returns progressPercent=100 when all concepts are at target', () => {
     createStudyPlan(makePlan({ id: 'plan-full', title: 'Full Plan' }));
-    createConcept(makeConcept({ id: 'c-x', title: 'X', bloomCeiling: 6, status: 'active' }));
-    createConcept(makeConcept({ id: 'c-y', title: 'Y', bloomCeiling: 5, status: 'active' }));
+    createConcept(
+      makeConcept({ id: 'c-x', title: 'X', bloomCeiling: 6, status: 'active' }),
+    );
+    createConcept(
+      makeConcept({ id: 'c-y', title: 'Y', bloomCeiling: 5, status: 'active' }),
+    );
     addConceptsToPlan('plan-full', ['c-x', 'c-y'], 4);
 
     const progress = getPlanProgress('plan-full');
@@ -831,31 +859,37 @@ describe('getActivePlans', () => {
   afterEach(() => _closeDatabase());
 
   it('returns only active plans, ordered by createdAt desc', () => {
-    createStudyPlan(makePlan({
-      id: 'plan-active-1',
-      title: 'Active Old',
-      status: 'active',
-      createdAt: '2026-01-01T00:00:00.000Z',
-      updatedAt: NOW,
-    }));
-    createStudyPlan(makePlan({
-      id: 'plan-active-2',
-      title: 'Active New',
-      status: 'active',
-      createdAt: '2026-04-01T00:00:00.000Z',
-      updatedAt: NOW,
-    }));
-    createStudyPlan(makePlan({
-      id: 'plan-archived',
-      title: 'Archived',
-      status: 'archived',
-      createdAt: '2026-03-01T00:00:00.000Z',
-      updatedAt: NOW,
-    }));
+    createStudyPlan(
+      makePlan({
+        id: 'plan-active-1',
+        title: 'Active Old',
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: NOW,
+      }),
+    );
+    createStudyPlan(
+      makePlan({
+        id: 'plan-active-2',
+        title: 'Active New',
+        status: 'active',
+        createdAt: '2026-04-01T00:00:00.000Z',
+        updatedAt: NOW,
+      }),
+    );
+    createStudyPlan(
+      makePlan({
+        id: 'plan-archived',
+        title: 'Archived',
+        status: 'archived',
+        createdAt: '2026-03-01T00:00:00.000Z',
+        updatedAt: NOW,
+      }),
+    );
 
     const active = getActivePlans();
     expect(active).toHaveLength(2);
-    const ids = active.map(p => p.id);
+    const ids = active.map((p) => p.id);
     expect(ids).toContain('plan-active-1');
     expect(ids).toContain('plan-active-2');
     expect(ids).not.toContain('plan-archived');
@@ -865,7 +899,9 @@ describe('getActivePlans', () => {
   });
 
   it('returns empty array when no active plans exist', () => {
-    createStudyPlan(makePlan({ id: 'plan-arch', status: 'archived', updatedAt: NOW }));
+    createStudyPlan(
+      makePlan({ id: 'plan-arch', status: 'archived', updatedAt: NOW }),
+    );
     const active = getActivePlans();
     expect(active).toHaveLength(0);
   });
@@ -896,7 +932,9 @@ describe('removeConceptFromPlan', () => {
   });
 
   it('is a no-op when the concept is not in the plan', () => {
-    expect(() => removeConceptFromPlan('plan-rm', 'does-not-exist')).not.toThrow();
+    expect(() =>
+      removeConceptFromPlan('plan-rm', 'does-not-exist'),
+    ).not.toThrow();
     const remaining = getPlanConceptIds('plan-rm');
     expect(remaining).toHaveLength(3);
   });

--- a/src/study/queries.ts
+++ b/src/study/queries.ts
@@ -422,12 +422,15 @@ export function getPlanProgress(planId: string): PlanProgress | null {
       targetBloom: schema.studyPlanConcepts.targetBloom,
     })
     .from(schema.studyPlanConcepts)
-    .innerJoin(schema.concepts, eq(schema.studyPlanConcepts.conceptId, schema.concepts.id))
+    .innerJoin(
+      schema.concepts,
+      eq(schema.studyPlanConcepts.conceptId, schema.concepts.id),
+    )
     .where(eq(schema.studyPlanConcepts.planId, planId))
     .orderBy(asc(schema.studyPlanConcepts.sortOrder))
     .all();
 
-  const details: PlanConceptProgress[] = rows.map(r => ({
+  const details: PlanConceptProgress[] = rows.map((r) => ({
     conceptId: r.conceptId,
     conceptTitle: r.conceptTitle,
     domain: r.domain,
@@ -437,13 +440,14 @@ export function getPlanProgress(planId: string): PlanProgress | null {
     atTarget: (r.bloomCeiling ?? 0) >= (r.targetBloom ?? 6),
   }));
 
-  const atTarget = details.filter(d => d.atTarget).length;
+  const atTarget = details.filter((d) => d.atTarget).length;
 
   return {
     planId,
     totalConcepts: details.length,
     conceptsAtTarget: atTarget,
-    progressPercent: details.length > 0 ? Math.round((atTarget / details.length) * 100) : 0,
+    progressPercent:
+      details.length > 0 ? Math.round((atTarget / details.length) * 100) : 0,
     conceptDetails: details,
   };
 }
@@ -475,7 +479,7 @@ export function getPlanConceptIds(planId: string): string[] {
     .from(schema.studyPlanConcepts)
     .where(eq(schema.studyPlanConcepts.planId, planId))
     .all()
-    .map(r => r.conceptId);
+    .map((r) => r.conceptId);
 }
 
 // ====================================================================

--- a/src/study/scheduled.test.ts
+++ b/src/study/scheduled.test.ts
@@ -18,22 +18,23 @@ describe('registerStudyScheduledTasks', () => {
     _closeDatabase();
   });
 
-  it('creates 4 tasks', () => {
+  it('creates 5 tasks', () => {
     registerStudyScheduledTasks(TEST_JID);
     const tasks = getAllTasks();
-    expect(tasks).toHaveLength(4);
+    expect(tasks).toHaveLength(5);
     const ids = tasks.map((t) => t.id);
     expect(ids).toContain('study-daily-morning');
     expect(ids).toContain('study-weekly-progress');
     expect(ids).toContain('study-monthly-mastery');
     expect(ids).toContain('study-sqlite-backup');
+    expect(ids).toContain('study-audio-primer');
   });
 
-  it('is idempotent — calling twice still yields only 4 tasks', () => {
+  it('is idempotent — calling twice still yields only 5 tasks', () => {
     registerStudyScheduledTasks(TEST_JID);
     registerStudyScheduledTasks(TEST_JID);
     const tasks = getAllTasks();
-    expect(tasks).toHaveLength(4);
+    expect(tasks).toHaveLength(5);
   });
 
   it('tasks have correct cron patterns', () => {
@@ -50,6 +51,9 @@ describe('registerStudyScheduledTasks', () => {
 
     const backup = getTaskById('study-sqlite-backup');
     expect(backup?.schedule_value).toBe('0 3 * * *');
+
+    const audioPrimer = getTaskById('study-audio-primer');
+    expect(audioPrimer?.schedule_value).toBe('0 6 * * *');
   });
 
   it('tasks have valid future next_run', () => {
@@ -65,13 +69,14 @@ describe('registerStudyScheduledTasks', () => {
 });
 
 describe('getStudyTaskDefinitions', () => {
-  it('returns 4 definitions with correct IDs', () => {
+  it('returns 5 definitions with correct IDs', () => {
     const defs = getStudyTaskDefinitions(TEST_JID);
-    expect(defs).toHaveLength(4);
+    expect(defs).toHaveLength(5);
     const ids = defs.map((d) => d.id);
     expect(ids).toContain('study-daily-morning');
     expect(ids).toContain('study-weekly-progress');
     expect(ids).toContain('study-monthly-mastery');
     expect(ids).toContain('study-sqlite-backup');
+    expect(ids).toContain('study-audio-primer');
   });
 });

--- a/src/study/scheduled.ts
+++ b/src/study/scheduled.ts
@@ -49,6 +49,26 @@ Query the study database at /workspace/project/store/messages.db for a comprehen
 
 Write a monthly mastery report (8–12 lines, Telegram formatting). Cover: highest mastery concepts, areas of decay risk, overall growth trend, and a recommended focus area for the coming month.`;
 
+export const AUDIO_PRIMER_PROMPT = `You are Mr. Rogers, a personal university teaching assistant. This is the daily audio review primer task (06:00).
+
+1. Check if there are due activities today:
+   SELECT count(*) FROM learning_activities WHERE due_at <= date('now')
+
+2. If there are 3+ due activities, generate a brief audio review primer:
+   - Get the titles and domains of concepts with due activities:
+     SELECT DISTINCT c.title, c.domain FROM concepts c
+     JOIN learning_activities la ON la.concept_id = c.id
+     WHERE la.due_at <= date('now') AND c.status = 'active'
+   - Write a 2-3 minute conversational audio script covering the key points
+   - Output via study_audio_script IPC:
+     echo '{"type":"study_audio_script","conceptIds":["<id1>","<id2>"],"script":"<your script>","contentType":"review_primer"}' > /workspace/ipc/tasks/audio_primer_$(date +%s).json
+
+3. If there are fewer than 3 due activities, skip audio generation.
+
+4. If an audio file was recently generated (check /workspace/project/data/audio/ for files from today), send it to the chat with a brief message like "Here is a quick audio review of today's concepts. Listen while you get ready!"
+
+Keep any text messages concise. Use Telegram formatting (*bold*, no ## headings).`;
+
 // ============================================================
 // Task definition type
 // ============================================================
@@ -88,6 +108,13 @@ export function getStudyTaskDefinitions(
       id: 'study-monthly-mastery',
       prompt: MONTHLY_MASTERY_PROMPT,
       cronExpression: '0 10 1 * *',
+      groupFolder: 'telegram_main',
+      chatJid: mainChatJid,
+    },
+    {
+      id: 'study-audio-primer',
+      prompt: AUDIO_PRIMER_PROMPT,
+      cronExpression: '0 6 * * *',
       groupFolder: 'telegram_main',
       chatJid: mainChatJid,
     },

--- a/src/study/session-builder.test.ts
+++ b/src/study/session-builder.test.ts
@@ -566,19 +566,40 @@ describe('buildDailySession', () => {
     const TODAY_DATE = '2026-04-15';
 
     // Concepts A, B, C with due activities
-    createConcept(makeConcept({ id: 'p-ca', title: 'Plan A', bloomCeiling: 2 }));
-    createConcept(makeConcept({ id: 'p-cb', title: 'Plan B', bloomCeiling: 2 }));
-    createConcept(makeConcept({ id: 'p-cc', title: 'Non-Plan C', bloomCeiling: 2 }));
+    createConcept(
+      makeConcept({ id: 'p-ca', title: 'Plan A', bloomCeiling: 2 }),
+    );
+    createConcept(
+      makeConcept({ id: 'p-cb', title: 'Plan B', bloomCeiling: 2 }),
+    );
+    createConcept(
+      makeConcept({ id: 'p-cc', title: 'Non-Plan C', bloomCeiling: 2 }),
+    );
 
     for (let i = 1; i <= 3; i++) {
       createActivity(
-        makeActivity({ id: `pa-${i}`, conceptId: 'p-ca', bloomLevel: 3, activityType: 'elaboration' }),
+        makeActivity({
+          id: `pa-${i}`,
+          conceptId: 'p-ca',
+          bloomLevel: 3,
+          activityType: 'elaboration',
+        }),
       );
       createActivity(
-        makeActivity({ id: `pb-${i}`, conceptId: 'p-cb', bloomLevel: 3, activityType: 'elaboration' }),
+        makeActivity({
+          id: `pb-${i}`,
+          conceptId: 'p-cb',
+          bloomLevel: 3,
+          activityType: 'elaboration',
+        }),
       );
       createActivity(
-        makeActivity({ id: `pc-${i}`, conceptId: 'p-cc', bloomLevel: 3, activityType: 'elaboration' }),
+        makeActivity({
+          id: `pc-${i}`,
+          conceptId: 'p-cc',
+          bloomLevel: 3,
+          activityType: 'elaboration',
+        }),
       );
     }
 
@@ -614,8 +635,12 @@ describe('buildDailySession', () => {
     const NOW_TS = '2026-04-15T12:00:00.000Z';
 
     // Some activities exist in the DB
-    createConcept(makeConcept({ id: 'ep-c1', title: 'Existing', bloomCeiling: 2 }));
-    createActivity(makeActivity({ id: 'ep-a1', conceptId: 'ep-c1', bloomLevel: 3 }));
+    createConcept(
+      makeConcept({ id: 'ep-c1', title: 'Existing', bloomCeiling: 2 }),
+    );
+    createActivity(
+      makeActivity({ id: 'ep-a1', conceptId: 'ep-c1', bloomLevel: 3 }),
+    );
 
     // Plan with no concepts added
     const plan: NewStudyPlan = {
@@ -643,9 +668,15 @@ describe('buildDailySession', () => {
     createConcept(makeConcept({ id: 'rg-c3', title: 'C3', bloomCeiling: 2 }));
 
     for (let i = 1; i <= 2; i++) {
-      createActivity(makeActivity({ id: `rg-c1-${i}`, conceptId: 'rg-c1', bloomLevel: 3 }));
-      createActivity(makeActivity({ id: `rg-c2-${i}`, conceptId: 'rg-c2', bloomLevel: 3 }));
-      createActivity(makeActivity({ id: `rg-c3-${i}`, conceptId: 'rg-c3', bloomLevel: 3 }));
+      createActivity(
+        makeActivity({ id: `rg-c1-${i}`, conceptId: 'rg-c1', bloomLevel: 3 }),
+      );
+      createActivity(
+        makeActivity({ id: `rg-c2-${i}`, conceptId: 'rg-c2', bloomLevel: 3 }),
+      );
+      createActivity(
+        makeActivity({ id: `rg-c3-${i}`, conceptId: 'rg-c3', bloomLevel: 3 }),
+      );
     }
 
     const result = await buildDailySession();


### PR DESCRIPTION
## Summary

Final sprint (S8) of the multi-method study system. Split into two sub-sprints:

**S8a: Analytics + Concept Detail + Polish**
- Analytics API (`GET /api/study/stats`) with retention rate, Bloom's distribution, method effectiveness, activity time series, calibration score
- Analytics section on `/study` overview page with summary cards, stacked Bloom's bar, method effectiveness, and period toggle (7d/30d/all)
- Concept detail page (`/study/concepts/[id]`) with 6-level mastery bars, activity history, method effectiveness, related concepts, prerequisites
- Prerequisite awareness warnings in study sessions (advisory, non-blocking)
- Staleness detection via file mtime comparison (source modified/deleted badges)

**S8b: Audio + Student Activities + Scaffolding**
- Audio/podcast pipeline: script generation via generator agent + OpenAI TTS synthesis (`src/study/audio.ts`)
- `study_audio_script` IPC handler for TTS synthesis + audio file management
- Telegram podcast delivery: daily 06:00 audio primer scheduled task + Mr. Rogers CLAUDE.md integration
- Student-generated activity prompting: post-completion quality-triggered suggestion form (quality 0-2 or 5)
- Adaptive scaffolding hint system: rolling 10-attempt success rate targeting 70-85% ZPD, progressive reference answer reveal

**S8.9 (monthly scheduled task)** was already implemented in S7.

870 tests passing (+27 new). 26 files changed, ~3500 lines added.

## Test plan

- [x] `npm test` — 870/871 pass (1 pre-existing failure in claw-skill.test.ts)
- [x] `npm run build` — clean
- [x] `cd dashboard && npm run build` — clean (30/30 pages)
- [ ] Start dashboard, verify `/study` analytics section renders
- [ ] Click concept title → verify detail page loads with mastery bars
- [ ] Start study session → verify prerequisite/staleness warnings appear when applicable
- [ ] Complete activity with quality 0-2 → verify student suggestion prompt
- [ ] Complete activity → verify scaffolding hints shown when level >= 1
- [ ] Verify `data/audio/` directory created by audio pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)