### PR TITLE
feat(study): concept-focused practice + working generation trigger

### DIFF
--- a/dashboard/src/app/api/study/generate/route.ts
+++ b/dashboard/src/app/api/study/generate/route.ts
@@ -1,0 +1,24 @@
+import { requestGeneration } from '@/lib/generation-trigger';
+
+export async function POST(request: Request) {
+  try {
+    const { conceptId, bloomLevel } = (await request.json()) as {
+      conceptId?: string;
+      bloomLevel?: number;
+    };
+
+    if (!conceptId) {
+      return Response.json({ error: 'Missing conceptId' }, { status: 400 });
+    }
+
+    const level = typeof bloomLevel === 'number' && bloomLevel >= 1 && bloomLevel <= 6
+      ? bloomLevel
+      : 1;
+
+    requestGeneration(conceptId, level);
+
+    return Response.json({ success: true, conceptId, bloomLevel: level });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/study/generate/route.ts
+++ b/dashboard/src/app/api/study/generate/route.ts
@@ -1,4 +1,5 @@
 import { requestGeneration } from '@/lib/generation-trigger';
+import { getConceptDetail } from '@/lib/study-db';
 
 export async function POST(request: Request) {
   try {
@@ -7,18 +8,27 @@ export async function POST(request: Request) {
       bloomLevel?: number;
     };
 
-    if (!conceptId) {
+    if (!conceptId || typeof conceptId !== 'string') {
       return Response.json({ error: 'Missing conceptId' }, { status: 400 });
     }
 
-    const level = typeof bloomLevel === 'number' && bloomLevel >= 1 && bloomLevel <= 6
-      ? bloomLevel
-      : 1;
+    const concept = getConceptDetail(conceptId);
+    if (!concept) {
+      return Response.json({ error: 'Concept not found' }, { status: 404 });
+    }
+
+    // Default to the concept's current ceiling so generic callers still
+    // target the right difficulty. Explicit override wins when valid.
+    const level =
+      typeof bloomLevel === 'number' && bloomLevel >= 1 && bloomLevel <= 6
+        ? bloomLevel
+        : Math.max(1, concept.bloomCeiling || 1);
 
     requestGeneration(conceptId, level);
 
     return Response.json({ success: true, conceptId, bloomLevel: level });
   } catch (err) {
-    return Response.json({ error: String(err) }, { status: 500 });
+    console.error('POST /api/study/generate failed:', err);
+    return Response.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/dashboard/src/app/api/study/session/route.ts
+++ b/dashboard/src/app/api/study/session/route.ts
@@ -13,7 +13,8 @@ export async function GET(request: Request) {
   try {
     const url = new URL(request.url);
     const planId = url.searchParams.get('planId') ?? undefined;
-    const composition = buildSessionComposition({ planId });
+    const conceptId = url.searchParams.get('conceptId') ?? undefined;
+    const composition = buildSessionComposition({ planId, conceptId });
     const enrichedBlocks = composition.blocks.map((block) => ({
       ...block,
       activities: block.activities

--- a/dashboard/src/app/study/concepts/[id]/page.tsx
+++ b/dashboard/src/app/study/concepts/[id]/page.tsx
@@ -128,7 +128,7 @@ export default function ConceptDetailPage({
       if (res.ok) {
         setGenerateMsg('Generation requested — activities will appear shortly.');
       } else {
-        const data = await res.json();
+        const data = (await res.json()) as { error?: string };
         setGenerateMsg(`Error: ${data.error ?? 'Unknown error'}`);
       }
     } catch {

--- a/dashboard/src/app/study/concepts/[id]/page.tsx
+++ b/dashboard/src/app/study/concepts/[id]/page.tsx
@@ -14,6 +14,30 @@ const BLOOM_LABELS: Record<number, string> = {
   6: 'Create',
 };
 
+const TYPE_DISPLAY: Record<string, { label: string; color: string }> = {
+  card_review: { label: 'Card', color: 'bg-blue-500/20 text-blue-300 border-blue-500/30' },
+  elaboration: { label: 'Elaboration', color: 'bg-amber-500/20 text-amber-300 border-amber-500/30' },
+  self_explain: { label: 'Self-explain', color: 'bg-purple-500/20 text-purple-300 border-purple-500/30' },
+  concept_map: { label: 'Concept map', color: 'bg-teal-500/20 text-teal-300 border-teal-500/30' },
+  comparison: { label: 'Comparison', color: 'bg-pink-500/20 text-pink-300 border-pink-500/30' },
+  case_analysis: { label: 'Case analysis', color: 'bg-orange-500/20 text-orange-300 border-orange-500/30' },
+  synthesis: { label: 'Synthesis', color: 'bg-emerald-500/20 text-emerald-300 border-emerald-500/30' },
+  socratic: { label: 'Socratic', color: 'bg-indigo-500/20 text-indigo-300 border-indigo-500/30' },
+};
+
+const CARD_TYPE_LABEL: Record<string, string> = {
+  basic: 'Basic',
+  cloze: 'Cloze',
+  reversed: 'Reversed',
+};
+
+const STATE_STYLES: Record<string, string> = {
+  mastered: 'bg-green-500/20 text-green-300 border-green-500/30',
+  reviewing: 'bg-blue-500/20 text-blue-300 border-blue-500/30',
+  learning: 'bg-yellow-500/20 text-yellow-300 border-yellow-500/30',
+  new: 'bg-gray-500/15 text-gray-400 border-gray-500/20',
+};
+
 function MasteryBar({ value, label }: { value: number; label: string }) {
   const pct = Math.min(100, Math.round((value / MASTERY_THRESHOLD) * 100));
   const colorClass =
@@ -73,6 +97,8 @@ export default function ConceptDetailPage({
   const [concept, setConcept] = useState<ConceptDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [generating, setGenerating] = useState(false);
+  const [generateMsg, setGenerateMsg] = useState<string | null>(null);
 
   useEffect(() => {
     fetch(`/api/study/concepts/${encodeURIComponent(id)}`)
@@ -87,6 +113,30 @@ export default function ConceptDetailPage({
       .catch((err: unknown) => setError(String(err)))
       .finally(() => setLoading(false));
   }, [id]);
+
+  const handleGenerate = async () => {
+    if (!concept || generating) return;
+    setGenerating(true);
+    setGenerateMsg(null);
+    try {
+      const bloomLevel = Math.max(1, concept.bloomCeiling || 1);
+      const res = await fetch('/api/study/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ conceptId: concept.id, bloomLevel }),
+      });
+      if (res.ok) {
+        setGenerateMsg('Generation requested — activities will appear shortly.');
+      } else {
+        const data = await res.json();
+        setGenerateMsg(`Error: ${data.error ?? 'Unknown error'}`);
+      }
+    } catch {
+      setGenerateMsg('Failed to request generation.');
+    } finally {
+      setGenerating(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -184,58 +234,78 @@ export default function ConceptDetailPage({
             Activities
             <span className="ml-2 text-gray-600 normal-case font-normal">({concept.totalActivities})</span>
           </h3>
-          <button
-            onClick={() => alert('Generation requested')}
-            className="px-3 py-1.5 rounded-md bg-blue-700 hover:bg-blue-600 text-white text-xs font-medium transition-colors"
-          >
-            Generate more
-          </button>
+          <div className="flex gap-2">
+            {concept.activities.length > 0 && (
+              <a
+                href={`/study/session?conceptId=${encodeURIComponent(concept.id)}`}
+                className="px-3 py-1.5 rounded-md bg-green-700 hover:bg-green-600 text-white text-xs font-medium transition-colors"
+              >
+                Practice ({concept.activities.length})
+              </a>
+            )}
+            <button
+              onClick={handleGenerate}
+              disabled={generating}
+              className="px-3 py-1.5 rounded-md bg-blue-700 hover:bg-blue-600 disabled:opacity-50 text-white text-xs font-medium transition-colors"
+            >
+              {generating ? 'Requesting...' : 'Generate more'}
+            </button>
+          </div>
         </div>
+        {generateMsg && (
+          <p className={`text-xs ${generateMsg.startsWith('Error') || generateMsg.startsWith('Failed') ? 'text-red-400' : 'text-green-400'}`}>
+            {generateMsg}
+          </p>
+        )}
         {concept.activities.length === 0 ? (
           <div className="rounded-lg border border-gray-800 bg-gray-900 p-5 text-center">
             <p className="text-sm text-gray-500">No activities generated yet.</p>
           </div>
         ) : (
-          <div className="rounded-lg border border-gray-800 overflow-hidden">
-            <table className="w-full text-sm">
-              <thead className="bg-gray-900 border-b border-gray-800">
-                <tr>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider">Type</th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-20">Bloom</th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-32">Due</th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-28">State</th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-gray-400 uppercase tracking-wider w-24">Author</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-800 bg-gray-950">
-                {concept.activities.map((activity) => (
-                  <tr key={activity.id} className="hover:bg-gray-900 transition-colors">
-                    <td className="px-4 py-3 text-gray-200">{activity.activityType}</td>
-                    <td className="px-4 py-3 text-gray-400">
-                      L{activity.bloomLevel}
-                      {BLOOM_LABELS[activity.bloomLevel] && (
-                        <span className="ml-1 text-gray-600 text-xs">{BLOOM_LABELS[activity.bloomLevel]}</span>
-                      )}
-                    </td>
-                    <td className="px-4 py-3 text-gray-400 text-xs">{formatDate(activity.dueAt)}</td>
-                    <td className="px-4 py-3">
-                      <span
-                        className={`text-xs px-1.5 py-0.5 rounded ${
-                          activity.masteryState === 'mastered'
-                            ? 'bg-green-900 text-green-300'
-                            : activity.masteryState === 'reviewing'
-                              ? 'bg-blue-900 text-blue-300'
-                              : 'bg-gray-800 text-gray-400'
-                        }`}
-                      >
-                        {activity.masteryState}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-gray-500 text-xs">{activity.author}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <div className="grid gap-2">
+            {concept.activities.map((activity) => {
+              const typeInfo = TYPE_DISPLAY[activity.activityType] ?? {
+                label: activity.activityType,
+                color: 'bg-gray-500/15 text-gray-400 border-gray-500/20',
+              };
+              const stateStyle = STATE_STYLES[activity.masteryState] ?? STATE_STYLES.new;
+              const isDue = new Date(activity.dueAt) <= new Date();
+
+              return (
+                <div
+                  key={activity.id}
+                  className="rounded-lg border border-gray-800 bg-gray-900 hover:bg-gray-900/80 transition-colors px-4 py-3"
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm text-gray-200 leading-relaxed">
+                        {activity.prompt}
+                      </p>
+                      <div className="mt-2 flex flex-wrap items-center gap-2">
+                        <span className={`inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded border ${typeInfo.color}`}>
+                          {typeInfo.label}
+                          {activity.cardType && CARD_TYPE_LABEL[activity.cardType] && (
+                            <span className="opacity-70">· {CARD_TYPE_LABEL[activity.cardType]}</span>
+                          )}
+                        </span>
+                        <span className="text-[11px] text-gray-500">
+                          L{activity.bloomLevel} {BLOOM_LABELS[activity.bloomLevel] ?? ''}
+                        </span>
+                        <span className={`text-[11px] font-medium px-1.5 py-0.5 rounded border ${stateStyle}`}>
+                          {activity.masteryState}
+                        </span>
+                        {isDue && activity.masteryState !== 'mastered' && (
+                          <span className="text-[11px] text-amber-400">Due</span>
+                        )}
+                        <span className="text-[11px] text-gray-600 ml-auto shrink-0">
+                          {formatDate(activity.dueAt)}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
           </div>
         )}
       </section>
@@ -263,7 +333,11 @@ export default function ConceptDetailPage({
                 {concept.recentLogs.map((log) => (
                   <tr key={log.id} className="hover:bg-gray-900 transition-colors">
                     <td className="px-4 py-3 text-gray-400 text-xs">{formatDate(log.reviewedAt)}</td>
-                    <td className="px-4 py-3 text-gray-200">{log.activityType}</td>
+                    <td className="px-4 py-3">
+                      <span className={`text-[11px] font-medium px-1.5 py-0.5 rounded border ${(TYPE_DISPLAY[log.activityType] ?? { color: 'bg-gray-500/15 text-gray-400 border-gray-500/20' }).color}`}>
+                        {(TYPE_DISPLAY[log.activityType] ?? { label: log.activityType }).label}
+                      </span>
+                    </td>
                     <td className="px-4 py-3 text-gray-400 text-xs">L{log.bloomLevel}</td>
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-2">
@@ -293,7 +367,9 @@ export default function ConceptDetailPage({
               const pct = Math.round((method.avgQuality / maxMethodQuality) * 100);
               return (
                 <div key={method.activityType} className="flex items-center gap-3">
-                  <span className="w-36 text-xs text-gray-400 shrink-0 truncate">{method.activityType}</span>
+                  <span className={`w-36 shrink-0 text-[11px] font-medium px-1.5 py-0.5 rounded border text-center ${(TYPE_DISPLAY[method.activityType] ?? { color: 'bg-gray-500/15 text-gray-400 border-gray-500/20' }).color}`}>
+                    {(TYPE_DISPLAY[method.activityType] ?? { label: method.activityType }).label}
+                  </span>
                   <div className="flex-1 h-2.5 rounded-full bg-gray-800 overflow-hidden">
                     <div
                       className="h-full rounded-full bg-blue-500 transition-all"

--- a/dashboard/src/app/study/session/page.tsx
+++ b/dashboard/src/app/study/session/page.tsx
@@ -204,6 +204,7 @@ function isAiEvalEligible(bloomLevel: number, activityType: string): boolean {
 function StudySessionInner() {
   const searchParams = useSearchParams();
   const planId = searchParams.get('planId');
+  const conceptId = searchParams.get('conceptId');
 
   const [phase, setPhase] = useState<Phase>('loading');
   const [sessionData, setSessionData] = useState<SessionData | null>(null);
@@ -308,7 +309,10 @@ function StudySessionInner() {
 
   useEffect(() => {
     if (phase !== 'loading') return;
-    const url = planId ? `/api/study/session?planId=${planId}` : '/api/study/session';
+    const params = new URLSearchParams();
+    if (planId) params.set('planId', planId);
+    if (conceptId) params.set('conceptId', conceptId);
+    const url = params.size > 0 ? `/api/study/session?${params}` : '/api/study/session';
     fetch(url)
       .then((r) => r.json())
       .then((data: { session?: SessionData; warnings?: SessionWarnings; error?: string }) => {
@@ -344,7 +348,7 @@ function StudySessionInner() {
       .catch((err: unknown) => {
         setLoadError(String(err));
       });
-  }, [phase, planId]);
+  }, [phase, planId, conceptId]);
 
   // ---------------------------------------------------------------------------
   // PRE_SESSION: begin session

--- a/dashboard/src/lib/generation-trigger.ts
+++ b/dashboard/src/lib/generation-trigger.ts
@@ -7,6 +7,12 @@ function ipcTaskDir(): string {
   return path.join(projectRoot, 'data', 'ipc', 'study-generator', 'tasks');
 }
 
+// IDs are interpolated into filenames, so anything outside a safe charset
+// must be stripped to prevent path traversal (../, /, etc.).
+function safeIdSegment(id: string): string {
+  return id.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64) || 'unknown';
+}
+
 function uniqueFilename(prefix: string): string {
   const ts = Date.now();
   const rand = Math.random().toString(36).slice(2, 8);
@@ -17,7 +23,7 @@ export function requestGeneration(conceptId: string, bloomLevel: number): void {
   const dir = ipcTaskDir();
   fs.mkdirSync(dir, { recursive: true });
   const payload = { type: 'study_generation_request', conceptId, bloomLevel };
-  const filename = uniqueFilename(`study_generation_request-${conceptId}`);
+  const filename = uniqueFilename(`study_generation_request-${safeIdSegment(conceptId)}`);
   fs.writeFileSync(path.join(dir, filename), JSON.stringify(payload));
 }
 
@@ -25,6 +31,6 @@ export function requestPostSessionGeneration(sessionId: string): void {
   const dir = ipcTaskDir();
   fs.mkdirSync(dir, { recursive: true });
   const payload = { type: 'study_post_session_generation', sessionId };
-  const filename = uniqueFilename(`study_post_session_generation-${sessionId}`);
+  const filename = uniqueFilename(`study_post_session_generation-${safeIdSegment(sessionId)}`);
   fs.writeFileSync(path.join(dir, filename), JSON.stringify(payload));
 }

--- a/dashboard/src/lib/session-builder.ts
+++ b/dashboard/src/lib/session-builder.ts
@@ -5,7 +5,7 @@
  * new-material / review / stretch block layout from spec Section 4.5.
  */
 
-import { getDueActivities, getActiveConcepts, getPlanConceptIds } from './study-db';
+import { getDueActivities, getActiveConcepts, getPlanConceptIds, getActivitiesByConceptId } from './study-db';
 import type { ConceptSummary } from './study-db';
 
 // ---------------------------------------------------------------------------
@@ -37,6 +37,7 @@ export interface SessionOptions {
   targetActivities?: number;
   domainFocus?: string;
   planId?: string;
+  conceptId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -102,13 +103,17 @@ function interleave(items: SessionActivity[]): SessionActivity[] {
 export function buildSessionComposition(
   options?: SessionOptions,
 ): SessionComposition {
-  const dueActivities = getDueActivities();
+  // Concept-focused sessions include ALL activities (not just due),
+  // since the user is explicitly choosing to practice this concept now.
+  const dueActivities = options?.conceptId
+    ? getActivitiesByConceptId(options.conceptId)
+    : getDueActivities();
 
   if (dueActivities.length === 0) {
     return { blocks: [], totalActivities: 0, estimatedMinutes: 0, domainsCovered: [] };
   }
 
-  // Plan concept filtering
+  // Plan filtering (conceptId already filtered above)
   let activitiesToUse = dueActivities;
   if (options?.planId) {
     const planConceptIds = new Set(getPlanConceptIds(options.planId));

--- a/dashboard/src/lib/session-builder.ts
+++ b/dashboard/src/lib/session-builder.ts
@@ -122,6 +122,35 @@ export function buildSessionComposition(
 
   const activeConcepts = getActiveConcepts();
 
+  // Concept-focused short-circuit: the new/review/stretch block taxonomy
+  // only makes sense across many concepts. For a single concept the user
+  // just wants to drill it — return one block, ordered easy → hard.
+  if (options?.conceptId) {
+    const concept = activeConcepts.find((c) => c.id === options.conceptId);
+    if (!concept) {
+      return { blocks: [], totalActivities: 0, estimatedMinutes: 0, domainsCovered: [] };
+    }
+    const target = options?.targetActivities ?? 20;
+    const sorted = [...activitiesToUse].sort((a, b) => a.bloom_level - b.bloom_level);
+    const capped = sorted.slice(0, target);
+    const sessionActivities: SessionActivity[] = capped.map((act) => ({
+      activityId: act.id,
+      conceptId: act.concept_id,
+      conceptTitle: concept.title,
+      domain: concept.domain,
+      activityType: act.activity_type,
+      bloomLevel: act.bloom_level,
+    }));
+    return {
+      blocks: [{ type: 'review', activities: sessionActivities }],
+      totalActivities: sessionActivities.length,
+      estimatedMinutes: Math.ceil(
+        sessionActivities.reduce((sum, a) => sum + estimateMinutes(a.activityType), 0),
+      ),
+      domainsCovered: concept.domain ? [concept.domain] : [],
+    };
+  }
+
   // Build concept lookup map keyed by id
   const conceptMap = new Map<string, ConceptSummary>();
   for (const concept of activeConcepts) {

--- a/dashboard/src/lib/study-db.ts
+++ b/dashboard/src/lib/study-db.ts
@@ -1267,7 +1267,9 @@ export interface ConceptDetail {
   activities: Array<{
     id: string;
     activityType: string;
+    prompt: string;
     bloomLevel: number;
+    cardType: string | null;
     dueAt: string;
     masteryState: string;
     author: string;
@@ -1446,7 +1448,9 @@ export function getConceptDetail(id: string): ConceptDetail | null {
     activities: activityRows.map((a) => ({
       id: a.id,
       activityType: a.activity_type,
+      prompt: a.prompt,
       bloomLevel: a.bloom_level,
+      cardType: a.card_type ?? null,
       dueAt: a.due_at,
       masteryState: a.mastery_state ?? 'new',
       author: a.author ?? 'system',

--- a/docs/research/2026-04-10-uniclaw-tutoring-research.md
+++ b/docs/research/2026-04-10-uniclaw-tutoring-research.md
@@ -1,0 +1,614 @@
+# UniClaw AI Tutoring System — Research & Architecture Analysis
+
+**Date:** 2026-04-10
+**Purpose:** Ground-up reevaluation of how NanoClaw can become a personal AI tutor with progressive, science-backed learning.
+
+---
+
+## Part 1: NanoClaw Architecture — What We Have
+
+### 1.1 Core Message Flow
+
+NanoClaw is a single Node.js process that orchestrates message-driven AI agents running in isolated containers.
+
+```
+Channel receives message
+  → storeMessage() to SQLite
+  → startMessageLoop() polls every 2s
+  → Trigger check (e.g. "@Andy" for non-main groups)
+  → GroupQueue dispatches to runContainerAgent()
+  → Claude Agent SDK executes inside Docker container
+  → Streaming output parsed via sentinel markers
+  → Response sent back through channel
+  → Per-group cursor updated
+```
+
+**Key property:** Every interaction is message-driven. The system doesn't distinguish between "a student asking a question" and "a scheduled task firing." Both become container invocations with prompts.
+
+### 1.2 Channel System
+
+Channels self-register at startup via a factory pattern. Available channels:
+- **Telegram** — Primary student-facing channel (Mr. Rogers persona)
+- **WhatsApp** — Legacy support
+- **Discord / Slack** — Group channels
+- **Web** — HTTP + SSE for dashboard draft review (port 3200)
+- **Email** — MCP integration
+
+Each channel implements: `connect()`, `sendMessage()`, `ownsJid()`, `isConnected()`, with optional `setTyping()`, `syncGroups()`, `sendVoice()`.
+
+**Tutoring relevance:** Telegram is the primary conversational tutoring channel. The web channel enables the dashboard quiz/study interface. Both can coexist.
+
+### 1.3 Agent Containers & Isolation
+
+Each group gets its own isolated container with:
+- **Read-only** project root (prevents code modification)
+- **Read-write** group folder (per-group state, CLAUDE.md)
+- **Read-only** global shared memory
+- **Per-group** `.claude/` session directory
+- **Per-group** IPC namespace
+
+Security: OneCLI gateway intercepts HTTPS and injects API keys — containers never see secrets directly. `.env` is shadowed with `/dev/null`.
+
+**Three agent personas exist:**
+| Agent | Group | Role |
+|-------|-------|------|
+| Mr. Rogers | `telegram_main` | Student-facing teaching assistant |
+| Chef Brockett | `review_agent` | Document ingestion & note generation |
+| Main | `main` | Admin control with elevated privileges |
+
+### 1.4 Task Scheduler
+
+Supports three schedule types: **cron**, **interval**, and **once**. Scheduler polls every 60 seconds, dispatches due tasks to GroupQueue just like messages. Tasks can run in **isolated** (fresh session) or **group** (shared context) mode.
+
+**Tutoring relevance:** This is the engine for daily reminders, weekly reviews, monthly assessments. Tasks can trigger container agents with specific prompts on schedule.
+
+### 1.5 IPC System
+
+File-based inter-process communication. Containers write JSON files to `/workspace/ipc/`, the main process polls and processes them. Supports:
+- **Messages** — Send text/voice to any channel
+- **Tasks** — Create/pause/cancel scheduled tasks
+- **Group management** — Register new groups, sync metadata
+
+Authorization: Main group can send anywhere; subgroups restricted to their own JID.
+
+**Tutoring relevance:** IPC is how the study system communicates between dashboard, agent, and scheduler. Study completion events, quiz results, and card updates all flow through IPC.
+
+### 1.6 RAG System (LightRAG)
+
+- **RagClient** — HTTP client to LightRAG server (port 9621)
+- **RagIndexer** — Watches vault directories, indexes with content-hash deduplication
+- **Indexed paths:** `concepts/`, `sources/`, `profile/archive/`
+- **Excluded:** `drafts/`, `attachments/`
+- **Wikilink injection** — Extracts `[[links]]` and creates graph relations
+
+The RAG system enables agents to ground answers in vault content. Query modes: naive, local, global, hybrid, mix.
+
+### 1.7 Ingestion Pipeline
+
+Five-stage pipeline: **Upload → Extraction (Docling) → Generation (Claude) → Promotion → Complete**
+
+Turns uploaded documents (PDFs, papers) into structured vault notes via:
+1. Docling Python extraction
+2. Claude agent generates atomic concept notes
+3. Notes promoted to vault with proper frontmatter
+4. RAG indexer picks them up automatically
+
+Also supports Zotero integration for automatic paper ingestion.
+
+### 1.8 Student Profile System
+
+Three markdown notebooks in `vault/profile/`:
+- **student-profile.md** — Courses, metadata
+- **knowledge-map.md** — Per-topic confidence scores
+- **study-log.md** — Activity log (quiz, Q&A, summary, writing sessions)
+
+Methods: `logStudySession()`, `updateKnowledgeMap()`, `addCourse()`
+
+**Current limitation:** Profile is markdown-based, not structured data. Works for the agent to read, but harder for the dashboard to query programmatically.
+
+### 1.9 Web Dashboard
+
+Next.js app (port 3100) with existing pages: Upload, Queue, Review, Vault, Quiz, Settings.
+
+No Study page yet. Navigation template ready for insertion.
+
+### 1.10 Database Schema
+
+SQLite with tables for: chats, messages, router_state, sessions, registered_groups, scheduled_tasks, task_run_logs, ingestion_jobs, zotero_sync, rag_index_tracker, citation_edges, settings.
+
+**Not yet created:** study_plans, sr_cards, study_plan_cards, sr_review_log (from the existing spec).
+
+---
+
+## Part 2: What's Already Been Planned
+
+### 2.1 Existing Design Documents
+
+Two documents dated 2026-04-05:
+- **Spec:** `docs/superpowers/specs/2026-04-05-study-plan-system-design.md`
+- **Plan:** `docs/superpowers/plans/2026-04-05-study-plan-system.md`
+
+### 2.2 Previous Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Brain-first, AI-second | Kosmyna et al. 2025 cognitive debt research |
+| SM-2 algorithm (not FSRS) | Simplicity for MVP |
+| Dashboard has NO LLM access | Thin SQLite UI layer only |
+| Main process handles all LLM work | Plan generation, answer evaluation |
+| IPC-based communication | Between Telegram agent and main process |
+| Two strategies: exam-prep + weekly-review | MVP scope |
+| Feynman technique via Telegram | Conversational, not form-based |
+
+### 2.3 Planned Data Model
+
+Four new tables: `study_plans`, `study_plan_cards`, `sr_cards`, `sr_review_log`
+
+Mastery state machine: `new → learning → reviewing → mastered` (with lapse back to learning)
+
+### 2.4 Implementation Status
+
+- **Done:** Student profile tracking, agent personas, vault structure, dashboard skeleton
+- **Not started:** SM-2 engine, study tables, dashboard study page, quiz module, agent integration, scheduled study tasks
+
+---
+
+## Part 3: Learning Science Research
+
+### 3.1 Spaced Repetition
+
+**Core science:**
+- Ebbinghaus forgetting curve: `R = e^(-t/S)` — memory decays exponentially, each successful retrieval increases strength
+- Cepeda et al. (2008): Optimal gap between reviews is ~10-20% of desired retention interval
+- SM-2 algorithm: Tracks repetitions, ease factor (initial 2.5), and interval. Simple, ~50 lines of code
+- FSRS (Free Spaced Repetition Scheduler): Modern ML-based successor, 20-30% fewer reviews for same retention
+
+**Recommendation:** Start with SM-2 (as planned), but design the review log schema to be algorithm-agnostic for future FSRS migration. Log everything: quality, response time, ease factor, interval — FSRS needs this training data.
+
+### 3.2 Active Recall & Testing Effect
+
+**Core science:**
+- Roediger & Karpicke (2006): Testing beats re-reading on delayed tests, even without feedback
+- Karpicke & Blunt (2011, Science): Retrieval practice > elaborative concept mapping
+- Karpicke (2012): Up to 400% improvement in long-term retention vs. re-reading
+- Bjork's "Desirable Difficulties": Harder retrieval = better learning
+
+**Question type hierarchy (by effectiveness):**
+1. Free recall ("Explain concept X from memory")
+2. Short-answer generation ("What are the three types of...?")
+3. Cued recall ("Given X, what is Y?")
+4. Recognition/MCQ (lowest effect)
+
+**Recommendation:** Prioritize free-recall and explain-in-your-own-words questions. MCQ only for factual recall at Remember level. The Feynman technique via Telegram (already planned) is excellent — it's the highest-effectiveness active recall strategy.
+
+### 3.3 Bloom's Taxonomy (Revised)
+
+**Six cognitive levels:** Remember → Understand → Apply → Analyze → Evaluate → Create
+
+**Four knowledge dimensions:** Factual, Conceptual, Procedural, Metacognitive
+
+**Recommendation:** Tag every card with its Bloom's level. Require mastery at lower levels before challenging at higher levels for the same concept. This creates natural progression:
+- First encounters: Remember & Understand
+- After initial mastery: Apply & Analyze
+- Advanced mastery: Evaluate & Create
+
+### 3.4 Mastery Learning (Bloom, 1968)
+
+**Core principle:** 90%+ of students can master material given sufficient time and targeted corrective instruction.
+
+**The cycle:** Instruction → Formative assessment → Correctives for gaps → Re-assess → Repeat until mastery
+
+**Recommendation:** Implement mastery gates (80%+ threshold). After failure, identify specific missed concepts and generate targeted corrective content via Claude + RAG. Don't make students redo everything — only remediate the gaps.
+
+### 3.5 Zone of Proximal Development (Vygotsky)
+
+**Core concept:** Learning happens in the gap between what a learner can do alone and what they can do with guidance.
+
+**Scaffolding levels (for the AI tutor):**
+- Level 0: Question only
+- Level 1: Contextual hint ("Think about concept X")
+- Level 2: Structural hint ("The answer involves three components...")
+- Level 3: Partial solution ("The first step is...")
+- Level 4: Worked example with similar problem
+- Level 5: Full explanation + answer
+
+**Target success rate: 70-85%** — difficult enough for desirable difficulty, not so hard as to cause frustration.
+
+**Recommendation:** Implement adaptive scaffolding. Track rolling success rate per concept. If >90%: increase difficulty. If <50%: decrease difficulty. Mr. Rogers serves as the "More Knowledgeable Other" providing calibrated support.
+
+### 3.6 Cognitive Load Theory (Sweller)
+
+**Three types of cognitive load:**
+- **Intrinsic:** Inherent material complexity (manage, can't eliminate)
+- **Extraneous:** Bad instructional design (minimize)
+- **Germane:** Productive schema-building effort (maximize)
+
+**Key insight — Expertise Reversal Effect:** What helps novices (worked examples, heavy scaffolding) hurts experts by adding unnecessary load.
+
+**Recommendation:**
+- New material: Block presentation, one concept at a time
+- Session length: 25-50 minutes (Pomodoro-aligned)
+- Prerequisite enforcement: Don't present concept B until sub-concepts are mastered
+- Adapt scaffolding to expertise level (reduce for advanced students)
+
+### 3.7 Interleaving & Distributed Practice
+
+**Core finding:** Mixing different problem types in review sessions beats blocked practice for long-term retention and transfer.
+
+**Critical nuance (Hwang, 2025):** For low-achieving learners, interleaving alone creates "undesirable difficulty." Hybrid approach works best: block first for initial learning, interleave for review.
+
+**Recommendation:**
+- New material: Blocked (one topic thoroughly)
+- Review sessions: Interleaved (mix topics and question types)
+- Session composition: ~30% new material (blocked), ~70% review (interleaved)
+- Never place 2+ cards from the same concept adjacent in review
+
+### 3.8 Self-Regulated Learning & Metacognition (Zimmerman)
+
+**Three-phase cycle:**
+1. **Forethought:** Goal setting, strategy planning, self-motivation
+2. **Performance:** Self-monitoring, attention control, help-seeking
+3. **Self-Reflection:** Self-evaluation, causal attribution, adaptive reactions
+
+**Recommendation:** Build all three phases into the study session lifecycle:
+- **Pre-session:** Show upcoming topics, ask confidence ratings, set goals
+- **During:** Track response time, prompt reflection every 5-7 cards
+- **Post-session:** Show accuracy vs. confidence (calibration), highlight improvements, prompt reflection
+
+Track **calibration score** = correlation(confidence predictions, actual performance). This builds metacognitive accuracy over time.
+
+### 3.9 AI Tutoring — State of the Art (2024-2026)
+
+**What works:**
+- RAG-grounded tutoring dramatically reduces hallucination
+- Prompt-engineering guardrails preserve academic integrity (guide, don't give answers)
+- Affective scaffolds (encouragement, empathy) increase persistence
+- Nature 2025 study: AI tutor outperformed traditional active learning for practice-based tasks
+
+**What doesn't work / pitfalls:**
+- Fully autonomous tutors perform worse than hybrid human-AI
+- "Cognitive debt" (Kosmyna et al., 2025): Habitual AI use causes cumulative cognitive cost — 83.3% of LLM users failed to quote from their own AI-assisted essay
+- Students who use AI for answers (not scaffolding) learn less
+
+**Emerging approaches:**
+- Bayesian Knowledge Tracing (BKT): Probabilistic mastery estimation per knowledge component
+- Multi-agent frameworks: Separate agents for content, assessment, emotional support, metacognitive coaching
+- LPITutor architecture: LLM + RAG + prompt engineering
+
+**Recommendation:** Our architecture (Claude + RAG + vault grounding + brain-first rule) aligns with best practices. Consider adding simplified BKT alongside SM-2: BKT for estimating concept mastery (what to ask), SM-2 for scheduling timing (when to ask).
+
+### 3.10 Progressive Curriculum Design
+
+**Bruner's Spiral Curriculum:**
+1. Cyclical revisiting of the same topics
+2. Increasing depth with each revisit
+3. Explicit building on prior knowledge
+
+**Cadence structure:**
+- **Daily (25-50 min):** 5-8 new cards (blocked) + 15-20 review cards (interleaved) + 1 metacognitive reflection
+- **Weekly:** Cross-topic synthesis questions, higher Bloom's assessments, knowledge map review
+- **Monthly:** Comprehensive mastery check, study plan regeneration, decay identification
+
+**Recommendation:** Implement Bloom's escalation per concept — each successful review cycle generates a higher-level question. This creates a natural spiral within the spaced repetition system.
+
+```
+encounters ≤ 2: Remember
+encounters ≤ 4: Understand
+encounters ≤ 6: Apply
+encounters ≤ 8: Analyze
+encounters ≤ 10: Evaluate
+encounters > 10: Create
+```
+
+### 3.11 Learning Analytics
+
+**Key metrics to track:**
+| Metric | What It Measures |
+|--------|-----------------|
+| Retention rate | % of cards with quality ≥ 3 at review |
+| Ease factor trend | Declining EF = concept getting harder |
+| Time-to-competency | Reviews before "mastered" state |
+| Response time | Proxy for knowledge fluency |
+| Calibration accuracy | Confidence prediction vs. actual performance |
+| Transfer score | High-Bloom success / Low-Bloom success |
+| Knowledge decay rate | How fast mastery drops between reviews |
+
+**Understanding vs. memorization test:** If a student aces Remember questions but fails Apply/Analyze, they memorized but didn't understand.
+
+### 3.12 Assessment Strategy
+
+**Formative (daily):** SR reviews, self-rated (quality 0-5), in-chat Feynman exercises, confidence ratings
+**Summative (at gates):** AI-evaluated free-text answers, mastery threshold ≥80%, required before advancing
+**Portfolio (auto-generated):** Weekly/monthly summaries of mastery progression, study time, Bloom's distribution
+
+---
+
+## Part 4: What's In The Vault (RAG Search Results)
+
+The vault contains content on these learning-relevant topics:
+
+**Strong coverage:**
+- Cognitive Load Theory (CLT and CTML, Sweller, multimedia learning principles)
+- Working memory constraints and concept formation (Cowan 2014)
+- Knowledge construction and comprehension
+- Chunking strategies
+- Critical thinking
+- Anticipatory reading
+- Learning analytics and adaptive learning
+- Formative assessment feedback loops
+- Personalized learning paths (adaptive systems, CBR, LMS)
+
+**Gaps (not in vault):**
+- Spaced repetition algorithms and research
+- Active recall / testing effect (Roediger & Karpicke)
+- Bloom's Taxonomy
+- Mastery learning (Bloom)
+- Zone of Proximal Development (Vygotsky)
+- Interleaving and distributed practice
+- Self-regulated learning (Zimmerman)
+- Bruner's spiral curriculum
+
+**Recommendation:** These gaps represent opportunity for the ingestion pipeline — the learning science papers referenced in Part 3 could be ingested to build vault coverage of pedagogical foundations.
+
+---
+
+## Part 5: Architecture for a Progressive AI Tutor
+
+### 5.1 The Three Learning Surfaces
+
+UniClaw has three natural surfaces for learning interactions:
+
+| Surface | Channel | Best For | Interaction Style |
+|---------|---------|----------|-------------------|
+| **Telegram** (Mr. Rogers) | Conversational | Feynman technique, Q&A, daily reminders, quick quizzes | Async, mobile-friendly, push notifications |
+| **Dashboard** (/study) | Web UI | Study plans, card review, progress analytics, mastery heatmap | Focused sessions, visual progress tracking |
+| **Scheduled Tasks** | Background | Daily reminders, weekly synthesis, monthly reviews | Proactive, no student action needed to trigger |
+
+### 5.2 Data Architecture
+
+**Existing (keep as-is):**
+- Vault notes (concepts, sources) — the knowledge base
+- RAG index — semantic search over vault
+- Student profile (markdown) — agent-readable context
+- Ingestion pipeline — document → knowledge flow
+
+**New (to build):**
+- `sr_cards` table — Spaced repetition cards with SM-2 fields + Bloom's level
+- `sr_review_log` table — Every review event (enables future FSRS, BKT)
+- `study_plans` table — Plan metadata (strategy, course, config)
+- `study_plan_cards` table — Join table linking plans to cards
+- Study engine (`src/study/`) — SM-2 algorithm, session builder, mastery tracking
+
+### 5.3 The Learning Loop
+
+```
+                    ┌─────────────────────────────────┐
+                    │                                  │
+                    ▼                                  │
+    ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌───┴──────┐
+    │ INGEST   │──▶│ GENERATE │──▶│ SCHEDULE │──▶│  REVIEW  │
+    │ content  │   │ cards    │   │ sessions │   │  & learn │
+    └──────────┘   └──────────┘   └──────────┘   └──────────┘
+         │              │              │               │
+         ▼              ▼              ▼               ▼
+    Upload/Zotero  Claude+RAG     SM-2 engine    Dashboard/
+    → vault notes  → SR cards    → due dates     Telegram
+                   + Bloom tags  → reminders     → feedback
+                                                 → mastery update
+```
+
+### 5.4 Progressive Cadences
+
+**Daily (triggered by scheduled task, ~25-50 min):**
+1. Mr. Rogers sends morning reminder via Telegram: "You have X cards due today"
+2. Student opens dashboard /study or responds in Telegram
+3. Session: 30% new cards (blocked by topic) + 70% review (interleaved)
+4. Pre-session: confidence ratings on upcoming topics
+5. During: active recall questions, scaffolded hints on struggle
+6. Post-session: calibration feedback, reflection prompt
+7. Results flow back: SR card updates, knowledge map updates, study log entry
+
+**Weekly (triggered by cron task, synthesis focus):**
+1. Cross-topic synthesis questions ("How does concept A relate to concept B?")
+2. Higher Bloom's level assessments for mastered concepts
+3. Weekly progress summary sent via Telegram
+4. Knowledge map review — visualize growth and gaps
+5. Optionally: Feynman session on weakest topic
+
+**Monthly (triggered by cron task, comprehensive review):**
+1. Full mastery check across all active courses
+2. Identify decaying concepts (mastery slipping)
+3. Study plan regeneration based on upcoming deadlines
+4. Portfolio generation: growth trajectory, Bloom's distribution
+5. Strategy adjustment recommendations
+
+### 5.5 Adaptive Difficulty & Scaffolding
+
+```
+For each concept, track:
+  - rolling_success_rate (last 10 attempts)
+  - current_bloom_level
+  - scaffolding_level (0-5)
+
+Adjustment rules:
+  if rolling_success > 0.90:
+    bloom_level++ (escalate)
+    scaffolding_level-- (reduce support)
+  elif rolling_success < 0.50:
+    bloom_level-- (de-escalate)
+    scaffolding_level++ (add support)
+  else:
+    maintain (in the ZPD sweet spot: 70-85%)
+```
+
+### 5.6 Dashboard Study Page Design
+
+**Main /study page:**
+- Study plan overview (active plans, progress bars)
+- Today's due cards (count, estimated time)
+- "Start Session" button → quiz mode
+- Mastery heatmap (concepts as nodes, colored by state)
+- Weekly/monthly analytics charts
+
+**Quiz mode (/study/quiz):**
+- One card at a time, clean interface (minimize extraneous load)
+- Free-text answer box (brain-first)
+- After submission: reference answer from vault, quality self-rating (0-5)
+- Progressive hint button (scaffolding levels 1-5)
+- Bloom's level indicator
+- Session progress bar
+
+### 5.7 Mr. Rogers Integration (Telegram)
+
+Enhanced capabilities:
+1. "What should I study today?" → Returns due cards with priority
+2. In-chat quiz: presents question, waits for answer, gives feedback
+3. Feynman technique: "Explain [concept] to me" → evaluates explanation
+4. Daily morning reminder (scheduled task)
+5. Weekly progress summary (scheduled task)
+6. Metacognitive prompts: "How confident are you about [topic]?"
+7. Results flow back to SR system via IPC
+
+### 5.8 Website ↔ Tutoring Integration
+
+The dashboard is the **study cockpit** — it shows progress, manages plans, and hosts focused study sessions. The tutoring system feeds it data:
+
+| Website Feature | Tutoring Data Source |
+|----------------|---------------------|
+| Study plan management | `study_plans` table |
+| Card review / quiz | `sr_cards` + SM-2 engine |
+| Progress analytics | `sr_review_log` aggregations |
+| Mastery heatmap | Knowledge map + Bloom's tracking |
+| Vault browser | Links from cards to source notes |
+| Upload page | Ingestion → cards pipeline |
+| RSVP reader | Deep-link from cards to vault notes |
+
+**Key integration:** When a student reviews a card on the dashboard, clicking the source link opens the relevant vault note in the RSVP reader or vault browser. Learning is grounded in the primary material.
+
+---
+
+## Part 6: Open Design Questions
+
+These are the decisions we need to make together:
+
+### Q1: SM-2 vs. SM-2 + BKT?
+- **SM-2 only:** Simpler. Cards have individual scheduling. Per-concept mastery derived from card aggregation.
+- **SM-2 + BKT:** More nuanced. BKT estimates concept-level mastery probabilistically, informing which questions to generate. SM-2 handles card-level timing.
+- **Trade-off:** Complexity vs. adaptive intelligence.
+
+### Q2: Self-Rated vs. AI-Evaluated Answers?
+- **Self-rated (MVP):** Student rates own answer quality 0-5. Builds metacognitive skills. Simpler to implement.
+- **AI-evaluated:** Claude + RAG evaluates free-text answers against vault content. More accurate but requires LLM call per review.
+- **Hybrid:** Self-rated for daily formative reviews, AI-evaluated for weekly/monthly summative gates.
+- **Recommendation from spec:** Start self-rated, add AI evaluation later.
+
+### Q3: Card Generation — When and How?
+- **On plan creation:** Generate all cards upfront from vault content via Claude. Fixed card set.
+- **On demand:** Generate cards as concepts become due. More dynamic but less predictable.
+- **Hybrid:** Generate initial card set, regenerate/add cards as new vault content arrives.
+
+### Q4: How Should the Dashboard and Telegram Interact?
+- **Dashboard-primary:** All study happens on dashboard, Telegram for reminders only.
+- **Telegram-primary:** Most study via chat, dashboard for analytics/management only.
+- **True hybrid:** Student can review cards on either surface, results sync via shared DB.
+- **Recommendation:** True hybrid — some students prefer mobile/chat, others prefer focused web sessions.
+
+### Q5: Mastery Scope — Per-Card or Per-Concept?
+- **Per-card:** Each card has its own mastery state. Simple but doesn't capture concept-level understanding.
+- **Per-concept:** Aggregate card results into concept-level mastery. Enables mastery gates and prerequisite enforcement.
+- **Recommendation:** Both — cards have individual SM-2 state, concepts have aggregated mastery (derived from their cards' Bloom's distribution).
+
+### Q6: How to Handle Vault Content Updates?
+- When a vault note is updated (new ingestion, manual edit), what happens to cards generated from it?
+- **Options:** Flag as stale (mtime comparison), auto-regenerate, manual regeneration.
+- **Spec recommendation:** Manual — auto-updating mid-study disrupts spacing.
+
+### Q7: Scheduling Architecture — Who Orchestrates?
+- **Main process:** Study engine lives in main Node.js process, generates sessions, evaluates answers.
+- **Container agent:** Agent in container handles quiz logic, has access to RAG.
+- **Recommendation from spec:** Main process handles LLM work, dashboard is thin UI. But Mr. Rogers (container agent) also needs to run quizzes conversationally.
+
+### Q8: Progressive Features — MVP vs. Full Vision?
+What's the minimum viable tutoring loop?
+- **Absolute MVP:** Cards in DB + SM-2 scheduling + dashboard quiz page + daily reminder
+- **Phase 2:** Bloom's escalation, scaffolding hints, Telegram quiz, weekly synthesis
+- **Phase 3:** BKT, AI evaluation, analytics dashboard, monthly reviews, calibration tracking
+- **Phase 4:** Adaptive difficulty, cross-course synthesis, portfolio generation
+
+---
+
+## Part 7: Recommended Implementation Phases
+
+### Phase 1 — The Core Loop (MVP)
+- [ ] Add study tables to SQLite schema
+- [ ] Implement SM-2 algorithm (pure functions)
+- [ ] Build study engine (plan generation, session builder)
+- [ ] Create dashboard /study page (plan management + quiz)
+- [ ] Add daily reminder scheduled task
+- [ ] Wire IPC for study completion events
+
+### Phase 2 — Progressive Intelligence
+- [ ] Add Bloom's level to cards and escalation logic
+- [ ] Implement scaffolding hint system (5 levels)
+- [ ] Mr. Rogers Telegram quiz integration
+- [ ] Weekly synthesis tasks
+- [ ] Interleaving algorithm for session building
+
+### Phase 3 — Adaptive & Analytical
+- [ ] Add confidence tracking and calibration scoring
+- [ ] Implement response time tracking
+- [ ] Build analytics dashboard (retention, Bloom's distribution, trends)
+- [ ] AI-evaluated answers for summative gates
+- [ ] Mastery heatmap visualization
+
+### Phase 4 — Advanced Tutoring
+- [ ] Bayesian Knowledge Tracing (optional)
+- [ ] Cross-course synthesis questions
+- [ ] Monthly comprehensive reviews
+- [ ] Portfolio generation
+- [ ] FSRS migration (if data supports it)
+
+---
+
+## Sources
+
+### Spaced Repetition
+- Ebbinghaus, H. (1885). *Memory: A Contribution to Experimental Psychology*
+- Cepeda, N.J. et al. (2008). Spacing effects in learning: A temporal ridgeline of optimal retention. *Psychological Science*, 19(11), 1095-1102
+- SM-2 Algorithm — SuperMemo (Wozniak, 1987)
+- FSRS — Open-source ML-based scheduler (Expertium)
+
+### Active Recall & Testing Effect
+- Roediger, H.L. & Karpicke, J.D. (2006). Test-enhanced learning. *Psychological Science*, 17(3), 249-255
+- Karpicke, J.D. & Blunt, J.R. (2011). Retrieval practice produces more learning than elaborative studying with concept mapping. *Science*, 331(6018), 772-775
+- Bjork, R.A. (1994). Memory and metamemory considerations in the training of human beings. *Metacognition*
+
+### Bloom's Taxonomy
+- Anderson, L.W. & Krathwohl, D.R. (2001). *A Taxonomy for Learning, Teaching, and Assessing* (Revised edition)
+
+### Mastery Learning
+- Bloom, B.S. (1968). Learning for Mastery. *Evaluation Comment*, 1(2), 1-12
+- Guskey, T.R. (2007). Closing achievement gaps: Revisiting Benjamin S. Bloom's "Learning for Mastery"
+
+### Zone of Proximal Development
+- Vygotsky, L.S. (1978). *Mind in Society*
+- Wood, D., Bruner, J.S. & Ross, G. (1976). The role of tutoring in problem solving. *Journal of Child Psychology and Psychiatry*, 17(2), 89-100
+
+### Cognitive Load Theory
+- Sweller, J. (1988). Cognitive load during problem solving. *Cognitive Science*, 12(2), 257-285
+- Mayer, R.E. (2009). *Multimedia Learning* (2nd ed.)
+
+### Interleaving & Distributed Practice
+- Cepeda, N.J. et al. (2006). Distributed practice in verbal recall tasks. *Review of Educational Research*, 76(3), 354-380
+- Hwang, H. (2025). Undesirable difficulty of interleaved practice for low-achieving learners. *Language Learning*
+
+### Self-Regulated Learning
+- Zimmerman, B.J. (2002). Becoming a self-regulated learner. *Theory Into Practice*, 41(2), 64-70
+
+### AI Tutoring
+- Kosmyna, N. et al. (2025). Cognitive debt from AI use. *Nature*
+- Dunlosky, J. et al. (2013). Improving students' learning with effective learning techniques. *Psychological Science in the Public Interest*, 14(1), 4-58
+
+### Curriculum Design
+- Bruner, J.S. (1960). *The Process of Education*
+- Harden, R.M. (1999). What is a spiral curriculum? *Medical Teacher*, 21(2), 141-143

--- a/docs/superpowers/plans/2026-04-05-study-plan-system.md
+++ b/docs/superpowers/plans/2026-04-05-study-plan-system.md
@@ -1,0 +1,207 @@
+# Study Plan System — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a science-backed, adaptive study planning system with spaced repetition, a quiz module on the dashboard, and agent integration for Mr. Rogers.
+
+**Spec:** `docs/superpowers/specs/2026-04-05-study-plan-system-design.md`
+
+**Tech Stack:** TypeScript/Node.js (backend), Next.js (dashboard), SQLite (better-sqlite3), LightRAG (existing), Vitest (tests)
+
+**Key architectural constraint:** The dashboard has no LLM access. Quiz questions are pre-generated during plan creation (main process). The dashboard reads from SQLite and writes completion results. Answer evaluation routes through the main process.
+
+---
+
+## File Structure
+
+### Existing files to modify
+
+- `src/db.ts` — Add study_plans, study_plan_cards, sr_cards, sr_review_log tables + CRUD functions
+- `src/types.ts` — Add study-related interfaces
+- `src/ipc.ts` — Add `study_complete` and `study_session` IPC task types
+- `dashboard/src/app/layout.tsx` — Add "Study" nav link
+- `dashboard/src/app/read/page.tsx` — Enable "From Vault" tab
+- `groups/telegram_main/CLAUDE.md` — Add study plan + Feynman instructions for Mr. Rogers
+
+### New files to create
+
+**Study Engine (backend):**
+- `src/study/sm2.ts` — SM-2 spaced repetition algorithm (pure functions)
+- `src/study/sm2.test.ts` — SM-2 tests
+- `src/study/engine.ts` — Plan generation, session management, completion tracking
+- `src/study/engine.test.ts` — Engine tests
+- `src/study/index.ts` — Public exports
+
+**Dashboard DB Layer:**
+- `dashboard/src/lib/study-db.ts` — Dashboard-side DB access for study tables
+
+**Dashboard API Routes (5 MVP routes):**
+- `dashboard/src/app/api/study/plans/route.ts` — GET (list), POST (trigger generation)
+- `dashboard/src/app/api/study/session/route.ts` — GET (today's due cards)
+- `dashboard/src/app/api/study/complete/route.ts` — POST (mark card complete)
+- `dashboard/src/app/api/study/stats/route.ts` — GET (progress metrics)
+
+**Dashboard Pages:**
+- `dashboard/src/app/study/page.tsx` — Study plan dashboard
+- `dashboard/src/app/study/quiz/page.tsx` — Quiz module
+
+---
+
+## Open Questions (Resolve During Implementation)
+
+1. **Website quiz evaluation** — Pre-generated questions are stored in `sr_cards.front/back`. When the student types a free-text answer on the website, who evaluates it? Options:
+   - **Self-rated (simpler):** Show the reference answer from `sr_cards.back`, student rates themselves 0-5. Works today, no proxy needed.
+   - **AI-evaluated (richer):** Dashboard posts answer to main process via internal HTTP endpoint, main process evaluates via Claude + RAG, returns feedback. Needs a new endpoint in the main process.
+   - Recommendation: Start self-rated, add AI evaluation as a follow-up.
+
+2. **Plan regeneration on new content** — When new vault notes are ingested (new lecture slides, new articles), should existing plans auto-update with new cards? Or does the student regenerate manually? Likely manual — auto-updating plans mid-study would mess with spacing.
+
+3. **Card staleness** — Pre-generated questions can go stale if the underlying vault note is edited. No refresh mechanism currently. Options: flag cards whose vault_path has a newer mtime than the card's created_at, or regenerate on demand.
+
+---
+
+## Phase 1: Data Model + SM-2 Engine
+
+### Step 1: Add study types to `src/types.ts`
+
+- [ ] Add `StudyPlan` interface (id, title, course, strategy, config, status, timestamps)
+- [ ] Add `SRCard` interface (id, topic, course, vault_path, card_type, front, back, ease_factor, interval_days, repetitions, due_at, last_reviewed, last_quality, mastery_state)
+- [ ] Add `SRReviewLog` interface (id, card_id, quality, response_time_ms, ease_factor, interval_days, reviewed_at)
+- [ ] Add `StudyStrategy` type: `'exam-prep' | 'weekly-review'`
+- [ ] Add `CardType` type: `'recall' | 'cloze' | 'explain'`
+- [ ] Add `MasteryState` type: `'new' | 'learning' | 'reviewing' | 'mastered'`
+
+### Step 2: Add study tables to `src/db.ts`
+
+- [ ] Add `study_plans` table to `createSchema()` (see spec for full schema)
+- [ ] Add `study_plan_cards` join table (plan_id, card_id, sort_order)
+- [ ] Add `sr_cards` table with indexes on due_at and course
+- [ ] Add `sr_review_log` table with index on card_id
+- [ ] Add CRUD functions: `createStudyPlan()`, `getStudyPlan()`, `getAllStudyPlans()`, `updateStudyPlan()`
+- [ ] Add CRUD functions: `createSRCard()`, `getSRCard()`, `getDueSRCards()`, `updateSRCard()`
+- [ ] Add functions: `addCardToPlan()`, `getCardsByPlan()`
+- [ ] Add functions: `createSRReviewLog()`, `getReviewLogByCard()`
+- [ ] Add function: `getStudyStats()` — mastery %, streak, forecast
+
+### Step 3: Create `src/study/sm2.ts`
+
+- [ ] Define `SM2Input` and `SM2Output` interfaces
+- [ ] Implement `calculateSM2(input: SM2Input): SM2Output` pure function
+- [ ] Implement `getNextDueDate(interval: number, fromDate?: Date): string` helper
+- [ ] Implement `updateMasteryState(repetitions: number, interval: number, easeFactor: number, quality: number, currentState: MasteryState): MasteryState`
+- [ ] Export all functions (follow RSVP pure-function pattern)
+
+### Step 4: Create `src/study/engine.ts`
+
+- [ ] Implement `generateStudyPlan(options)` — queries RAG + knowledge map, generates cards via Claude, creates plan with cards linked via study_plan_cards
+- [ ] Implement `getTodaySession(limit?)` — returns due cards sorted by priority (overdue first, low EF, type variety)
+- [ ] Implement `completeCard(cardId, result)` — runs SM-2, updates card, logs review, updates knowledge map
+- [ ] Implement `evaluateAnswer(cardId, studentAnswer)` — uses RAG + Claude to evaluate, returns feedback
+- [ ] Implement `getStudyStats()` — mastery %, streak, review forecast
+
+### Step 5: Create `src/study/index.ts`
+
+- [ ] Re-export public API from sm2.ts and engine.ts
+
+### Step 6: Write Phase 1 tests
+
+- [ ] `src/study/sm2.test.ts` — test SM-2 calculations: quality 0-5, EF floor at 1.3, interval progression (1→6→EF*I), mastery state transitions
+- [ ] `src/study/engine.test.ts` — test session queries, completion flow, stats computation (mock RAG for plan generation)
+- [ ] Test DB operations via `_initTestDatabase()`: create plan → add cards → link → complete → verify SR updates
+
+---
+
+## Phase 2: Dashboard — Study Plan Page + Quiz
+
+### Step 7: Add Study nav link
+
+- [ ] Add `<a href="/study" ...>Study</a>` to `dashboard/src/app/layout.tsx` nav (between Vault and Read)
+
+### Step 8: Create dashboard DB layer
+
+- [ ] Create `dashboard/src/lib/study-db.ts` following `ingestion-db.ts` pattern
+- [ ] Add camelCase interfaces: `StudyPlanSummary`, `SRCardSummary`, `StudyStats`
+- [ ] Add row mapper functions: `rowToPlan()`, `rowToCard()`
+- [ ] Add query functions: `getPlans()`, `getDueCards()`, `getStats()`, `getCardsByPlan()`
+
+### Step 9: Create API routes (5 MVP routes)
+
+- [ ] `GET /api/study/plans` — list plans with card counts + progress (% mastered/reviewing)
+- [ ] `POST /api/study/plans` — trigger plan generation (calls main process study engine)
+- [ ] `GET /api/study/session` — today's due cards across all plans
+- [ ] `POST /api/study/complete` — mark card complete with quality (0-5) + optional response_time_ms
+- [ ] `GET /api/study/stats` — mastery %, streak, review forecast
+
+### Step 10: Build study plan page
+
+- [ ] Create `dashboard/src/app/study/page.tsx` — `'use client'`
+- [ ] Today's Session section: cards for each due card with type badge, topic, course, link to quiz
+- [ ] Active Plans section: plan cards with progress bar, due count, course tag
+- [ ] Generate Plan form: course dropdown (from knowledge map courses), strategy selector (exam-prep / weekly), optional focus topics, exam date picker (for exam-prep)
+- [ ] Progress section: mastery %, streak, cards due this week
+- [ ] Follow existing dark theme styling (`bg-gray-900`, `border-gray-800`, etc.)
+
+### Step 11: Build quiz module page
+
+- [ ] Create `dashboard/src/app/study/quiz/page.tsx` — `'use client'`
+- [ ] Accept `?card=<id>` or `?plan=<id>` query params
+- [ ] Show question from `sr_cards.front` with topic and course context
+- [ ] Text area for free-form answer (brain-first: no hints visible)
+- [ ] Submit → POST to `/api/study/complete` → show reference answer from `sr_cards.back` + feedback
+- [ ] Post-answer quality rating (0-5, auto-suggested, overridable)
+- [ ] Batch flow: next card button, session summary at end (score, weak areas)
+
+---
+
+## Phase 3: RSVP Vault Integration
+
+### Step 12: Enable vault tab on `/read`
+
+- [ ] Wire up the disabled "From Vault" tab in `dashboard/src/app/read/page.tsx`
+- [ ] Add vault note search/browse (call `/api/vault?path=concepts/` for listing)
+- [ ] Select note → strip frontmatter → feed content to RSVP engine
+- [ ] Support `?vault_path=` query param for deep linking from study cards
+
+---
+
+## Phase 4: Agent Integration
+
+### Step 13: Add study IPC task types to `src/ipc.ts`
+
+- [ ] Add `study_complete` handler: reads `{ cardId, quality, responseTimeMs? }`, calls `completeCard()`
+- [ ] Add `study_session` handler: reads `{ limit? }`, calls `getTodaySession()`, writes result to response file
+- [ ] Follow existing IPC switch/case pattern in `processIpcTask()`
+
+### Step 14: Add daily study reminder
+
+- [ ] Create scheduled task in `groups/telegram_main/` config
+- [ ] Task queries due cards, formats a summary message with counts by course
+- [ ] Includes dashboard link and offer to run a quick quiz in chat
+
+### Step 15: Update Mr. Rogers instructions
+
+- [ ] Add study plan section to `groups/telegram_main/CLAUDE.md`
+- [ ] "What should I study?" → write IPC `study_session`, report due cards + weak areas from knowledge map
+- [ ] After in-chat quiz: write IPC `study_complete` with quality rating
+- [ ] Feynman technique: when a concept has low mastery (quality <= 3 after multiple attempts), suggest "explain this concept to me" exercises. Evaluate explanation against vault content via RAG, identify gaps, iterate
+- [ ] Brain-first principle: always ask question → wait for answer → evaluate
+
+---
+
+## Verification
+
+After each phase, run:
+```bash
+npm test                    # Backend tests pass
+npm run build              # TypeScript compiles
+cd dashboard && npm run dev # Dashboard renders correctly
+```
+
+End-to-end flow after all phases:
+1. Generate a study plan from `/study` page
+2. Complete quiz cards → verify SR intervals update correctly
+3. Mastery states transition: new → learning → reviewing → mastered
+4. Load vault note in RSVP via "From Vault" tab
+5. Ask Mr. Rogers "what should I study?" → get due cards
+6. Mr. Rogers in-chat quiz → results update SR cards via IPC
+7. Next day: verify spaced cards appear at correct intervals

--- a/docs/superpowers/plans/2026-04-13-study-system-master-plan.md
+++ b/docs/superpowers/plans/2026-04-13-study-system-master-plan.md
@@ -1,0 +1,1138 @@
+# Multi-Method Study System — Master Implementation Plan
+
+> **Cross-session tracker.** This document is the single source of truth for the study system implementation. Each sprint has checkboxes for progress tracking. At the start of each session, check what's done and pick up the next unchecked item. Sub-plans for each sprint live alongside this file.
+
+**Spec:** `docs/superpowers/specs/2026-04-12-multi-method-study-system-design.md` (v2.1)
+
+**Supersedes:** `docs/superpowers/plans/2026-04-05-study-plan-system.md` (cards-only plan, never implemented)
+
+**Spec deviations:** The spec's Phase 1 includes Telegram daily reminders and concept discovery as part of the MVP. This plan deliberately defers Telegram to S7, making the dashboard study loop (S4) the usable MVP. Rationale: the dashboard is the primary learning surface — getting it right matters more than mobile reminders. Post-session activity generation is pulled forward from spec Phase 4 to S3 so that sessions produce new activities immediately.
+
+**Tech Stack:** TypeScript/Node.js (backend), Next.js 16 + React 19 (dashboard), Drizzle ORM + SQLite/better-sqlite3 (storage), LightRAG (RAG), Vitest (tests), NanoClaw container agents (LLM work)
+
+---
+
+## 1. Architecture Decisions
+
+These decisions are **binding across all sprints**. Sub-plans must not contradict them. If a decision needs revision, update this section first.
+
+### 1.1 Agent Architecture
+
+Two container agent roles serve the study system. Both use the same container image (`nanoclaw-agent:latest`) but get different CLAUDE.md files, IPC namespaces, and mounted context.
+
+#### Study Agent (interactive, long-lived)
+
+**Purpose:** Handles all conversational learning methods and AI evaluation during study sessions.
+
+**Surface:** Dashboard chat via web channel (SSE streaming).
+
+**Session lifecycle:**
+1. Student opens `/study/chat` or triggers AI evaluation from `/study/session`
+2. Dashboard creates a session ID, sends first message via web channel
+3. Main process spawns container with study group context
+4. Container stays alive across all activities in the session (reuses session ID)
+5. Container dies after 30-min idle timeout or explicit close
+6. Next study session gets a fresh container (clean cognitive context)
+
+**JID format:** `web:study:{sessionId}` (new pattern, alongside existing `web:review:{draftId}`)
+
+**Mounted context:**
+- `/workspace/group` ← `groups/study/` (rw) — Study agent's working directory
+- `/workspace/group/CLAUDE.md` — Study-specific system prompt with:
+  - Available methods (Feynman, Socratic, case analysis, comparison, synthesis)
+  - Evaluation rubrics per Bloom's level
+  - Brain-first principle enforcement ("never lead with answers")
+  - Session state awareness (current concept, Bloom's level, method)
+  - RAG query instructions
+- Vault mounted read-only for source reference
+- IPC namespace: `study/{sessionId}`
+
+**Handles:**
+- Feynman technique dialogue (multi-turn, gap identification)
+- Socratic questioning (iterative, assumption-probing)
+- Case analysis discussion (multi-step reasoning)
+- Synthesis conversation (cross-concept integration)
+- AI evaluation of L3+ activity responses
+- Collaborative plan creation dialogue
+- Student-generated activity refinement
+
+**IPC contract (agent → main process):**
+```typescript
+// Agent completes an evaluation
+{ type: 'study_complete', activityId: string, quality: number,
+  responseText?: string, aiFeedback?: string, surface: 'dashboard_chat' }
+
+// Agent requests concept state for context
+{ type: 'study_concept_status', conceptId?: string, domain?: string }
+
+// Agent suggests new activities from dialogue
+{ type: 'study_suggest_activity', conceptId: string, activityType: string,
+  prompt: string, bloomLevel: number, author: 'student' | 'system' }
+```
+
+#### Generator Agent (batch, single-turn)
+
+**Purpose:** Generates learning activities and audio scripts in batches.
+
+**Surface:** Background — triggered by engine post-session or morning scheduled task.
+
+**Session lifecycle:**
+1. Engine determines which concepts need new activities
+2. Main process spawns container with generator context
+3. Agent generates activities as structured JSON, writes to IPC
+4. Container closes after single turn
+
+**JID format:** Uses existing task scheduling infrastructure (no web channel needed).
+
+**Mounted context:**
+- `/workspace/group` ← `groups/study-generator/` (rw) — Generator working directory
+- `/workspace/group/CLAUDE.md` — Generation-specific system prompt with:
+  - Activity type specifications (card, elaboration, Feynman prompt, comparison, etc.)
+  - Quality rules (Wozniak 20 Rules, Matuschak 5 Attributes, anti-patterns)
+  - Bloom's level generation guidelines
+  - Structured JSON output format
+  - RAG query instructions for source content retrieval
+- Vault mounted read-only for source content
+- IPC namespace: `study-generator/{jobId}`
+
+**Handles:**
+- L1-L2 activity generation (cards + elaboration prompts)
+- L3-L4 activity generation (Feynman prompts, concept maps, comparison tasks)
+- L5-L6 activity generation (synthesis prompts, Socratic starters, case scenarios)
+- Audio/podcast script generation
+- Activity quality self-validation before output
+
+**IPC contract (agent → main process):**
+```typescript
+// Agent outputs generated activities
+{ type: 'study_generated_activities', conceptId: string,
+  activities: GeneratedActivity[] }
+
+// Agent outputs audio script
+{ type: 'study_audio_script', conceptIds: string[],
+  script: string, contentType: 'summary' | 'review_primer' | 'weekly_digest' }
+```
+
+### 1.2 Data Flow Architecture
+
+Three distinct data flows, each using the appropriate mechanism:
+
+```
+FLOW 1: Structured data (reads + writes)
+  Dashboard ←→ SQLite (direct, via better-sqlite3)
+  - Concept lists, mastery bars, due counts, session composition
+  - Activity completion writes, concept approval, plan management
+  - Analytics queries
+  - No main process involvement needed
+
+FLOW 2: Conversational AI (dashboard chat)
+  Dashboard → HTTP POST /api/study/chat → Web Channel (port 3200)
+    → Main Process → Container Agent (Study Agent)
+    → Agent responds via stdout → Main Process
+    → Web Channel SSE → Dashboard EventSource
+  - Feynman, Socratic, case analysis, synthesis, plan dialogue
+  - AI evaluation of free-text responses
+
+FLOW 3: Background generation (no dashboard involvement)
+  Engine (main process) → Container Agent (Generator Agent)
+    → Agent outputs via IPC → Main Process → SQLite writes
+  - Post-session activity generation
+  - Morning scheduled task generation
+  - Audio/podcast script generation
+```
+
+**Key principle:** The dashboard never spawns containers or calls LLMs. It reads/writes SQLite for structured data and proxies to the web channel for conversational AI. The main process owns all LLM orchestration.
+
+### 1.3 Study Session Lifecycle
+
+A study session spans the student's entire sitting, potentially mixing self-rated activities (no LLM) with AI-evaluated activities (LLM via container).
+
+```
+Student opens /study → Dashboard reads session composition from SQLite
+  │
+  ├─ Self-rated activity (L1-L2 card, basic elaboration):
+  │    Dashboard shows question → student types answer → reveals reference
+  │    → student self-rates (0-5) → Dashboard POSTs to /api/study/complete
+  │    → API writes to activity_log + updates learning_activities SM-2 fields
+  │    → API calls mastery update (pure function) → updates concepts table
+  │    → Dashboard refreshes next activity from local session state
+  │    (No container involved)
+  │
+  ├─ AI-evaluated activity (L3+ Feynman, case, synthesis):
+  │    Dashboard shows prompt → student writes response → submits
+  │    → Dashboard POSTs to /api/study/evaluate with response text
+  │    → API proxies to web channel → Study Agent evaluates via RAG
+  │    → Agent returns quality score + feedback via SSE
+  │    → Dashboard displays feedback → student reviews
+  │    → Dashboard POSTs to /api/study/complete with AI quality score
+  │    → Same DB update path as self-rated
+  │
+  └─ Conversational activity (Socratic, deep Feynman):
+       Student navigates to /study/chat
+       → Opens SSE connection → sends first message
+       → Study Agent conducts multi-turn dialogue
+       → At conclusion, agent sends study_complete via IPC
+       → Main process updates DB
+       → Dashboard refreshes on return to /study/session
+```
+
+### 1.4 Web Channel Extension
+
+The existing web channel (`src/channels/web.ts`) supports `web:review:{draftId}` for draft reviews. The study system adds a new JID pattern:
+
+**New JID pattern:** `web:study:{sessionId}`
+
+**Changes required:**
+- `sendMessage()`: detect `web:study:` prefix, route to study SSE clients
+- New endpoint: `POST /study-message` — accepts `{ sessionId, text }`, routes to study container
+- New endpoint: `GET /study-stream/{sessionId}` — SSE connection for study chat
+- New endpoint: `POST /study-close/{sessionId}` — close study session container
+- Response buffer: same 50-message cap (study transcripts saved in DB, not buffer)
+
+**Session persistence:** Study chat transcripts are saved in `activity_log.response_text` and linked to the session. The buffer is ephemeral — if the student refreshes, the dashboard reloads transcript from DB and reconnects SSE.
+
+### 1.5 Concept Discovery Pipeline
+
+When ingestion promotes a vault note to `concepts/`, the study system creates a pending concept:
+
+```
+handlePromotion() completes → promoted_paths includes concepts/*.md
+  → For each promoted concept note:
+     1. Read frontmatter (title, type, domain, subdomain, topics, source_doc)
+     2. Check if concept already exists in concepts table (by vault_note_path)
+     3. If new: INSERT with status='pending', populate from frontmatter
+     4. If exists: update vault_note_path if moved, leave status unchanged
+  → Dashboard shows pending count on /study overview
+  → Telegram morning message includes: "N new concepts from yesterday"
+```
+
+**Frontmatter extension:** The ingestion agent prompt gets two new required fields:
+- `domain` — knowledge domain (e.g., "Knowledge Management", "Cognitive Psychology")
+- `subdomain` — subdomain within the domain (e.g., "KM Models", "Learning & Memory")
+
+These are added to the agent's generation prompt template and validation rules in `draft-validator.ts`.
+
+**Existing vault notes migration:** A one-time script scans `vault/concepts/` and creates pending concept entries for any note not yet in the concepts table. Domain/subdomain inferred from existing `topics` frontmatter field where possible, null otherwise.
+
+### 1.6 Testing Strategy
+
+**TDD (write tests first):**
+- SM-2 algorithm — pure function, easy to get wrong, critical for correctness
+- Weighted evidence mastery — time decay math, threshold logic, Bloom's ceiling
+- Session builder composition — block allocation, interleaving, constraints
+
+**Unit tests (write alongside):**
+- Engine concept progression (given state → recommendations)
+- Activity quality validation (Wozniak/Matuschak rules)
+- Concept discovery hook (frontmatter → pending concept)
+- DB CRUD functions for all study tables
+- Use Drizzle test helper (`createTestDb()`) from S0
+
+**Integration tests (write after feature works):**
+- Full cycle: build session → complete activity → mastery update → next session changes
+- Concept approval → activity generation trigger
+- Plan creation → concept association → session inclusion
+
+**Manual verification:**
+- All dashboard UI (start dev server, test flows)
+- Container agent dialogue quality (manual study sessions)
+- Telegram notifications (manual trigger)
+
+**Not tested:**
+- LLM output quality (test parsing, not generation)
+- E2E browser automation (overkill for single-user)
+- Coverage thresholds (focus on critical path correctness)
+
+### 1.7 Data Layer: Drizzle ORM
+
+The project migrates from raw SQL (`better-sqlite3` with hand-written queries) to **Drizzle ORM** before any study system work begins (S0). This is a full data layer rewrite that future-proofs the project for distribution and ongoing development.
+
+**Why Drizzle:**
+- Schema-as-code: TypeScript table definitions = single source of truth for types and schema
+- Built-in migrations: `drizzle-kit generate` produces SQL migration files, `drizzle-kit migrate` applies them. No hand-rolled ALTER TABLE or try-catch patterns.
+- Type-safe queries: all DB access is fully typed, no raw SQL string errors
+- Native `better-sqlite3` support: zero runtime overhead, synchronous API preserved
+- Lightweight: minimal dependency footprint (~50KB runtime)
+
+**Schema organization:**
+```
+src/db/
+  schema/
+    chats.ts              — chats, messages tables
+    tasks.ts              — scheduled_tasks, task_run_logs tables
+    ingestion.ts          — ingestion_jobs table
+    rag.ts                — rag_index_tracker table
+    groups.ts             — registered_groups, sessions tables
+    state.ts              — router_state, settings, zotero_sync tables
+    citations.ts          — citation_edges table
+    study.ts              — concepts, learning_activities, activity_log,
+                            study_sessions, study_plans + join tables
+  index.ts                — Drizzle instance, db export, shared helpers
+  migrate.ts              — Migration runner (called on startup)
+drizzle/
+  migrations/             — Generated SQL migration files (committed to git)
+drizzle.config.ts         — Drizzle Kit configuration
+```
+
+**Migration strategy:**
+- S0 creates a baseline migration from the current raw schema (12 existing tables)
+- S1 adds study tables as the next migration
+- Each subsequent schema change generates a new migration via `drizzle-kit generate`
+- Migrations run automatically on startup via `migrate()` in `src/db/migrate.ts`
+- Existing databases are migrated in-place; new installs run all migrations from scratch
+
+**Dashboard DB access:**
+- Dashboard imports the same Drizzle schema types for type safety
+- Dashboard's `study-db.ts` and `ingestion-db.ts` use Drizzle queries (not raw SQL)
+- Schema version mismatch (dashboard starts before main process runs migrations) handled by Drizzle's migration check — throws a clear error
+
+**Test infrastructure:**
+- `_initTestDatabase()` replaced with a Drizzle-based helper that creates an in-memory SQLite + runs all migrations
+- All existing tests updated to use Drizzle queries where they interact with DB
+- Test pattern: `const testDb = createTestDb()` → returns typed Drizzle instance
+
+---
+
+## 2. Group Setup
+
+Two new NanoClaw groups for study system agents.
+
+### 2.1 `groups/study/`
+
+Interactive study agent for dashboard chat.
+
+```
+groups/study/
+  CLAUDE.md          — Study agent system prompt
+  logs/              — Container logs (auto-created)
+```
+
+**CLAUDE.md contents (designed in S5, scaffolded in S2):**
+- Role: "You are a study tutor for Simon's university courses"
+- Available methods with instructions for each
+- Evaluation rubrics per Bloom's level
+- Brain-first enforcement rules
+- RAG query instructions (how to retrieve vault content)
+- IPC output format for study_complete
+- Concept and activity context injection pattern
+
+**Registration:** Added to `registered_groups` in DB with:
+- `jid`: `web:study:__agent__` (base JID, sessionId appended at runtime)
+- `folder`: `study`
+- `trigger_pattern`: null (no trigger needed — activated by web channel routing)
+- `requires_trigger`: 0
+- `is_main`: 0
+
+### 2.2 `groups/study-generator/`
+
+Batch activity generator for background tasks.
+
+```
+groups/study-generator/
+  CLAUDE.md          — Generation prompt with quality rules
+  logs/              — Container logs (auto-created)
+```
+
+**CLAUDE.md contents (designed in S3):**
+- Role: "You generate learning activities from vault content"
+- Activity type specifications with examples
+- Quality rules (Wozniak, Matuschak, anti-patterns)
+- Bloom's level mapping to activity types
+- Structured JSON output format
+- RAG query instructions
+
+**Registration:** Added to `registered_groups` with:
+- `jid`: `internal:study-generator` (not a real chat JID — triggered by scheduler)
+- `folder`: `study-generator`
+- `trigger_pattern`: null
+- `requires_trigger`: 0
+- `is_main`: 0
+
+---
+
+## 3. File Map
+
+All new and modified files, organized by sprint.
+
+### New files
+
+```
+src/db/                        — S0: Drizzle ORM data layer
+  schema/
+    chats.ts                   — S0: chats, messages tables
+    tasks.ts                   — S0: scheduled_tasks, task_run_logs tables
+    ingestion.ts               — S0: ingestion_jobs table
+    rag.ts                     — S0: rag_index_tracker table
+    groups.ts                  — S0: registered_groups, sessions tables
+    state.ts                   — S0: router_state, settings, zotero_sync tables
+    citations.ts               — S0: citation_edges table
+    study.ts                   — S1: study system tables (concepts, activities, sessions, plans)
+    index.ts                   — S0: re-exports all schemas
+  index.ts                     — S0: Drizzle instance, db export, helpers
+  migrate.ts                   — S0: Migration runner (called on startup)
+
+drizzle/
+  migrations/                  — S0+: Generated SQL migration files (committed to git)
+
+drizzle.config.ts              — S0: Drizzle Kit configuration
+
+src/study/
+  types.ts                     — S1: Non-DB interfaces, enums, result types
+  sm2.ts                       — S1: SM-2 algorithm (pure functions)
+  sm2.test.ts                  — S1: SM-2 tests (TDD)
+  mastery.ts                   — S1: Weighted evidence mastery (pure functions)
+  mastery.test.ts              — S1: Mastery tests (TDD)
+  engine.ts                    — S3: Concept progression, activity recommendations
+  engine.test.ts               — S3: Engine tests
+  session-builder.ts           — S3: Daily session composition
+  session-builder.test.ts      — S3: Session builder tests (TDD)
+  generator.ts                 — S3: Activity generation orchestration (container dispatch)
+  generator.test.ts            — S3: Generator tests
+  planner.ts                   — S6: Collaborative plan dialogue orchestration
+  audio.ts                     — S8: Audio/podcast generation pipeline
+  scheduled.ts                 — S7: Study-specific scheduled task definitions
+  concept-discovery.ts         — S2: Ingestion hook for concept creation
+  concept-discovery.test.ts    — S2: Discovery tests
+  index.ts                     — S1: Public exports
+
+groups/study/
+  CLAUDE.md                    — S2 (scaffold), S5 (full)
+
+groups/study-generator/
+  CLAUDE.md                    — S3
+
+dashboard/src/app/study/
+  page.tsx                     — S4: Study overview (concept list, due counts, mastery bars)
+  session/
+    page.tsx                   — S4: Study session UI (card review, elaboration, self-rating)
+  chat/
+    page.tsx                   — S5: Dashboard chat interface (SSE streaming)
+  plan/
+    page.tsx                   — S6: Plan creation and management
+  concepts/
+    [id]/
+      page.tsx                 — S8: Concept detail page
+
+dashboard/src/app/api/study/
+  concepts/
+    route.ts                   — S2: GET concepts list with mastery
+    pending/
+      route.ts                 — S2: GET pending concepts
+    approve/
+      route.ts                 — S2: POST approve concept(s)
+  session/
+    route.ts                   — S4: GET build session, POST create session record
+    [id]/
+      reflect/
+        route.ts               — S4: POST save reflection
+  complete/
+    route.ts                   — S4: POST complete activity
+  evaluate/
+    route.ts                   — S5: POST proxy to study agent for AI evaluation
+  plans/
+    route.ts                   — S6: GET list plans, POST create plan
+  stats/
+    route.ts                   — S8: GET analytics data
+  chat/
+    route.ts                   — S5: POST send message to study agent
+    stream/
+      [sessionId]/
+        route.ts               — S5: GET SSE stream from study agent
+
+dashboard/src/lib/
+  study-db.ts                  — S2: Dashboard-side Drizzle queries for study tables
+
+scripts/
+  migrate-vault-concepts.ts    — S2: One-time vault → concepts table migration
+```
+
+### Modified files
+
+```
+src/db.ts                      — S0: Replaced by src/db/index.ts (all raw SQL → Drizzle)
+src/ipc.ts                     — S3: study_generated_activities IPC; S5: study_complete + study_concept_status; S7: remaining IPC
+src/channels/web.ts            — S5: Add web:study: JID pattern + endpoints
+src/index.ts                   — S0: Drizzle startup; S5: findGroupForJid + study JID routing
+src/ingestion/pipeline.ts      — S2: Post-promotion concept discovery hook
+src/ingestion/draft-validator.ts — S2: Add domain/subdomain validation
+src/ingestion/agent-processor.ts — S2: Add domain/subdomain to generation prompt
+src/channels/registry.ts       — S5: Add onStudyClosed to ChannelOpts
+src/task-scheduler.ts          — S7: Register study scheduled tasks
+dashboard/src/app/layout.tsx   — S4: Add "Study" nav link
+dashboard/src/lib/ingestion-db.ts — S0: Raw SQL → Drizzle queries
+```
+
+---
+
+## 4. Sprint Plan
+
+### Dependency graph
+
+```
+S0: Drizzle Migration ───────────┐
+  (ORM migration, schema-as-code,│
+   migrate all queries + tests)  │
+                                 │
+S1: Foundation ──────────────────┤
+  (study schema, SM-2, mastery,  │
+   types, group scaffolds)       │
+                                 │
+S2: Concept Lifecycle ───────────┤
+  (CRUD, discovery, approval,    │
+   migration, basic /study page) │
+                                 │
+S3: Generation + Engine ─────────┤
+  (generator agent, engine,      │
+   session builder)              │
+                                 │
+         ┌───────────────────────┤
+         │                       │
+S4: Study Session UI        S5: Dashboard Chat + Deep Methods
+  (session page, self-rate,   (chat UI, SSE, study agent,
+   completion flow)            AI evaluation, L3-L6 gen)
+         │                       │
+         └───────────┬───────────┘
+                     │
+         ┌───────────┤
+         │           │
+S6: Planning    S7: Telegram + Scheduled
+  (plan dialogue,  (IPC handlers, daily/weekly
+   plan management) cron, Mr. Rogers integration)
+         │           │
+         └─────┬─────┘
+               │
+S8: Analytics + Audio + Polish
+  (stats, concept detail, podcasts,
+   scaffolding, staleness, prereqs)
+```
+
+### Parallelization opportunities
+
+| Phase | Session A | Session B | Notes |
+|-------|-----------|-----------|-------|
+| S0 | `src/db.ts` → Drizzle schema + queries | Dashboard DB files → Drizzle | Independent: backend vs. dashboard |
+| S1 | Study schema + types + group scaffolds | SM-2 + mastery algorithms (TDD) | Types file needed by both — create first or duplicate temporarily |
+| S2 | Sequential | — | Small sprint, not worth splitting |
+| S3 | Generator agent + CLAUDE.md | Engine + session builder (TDD) | Generator needs container; engine is pure logic |
+| S4 + S5 | Study session UI (S4) | Dashboard chat + web channel (S5) | Fully independent — different pages, different data flows |
+| S6 + S7 | Planning system (S6) | Telegram + scheduled tasks (S7) | Fully independent codepaths |
+| S8 | Analytics + concept detail | Audio + remaining polish | Independent features |
+
+---
+
+### S0: Drizzle ORM Migration
+
+**Goal:** Migrate the entire data layer from raw SQL to Drizzle ORM. All existing tables, queries, and tests converted. Baseline migration generated. Project is distribution-ready with proper schema management.
+
+**Estimated sessions:** 2-3 (parallelizable: backend vs. dashboard)
+
+**Dependencies:** None — this is the first sprint.
+
+**Key decisions:**
+- Full migration, not incremental. No raw SQL remains after S0.
+- Schema files organized by domain (see Section 1.7)
+- Drizzle Kit for migration generation; migrations committed to git
+- Migrations run automatically on startup
+- In-memory SQLite + Drizzle for test infrastructure
+- Dashboard uses same Drizzle schema types (imported) for type safety
+
+#### Checklist
+
+- [ ] **S0.0** Backup current database
+  - `cp store/messages.db store/messages.db.pre-drizzle-backup`
+  - Verify backup: `sqlite3 store/messages.db.pre-drizzle-backup "SELECT count(*) FROM chats"`
+- [ ] **S0.1** Install dependencies
+  - `npm install drizzle-orm` (runtime)
+  - `npm install -D drizzle-kit` (dev — migration generation + studio)
+  - `cd dashboard && npm install drizzle-orm` (dashboard runtime)
+- [ ] **S0.2** Create Drizzle config
+  - `drizzle.config.ts` at project root
+  - SQLite dialect, `better-sqlite3` driver
+  - Schema path: `src/db/schema/*`
+  - Migration output: `drizzle/migrations/`
+- [ ] **S0.3** Define existing table schemas in TypeScript
+  - `src/db/schema/chats.ts` — `chats`, `messages` tables
+  - `src/db/schema/tasks.ts` — `scheduled_tasks`, `task_run_logs` tables
+  - `src/db/schema/ingestion.ts` — `ingestion_jobs` table
+  - `src/db/schema/rag.ts` — `rag_index_tracker` table
+  - `src/db/schema/groups.ts` — `registered_groups`, `sessions` tables
+  - `src/db/schema/state.ts` — `router_state`, `settings`, `zotero_sync` tables
+  - `src/db/schema/citations.ts` — `citation_edges` table
+  - `src/db/schema/index.ts` — re-exports all schemas
+  - Each table must exactly match current CREATE TABLE + ALTER TABLE columns
+- [ ] **S0.4** Generate baseline migration
+  - `npx drizzle-kit generate` → produces initial SQL migration in `drizzle/migrations/`
+  - Verify generated SQL matches current `createSchema()` output
+  - Add `drizzle/migrations/meta/` journal file to git
+- [ ] **S0.5** Create Drizzle instance and migration runner
+  - `src/db/index.ts` — create `better-sqlite3` connection, wrap with `drizzle()`, export `db`
+  - `src/db/migrate.ts` — run pending migrations on startup via `migrate()`
+  - Preserve WAL mode and FK enforcement (`PRAGMA journal_mode = WAL; PRAGMA foreign_keys = ON`)
+  - Export `getDb()` for backwards compatibility during migration (can remove later)
+- [ ] **S0.6** Migrate all query functions in `src/db.ts` to Drizzle
+  - Replace raw SQL in every exported function with Drizzle query builder
+  - Maintain same function signatures (callers don't change yet)
+  - Functions to migrate (~50+): storeChatMetadata, storeMessage, getNewMessages, getMessagesSince, createTask, getTaskById, getDueTasks, updateTask, deleteTask, logTaskRun, createIngestionJob, getIngestionJobs, updateIngestionJob, getTrackedDoc, upsertTrackedDoc, deleteTrackedDoc, getRegisteredGroup, setRegisteredGroup, getAllRegisteredGroups, getRouterState, setRouterState, getSession, setSession, getSetting, setSetting, insertCitationEdge, deleteCitationEdges, getCites, getCitedBy, etc.
+  - Transaction support: Drizzle wraps `better-sqlite3`'s synchronous transactions natively
+- [ ] **S0.7** Migrate dashboard DB access to Drizzle
+  - `dashboard/src/lib/ingestion-db.ts` → Drizzle queries
+  - Any other dashboard files with raw SQL
+  - Import schema types from shared schema files (or duplicate — Next.js may need its own Drizzle instance due to separate process)
+  - Dashboard creates its own Drizzle instance pointing to same `store/messages.db`
+- [ ] **S0.8** Update test infrastructure
+  - Replace `_initTestDatabase()` with Drizzle-based helper: creates in-memory SQLite, runs all migrations, returns typed Drizzle instance
+  - Update all ~50 test files that use `_initTestDatabase()` or raw DB access
+  - Verify all 664 tests pass
+- [ ] **S0.9** Update startup sequence in `src/index.ts`
+  - Replace `initDatabase()` call with Drizzle migration runner
+  - Ensure migrations run before any other initialization (channels, IPC, scheduler)
+- [ ] **S0.10** Cleanup
+  - Remove old `createSchema()` function and inline ALTER TABLE migrations from `src/db.ts`
+  - Remove `_initTestDatabase()` (replaced by Drizzle test helper)
+  - Verify `npm test` passes, `npm run build` succeeds
+  - Verify dashboard `npm run dev` works with Drizzle
+
+**Acceptance criteria:**
+- Zero raw SQL remaining in `src/db.ts` or dashboard DB files
+- `drizzle/migrations/` contains baseline migration committed to git
+- All 664+ existing tests pass with Drizzle
+- New install (empty DB) runs migrations and produces correct schema
+- Existing install (populated DB) runs migrations without data loss
+- `npx drizzle-kit studio` can browse the database (dev tooling works)
+
+---
+
+### S1: Foundation
+
+**Goal:** Study system schema (as Drizzle migration), pure algorithms, shared types, group directory scaffolds. Everything downstream depends on this.
+
+**Estimated sessions:** 2 (parallelizable: schema vs. algorithms)
+
+**Key decisions:**
+- Study tables defined in `src/db/schema/study.ts` as Drizzle schema, migration generated via `drizzle-kit generate`
+- Transactions via Drizzle's native `db.transaction()` wrapper (synchronous, better-sqlite3)
+- Study query functions in `src/study/` modules (not in `src/db.ts` — study system is self-contained)
+- Types derived from Drizzle schema via `typeof table.$inferSelect` / `$inferInsert` where possible, custom interfaces in `src/study/types.ts` for non-DB types
+
+#### Checklist
+
+- [ ] **S1.1** Create `src/study/types.ts` — non-DB interfaces and enums
+  - ActivityType, BloomLevel, MasteryState enums/unions
+  - GeneratedActivity (generator agent output format)
+  - SessionComposition (session builder output)
+  - SM2Result, MasteryResult, CompletionResult, BloomAdvancement
+  - DB row types (Concept, LearningActivity, etc.) inferred from Drizzle schema via `$inferSelect`
+- [ ] **S1.2** Define study tables in `src/db/schema/study.ts` (Drizzle schema)
+  - `concepts` (with mastery_L1-L6, bloom_ceiling, status, domain/subdomain)
+  - `conceptPrerequisites` (concept_id → concepts)
+  - `learningActivities` (SM-2 fields, activity_type, bloom_level, author → concepts)
+  - `activityConcepts` (join table → learningActivities, concepts)
+  - `studyPlans` + `studyPlanConcepts` (learning contracts → concepts)
+  - `studySessions` (metacognition → studyPlans, nullable FK)
+  - `activityLog` (every interaction → learningActivities, studySessions)
+  - All indexes from spec Section 3.1
+  - Re-export from `src/db/schema/index.ts`
+- [ ] **S1.3** Generate and apply study tables migration
+  - `npx drizzle-kit generate` → new migration file in `drizzle/migrations/`
+  - Verify migration applies cleanly on existing DB (with S0 baseline)
+  - Verify fresh DB (all migrations from scratch) produces correct schema
+- [ ] **S1.4** Add study query functions in `src/study/` modules (Drizzle queries)
+  - Concept: create, get, getByDomain, getPending, updateStatus, updateMastery
+  - Activity: create, get, getDue, updateSM2, getByConceptAndType
+  - ActivityLog: create, getByConceptAndLevel, getBySession
+  - Session: create, update, getActive
+  - Plan: create, get, getAll, update, addConcepts
+  - Multi-table writes use Drizzle's `db.transaction()` (synchronous, native better-sqlite3)
+  - Add a test for transaction rollback on partial failure
+- [ ] **S1.5** Add DB tests for all study query functions
+- [ ] **S1.6** Implement SM-2 in `src/study/sm2.ts` (TDD)
+  - `computeSM2(quality, repetitions, easeFactor, interval) → SM2Result`
+  - `computeDueDate(interval, fromDate?) → string`
+  - Pure functions, no side effects, no DB access
+  - Edge cases: quality 0-5, first review, EF floor at 1.3
+- [ ] **S1.7** Implement weighted evidence mastery in `src/study/mastery.ts` (TDD)
+  - `computeMastery(activityLogs, now?) → MasteryResult`
+  - `computeBloomCeiling(mastery) → number`
+  - `computeOverallMastery(mastery) → number`
+  - Constants: BLOOM_WEIGHTS, MASTERY_THRESHOLD (10.0), DECAY_HALF_LIFE_DAYS (30)
+  - Time decay: `0.5^(daysSince / halfLife)`
+- [ ] **S1.8** Create `src/study/index.ts` — public exports
+- [ ] **S1.9** Scaffold group directories
+  - `groups/study/CLAUDE.md` — placeholder with role description
+  - `groups/study-generator/CLAUDE.md` — placeholder with role description
+
+**Acceptance criteria:**
+- All study tables created with correct schema (verified by DB tests)
+- SM-2 produces correct intervals for all quality values 0-5 across multiple repetitions
+- Mastery correctly computes per-level evidence with time decay
+- Bloom ceiling advances when evidence exceeds 70% of threshold
+- All tests pass (`npm test`)
+
+---
+
+### S2: Concept Lifecycle
+
+**Goal:** Concepts flow from ingestion → pending → active. Dashboard shows concept list with approval UI.
+
+**Estimated sessions:** 2
+
+**Dependencies:** S1 (tables + types)
+
+**Key decisions:**
+- Concept discovery is a synchronous call at end of `handlePromotion()`, not an async watcher
+- Domain/subdomain added to ingestion agent prompt as required frontmatter fields
+- Batch approval by domain is a single API call, not per-concept
+- The `/study` page in this sprint is minimal — concept list + approval. Session UI comes in S4.
+
+#### Checklist
+
+- [ ] **S2.1** Create `src/study/concept-discovery.ts`
+  - `discoverConcepts(promotedPaths: string[], vaultDir: string) → ConceptDiscovery[]`
+  - Reads each promoted `concepts/*.md`, extracts frontmatter
+  - Returns array of concept data ready for DB insert
+  - Handles: missing domain (null), existing concept (skip), non-concept notes (skip)
+- [ ] **S2.2** Tests for concept discovery
+- [ ] **S2.3** Hook concept discovery into `src/ingestion/pipeline.ts`
+  - At end of `handlePromotion()`, after promoted_paths are set
+  - Call `discoverConcepts()` → batch insert into concepts table with status='pending'
+  - Non-blocking: log errors but don't fail the promotion
+- [ ] **S2.4** Update ingestion agent prompt (`src/ingestion/agent-processor.ts`)
+  - Add `domain` and `subdomain` as required frontmatter fields for concept notes
+  - Add guidance: "domain is the broad knowledge area, subdomain is the specific topic area"
+- [ ] **S2.5** Update draft validator (`src/ingestion/draft-validator.ts`)
+  - Add `domain` and `subdomain` to required fields for type=concept (warning, not error — allows null)
+- [ ] **S2.6** Create `dashboard/src/lib/study-db.ts`
+  - Dashboard-side Drizzle queries for study tables (same pattern as `ingestion-db.ts` post-S0: own Drizzle instance, shared schema types)
+  - Functions: getConcepts, getPendingConcepts, approveConcept, approveDomain, getConceptStats
+- [ ] **S2.7** Create dashboard API routes
+  - `GET /api/study/concepts` — list concepts with mastery, Bloom's ceiling, due activity counts
+  - `GET /api/study/concepts/pending` — list pending concepts grouped by domain
+  - `POST /api/study/concepts/approve` — approve single or domain batch `{ conceptIds?: string[], domain?: string }`
+- [ ] **S2.8** Create dashboard `/study` page (minimal)
+  - Pending concepts section with domain-batch approve buttons
+  - Active concepts table: name, domain, Bloom's ceiling, mastery bar, due count
+  - Nav link added to `layout.tsx`
+- [ ] **S2.9** Create `scripts/migrate-vault-concepts.ts`
+  - Scans `vault/concepts/`, creates pending entries for notes not in concepts table
+  - Infers domain from `topics` frontmatter where possible
+  - Idempotent: safe to run multiple times
+- [ ] **S2.10** Scaffold `groups/study/` registration
+  - Register study group in DB (manual or via setup script)
+  - CLAUDE.md updated with basic study context (full prompt designed in S5)
+
+**Acceptance criteria:**
+- Ingesting a new PDF produces pending concepts visible on `/study`
+- Domain-batch approval moves concepts to active status
+- Migration script correctly creates entries for existing vault notes
+- No regressions in ingestion pipeline (existing tests pass)
+
+---
+
+### S3: Generation + Engine
+
+**Goal:** System can generate activities for concepts, recommend what to study, and compose sessions.
+
+**Estimated sessions:** 3-4 (parallelizable: generator vs. engine)
+
+**Dependencies:** S2 (concepts exist in DB)
+
+**Key decisions:**
+- Generator agent receives concept content via RAG query (not direct vault mount — consistent with how other agents access knowledge)
+- Engine is a pure logic module — no container spawning, no LLM calls. It reads DB state and returns recommendations.
+- Session builder outputs a `SessionComposition` object that the API returns directly to the dashboard.
+- Activity generation is rate-limited: max 10 concepts per cycle.
+
+#### Checklist
+
+- [ ] **S3.1** Design generator agent CLAUDE.md (`groups/study-generator/CLAUDE.md`)
+  - Role, output format (JSON array of activities), quality rules
+  - Bloom's level guidelines: what to generate at each level
+  - Anti-pattern list from spec Section 3.3
+  - Example outputs for each activity type
+- [ ] **S3.2** Implement `src/study/generator.ts`
+  - `generateActivities(conceptId, bloomLevel, options?) → GeneratedActivity[]`
+  - Queries RAG for concept's vault content
+  - Builds generation prompt with Bloom's level + quality rules
+  - Spawns generator agent container (single-turn)
+  - Parses structured JSON output
+  - Validates against quality rules (rejects anti-patterns)
+  - Stores valid activities in learning_activities table with SM-2 initial params
+  - Rate limit: tracks concepts per cycle, queues remainder
+- [ ] **S3.3** Generator tests (mock container output, test parsing + validation + DB writes)
+- [ ] **S3.4** Implement `src/study/engine.ts`
+  - `getConceptRecommendations(conceptId) → ActivityRecommendation[]`
+    - Given mastery state, returns recommended activity types and Bloom's levels
+  - `checkForAdvancement(conceptId) → BloomAdvancement | null`
+    - After activity completion, checks if concept advanced to new Bloom's level
+  - `processCompletion(activityId, quality, opts?) → CompletionResult`
+    - Updates SM-2 on activity, logs to activity_log, updates concept mastery
+    - Checks for advancement, returns whether generation is needed
+    - All within a transaction
+    - Note: `activity_log.session_id` is nullable — completions before S4 (and out-of-session completions like Telegram) pass `session_id = NULL`
+  - `getDeEscalationAdvice(conceptId) → string | null`
+    - If quality consistently < 3 and mastery declining, suggest returning to lower level
+  - `getSynthesisOpportunities(domain?) → SynthesisOpportunity[]`
+    - Within-subdomain: auto when 2+ concepts have bloom_ceiling >= 4
+    - Within-domain: auto when concepts across subdomains have bloom_ceiling >= 4
+    - Cross-domain: proposed only, requires confirmation
+- [ ] **S3.5** Engine tests (with in-memory DB, test progression scenarios)
+- [ ] **S3.6** Implement `src/study/session-builder.ts` (TDD)
+  - `buildDailySession(options?) → SessionComposition`
+  - Three blocks:
+    - New material (~30%): L1-L2 activities for recent concepts, blocked by topic
+    - Review (~50%): mixed types, interleaved across concepts/domains
+    - Stretch (~20%): highest available Bloom's for concepts at ceiling 4+
+  - Constraints: 25-30 min target OR 15-25 activities, at least 1 per active domain
+  - Sorting: overdue first, low ease_factor, type variety
+  - Never 2 consecutive same-concept activities in review block
+- [ ] **S3.7** Session builder tests (TDD — test block allocation, interleaving, constraints)
+- [ ] **S3.8** Add `study_generated_activities` IPC handler to `src/ipc.ts`
+  - Receives generator agent output (array of activities)
+  - Validates and inserts into learning_activities table
+  - Creates activity_concepts entries for multi-concept activities
+  - Needed for generator output to reach the DB
+- [ ] **S3.9** Post-session generation trigger
+  - After session completion, engine checks for Bloom's advancements
+  - Dispatches generator for each advanced concept (background, rate-limited)
+  - Queues remainder for next cycle
+
+**Acceptance criteria:**
+- Generator produces valid activities for a concept at each Bloom's level
+- Generated activities pass quality validation (no anti-patterns)
+- Engine correctly recommends activity types based on mastery state
+- Session builder produces balanced sessions with correct block composition
+- Completion flow: activity done → SM-2 updated → mastery updated → advancement detected → generation triggered
+
+---
+
+### S4: Study Session UI
+
+**Goal:** End-to-end study loop on the dashboard for self-rated activities (L1-L2).
+
+**Estimated sessions:** 2
+
+**Dependencies:** S3 (engine + session builder produce sessions)
+
+**Key decisions:**
+- Session UI handles only self-rated activities in this sprint. AI evaluation added in S5.
+- Activity type determines UI variant (card → text input, elaboration → text area, etc.)
+- Pre/post session metacognition is basic: confidence rating (pre) + reflection text (post)
+
+#### Checklist
+
+- [ ] **S4.1** Create study session API routes
+  - `GET /api/study/session` — calls session builder, returns SessionComposition
+  - `POST /api/study/session` — creates study_sessions record with pre_confidence
+  - `POST /api/study/complete` — calls engine.processCompletion(), returns result
+  - `POST /api/study/session/[id]/reflect` — saves post_reflection, computes calibration
+- [ ] **S4.2** Update `/study` overview page
+  - Today's session card: activity counts by type, estimated time, "Start Session" button
+  - Active concepts with Bloom's ceiling, mastery bars per level, due counts
+  - 7-day streak indicator (sessions completed)
+- [ ] **S4.3** Create `/study/session` page
+  - Pre-session: confidence rating per concept (1-5 slider/buttons)
+  - Activity flow: show prompt → student types response → submit → reveal reference → self-rate (0-5)
+  - Activity type variants:
+    - `card_review`: question → text input → reference answer
+    - `elaboration`: "Why?" prompt → text area → source reasoning
+  - Progress bar: activities completed / total
+  - Skip button (logs quality=0)
+  - Block labels ("New Material", "Review", "Stretch") with explanations
+- [ ] **S4.4** Post-session reflection
+  - Calibration feedback: compare pre-confidence vs. actual performance
+  - Reflection prompt: "What did you find surprising or difficult?"
+  - Session summary: activities completed, average quality, time spent
+- [ ] **S4.5** Add "Study" link to dashboard nav (`layout.tsx`)
+
+**Acceptance criteria:**
+- Student can start a session, complete card + elaboration activities, rate themselves
+- SM-2 schedules update after each completion (due dates change)
+- Mastery bars update after session
+- Pre/post metacognition flow works
+- Session recorded in study_sessions table
+
+---
+
+### S5: Dashboard Chat + Deep Methods
+
+**Goal:** Full conversational interface for deep learning methods (Feynman, Socratic, etc.) and AI evaluation.
+
+**Estimated sessions:** 3-4
+
+**Dependencies:** S3 (engine), S4 (completion flow)
+
+**Key decisions:**
+- Web channel extended with `web:study:` JID pattern (not a separate server)
+- Chat transcripts saved per-activity in activity_log, linked to session
+- Study agent gets full CLAUDE.md with method instructions and RAG access
+- AI evaluation returns both a quality score (0-5) and textual feedback
+
+#### Checklist
+
+- [ ] **S5.1** Extend web channel and message routing for study sessions
+  - `src/channels/web.ts`: Add `WEB_STUDY_PREFIX = 'web:study:'` constant
+  - `src/channels/web.ts`: Update `ownsJid()` to match both `web:review:` and `web:study:` prefixes
+  - `src/channels/web.ts`: Add `sendMessage()` handling for `web:study:` JIDs (route to study SSE clients)
+  - `src/channels/web.ts`: New endpoint `POST /study-message` — accepts `{ sessionId, text }`, routes to study container
+  - `src/channels/web.ts`: New endpoint `GET /study-stream/{sessionId}` — SSE connection for study chat
+  - `src/channels/web.ts`: New endpoint `POST /study-close/{sessionId}` — close study session container
+  - `src/index.ts`: Extend `findGroupForJid()` with `WEB_STUDY_PREFIX` handler (analogous to `WEB_REVIEW_PREFIX`)
+  - `src/index.ts`: Add `activeWebStudyJids` tracking set (or generalize `activeWebReviewJids` to handle both patterns)
+  - `src/index.ts`: Update `channelOpts.onMessage` to add study JIDs to tracking set
+  - `src/channels/registry.ts`: Add `onStudyClosed?: (sessionId: string) => void` to `ChannelOpts` (or generalize `onDraftClosed`)
+  - `src/index.ts`: Wire `onStudyClosed` in `channelOpts` to kill study container and remove from active JID set
+- [ ] **S5.2** Design full study agent CLAUDE.md (`groups/study/CLAUDE.md`)
+  - Method-specific instructions: Feynman (identify gaps, ask clarifying), Socratic (question assumptions, don't reveal), case analysis (multi-step framework), synthesis (cross-concept integration)
+  - Brain-first rules: never lead with answers, always let student attempt first
+  - Evaluation rubrics per Bloom's level
+  - IPC output format: study_complete with quality + feedback
+  - Session state injection pattern (concept, method, Bloom's level as context in first message)
+- [ ] **S5.3** Create dashboard chat API routes
+  - `POST /api/study/chat` — proxy message to web channel study endpoint
+  - `GET /api/study/chat/stream/[sessionId]` — proxy SSE from web channel
+- [ ] **S5.4** Create `/study/chat` page
+  - Message list with SSE streaming (real-time agent responses)
+  - Text input with send button
+  - Session context display: current concept, method, Bloom's level
+  - Method selector: Feynman, Socratic, Case Analysis, Synthesis, Free
+  - Concept selector: pick concept to discuss
+  - "End session" button that triggers study_close
+- [ ] **S5.5** AI evaluation endpoint
+  - `POST /api/study/evaluate` — sends student response + activity context to study agent
+  - Study agent evaluates against vault content via RAG
+  - Returns: `{ quality: number, feedback: string }`
+  - Dashboard displays feedback alongside self-rating (hybrid evaluation for L2-L3)
+- [ ] **S5.6** Integrate AI evaluation into `/study/session` page
+  - For L3+ activities: show "AI is evaluating..." after submission
+  - Display AI feedback + quality alongside student's self-rating
+  - For L2-L3: show both ratings (calibration training)
+  - For L4-L6: AI rating feeds SM-2 (primary)
+- [ ] **S5.7** Add L3-L6 activity types to `/study/session`
+  - `self_explain`: "Explain X" → large text area → AI gap analysis
+  - `concept_map`: concept list → relationship builder (text-based initially)
+  - `comparison`: comparison prompt → structured input → expert analysis
+  - `case_analysis`: scenario → multi-step response → expert comparison
+  - `synthesis`: integration prompt → essay area → AI feedback
+  - `socratic`: redirects to `/study/chat` with Socratic method pre-selected
+- [ ] **S5.8** Expand generator for L3-L6 activity types
+  - Update generator CLAUDE.md with L3-L6 generation guidelines
+  - Add activity types: self_explain, concept_map, comparison, case_analysis, synthesis, socratic
+  - Update quality validation for new types
+- [ ] **S5.9** Add `study_complete` and `study_concept_status` IPC handlers to `src/ipc.ts`
+  - `study_complete`: process activity completion from study agent (quality, feedback, response)
+  - `study_concept_status`: return concept mastery state to study agent for context
+  - Needed for AI evaluation flow (study agent evaluates → reports back via IPC)
+- [ ] **S5.10** Add stretch block to session builder
+  - Stretch block (20%): one L5-L6 activity if concepts at bloom_ceiling 4+
+  - Only included if student has eligible concepts
+
+**Acceptance criteria:**
+- Dashboard chat streams agent responses in real-time
+- Feynman dialogue: student explains → agent identifies gaps → follow-up questions
+- AI evaluation returns quality + feedback for L3+ activities
+- All 8 activity types functional in session UI
+- Transcripts saved and linked to sessions/concepts
+
+---
+
+### S6: Planning System
+
+**Goal:** Collaborative study plan creation through dialogue.
+
+**Estimated sessions:** 2
+
+**Dependencies:** S5 (dashboard chat for plan dialogue)
+
+**Key decisions:**
+- Planning dialogue happens in dashboard chat with method="plan"
+- Plan data structure stores results of dialogue — all optional fields except domain + concepts
+- Quick path (30s) doesn't require chat — direct API call with defaults
+- Deep path uses chat agent to guide through 5-phase framework
+
+#### Checklist
+
+- [ ] **S6.1** Implement `src/study/planner.ts`
+  - `createQuickPlan(title, conceptIds, options?) → StudyPlan`
+    - Quick path: select concepts + defaults, no dialogue needed
+  - `processPlanDialogue(sessionTranscript) → PlanUpdate`
+    - Extracts plan fields from dialogue transcript
+    - Handles partial: only fills fields the student provided
+  - Plan lifecycle: active → completed → archived
+  - Checkpoint computation: next_checkpoint_at = created_at + checkpoint_interval_days
+- [ ] **S6.2** Create plan API routes
+  - `GET /api/study/plans` — list plans with concept counts + progress
+  - `POST /api/study/plans` — create plan (quick or from dialogue)
+- [ ] **S6.3** Create `/study/plan` page
+  - Active plans list with progress, upcoming checkpoints
+  - "New Plan" button → choice: Quick (form) or Guided (opens chat with plan mode)
+  - Quick form: title, select concepts (grouped by domain), strategy, optional deadline
+  - Plan detail view: concept progress within plan, checkpoint history
+- [ ] **S6.4** Update study agent for plan dialogue
+  - Add plan dialogue instructions to CLAUDE.md
+  - 5-phase framework: Discover → Define → Design → Commit → Adapt
+  - "Want to go deeper?" at natural break points
+  - Output: study_plan IPC message with extracted fields
+- [ ] **S6.5** Plan integration with engine
+  - Session builder respects active plans: prioritize plan concepts
+  - Plan concepts get target_bloom from plan (not just system default)
+  - Checkpoint due → suggest plan review in daily summary
+
+**Acceptance criteria:**
+- Quick plan creation works (30-second path)
+- Guided plan dialogue produces a valid plan through chat
+- Plans appear on `/study/plan` with concept progress
+- Session builder includes plan concepts with appropriate priority
+
+---
+
+### S7: Telegram + Scheduled Tasks
+
+**Goal:** Mr. Rogers sends daily reminders, supports quick review, study system has cron tasks.
+
+**Estimated sessions:** 2
+
+**Dependencies:** S3 (engine), S4 (completion flow)
+
+**Key decisions:**
+- Study IPC handlers extend existing `src/ipc.ts` switch/case
+- Scheduled tasks use existing task scheduler infrastructure (cron patterns)
+- Mr. Rogers quick review: sends card prompt via Telegram, student responds, Telegram agent evaluates
+- Telegram completion data flows through IPC to main process
+
+#### Checklist
+
+- [ ] **S7.1** Add remaining study IPC handlers to `src/ipc.ts`
+  - `study_session`: return today's due activities (for Telegram quick review)
+  - `study_generate`: trigger activity generation for concept (for Telegram-triggered generation)
+  - Note: `study_generated_activities` added in S3.8, `study_complete` + `study_concept_status` added in S5.9
+- [ ] **S7.2** Create `src/study/scheduled.ts`
+  - `buildMorningTask() → ScheduledTaskConfig`
+    - Check for generation gaps, build session, compose Telegram message
+    - "Good morning! 15 activities ready (~25 min). 3 new concepts from yesterday."
+  - `buildWeeklyTask() → ScheduledTaskConfig`
+    - Progress summary: retention, concepts advanced, Bloom's distribution
+    - Cross-domain synthesis suggestions
+    - Plan checkpoint reminder
+  - `buildMonthlyTask() → ScheduledTaskConfig`
+    - Comprehensive mastery review, decay detection, growth trajectory
+- [ ] **S7.3** Register scheduled tasks
+  - Daily: morning (e.g., 07:00) via cron
+  - Weekly: Sunday evening via cron
+  - Monthly: 1st of month via cron
+  - Registration in DB via existing `createTask()` or setup script
+- [ ] **S7.4** Update Mr. Rogers for study integration
+  - Update `groups/telegram_main/CLAUDE.md` with study awareness
+  - Quick card review: Mr. Rogers sends card prompt, student responds, agent evaluates
+  - Light elaboration: "Why does X work?" style prompts
+  - Concept discovery alerts in morning message
+- [ ] **S7.5** SQLite backup scheduled task
+  - Daily cron: `cp store/messages.db store/backups/messages-{YYYY-MM-DD}.db`
+  - Retain last 7 daily backups (rotate out older ones)
+  - Lightweight — SQLite in WAL mode supports safe hot copies via `.backup` command
+- [ ] **S7.6** Telegram quick review flow
+  - Mr. Rogers picks 3-5 due card activities
+  - Sends as individual messages: "Quick review: [prompt]"
+  - Student responds in chat
+  - Mr. Rogers evaluates, sends feedback, logs via study_complete IPC
+
+**Acceptance criteria:**
+- Daily Telegram message with session summary and concept alerts
+- Quick card review works via Telegram (send, respond, evaluate)
+- Weekly summary includes retention and progression data
+- All scheduled tasks register and fire on schedule
+
+---
+
+### S8: Analytics + Audio + Polish
+
+**Goal:** Feature-complete system with analytics, audio, and remaining features.
+
+**Estimated sessions:** 2-3
+
+**Dependencies:** S4-S7 (all core features)
+
+#### Checklist
+
+- [ ] **S8.1** Analytics API and dashboard
+  - `GET /api/study/stats` — retention rate, calibration score, per-level mastery, time to level, method effectiveness, Bloom's distribution
+  - Analytics section on `/study` page: charts, trends, method comparison
+- [ ] **S8.2** Concept detail page (`/study/concepts/[id]`)
+  - Bloom's level mastery breakdown (6-level bar chart)
+  - Activity history for this concept
+  - Method effectiveness comparison
+  - Related concepts (from activity_concepts)
+  - Vault source link
+  - "Generate more activities" button
+- [ ] **S8.3** Audio/podcast generation (`src/study/audio.ts`)
+  - Script generation via generator agent
+  - TTS via Mistral API (existing integration)
+  - Content types: concept summary, review primer, weekly digest
+  - Storage: audio files linked to concepts
+- [ ] **S8.4** Telegram podcast delivery
+  - Send audio via existing `sendVoice()` channel method
+  - Triggered by scheduled task or on-demand
+- [ ] **S8.5** Student-generated activities
+  - Prompting in dashboard chat at key moments (post-struggle, post-insight)
+  - `author = 'student'` in learning_activities
+  - Quality refinement through chat agent
+- [ ] **S8.6** Scaffolding hint system
+  - 5 levels: no hints → contextual → structural → partial → worked example → full explanation
+  - Adaptive: target 70-85% success rate
+  - Integrated into activity UI: "Need a hint?" button
+- [ ] **S8.7** Prerequisite awareness
+  - Flag when concept's prerequisites have weak mastery
+  - Display on session UI: "Note: prerequisite X has low mastery"
+  - Non-blocking: student decides whether to proceed
+- [ ] **S8.8** Staleness detection
+  - Compare source_chunk_hash against current vault content
+  - Flag stale activities on session UI
+  - "Regenerate" button for stale activities
+- [ ] **S8.9** Monthly scheduled task
+  - Comprehensive mastery check across all domains
+  - Decay detection: identify concepts with declining mastery evidence
+  - Plan adaptation recommendation
+  - Growth trajectory: Bloom's distribution over time
+
+**Backlog (post-S8):**
+- RSVP vault integration: deep-link from study activities to `/read` page (spec Phase 4)
+- FSRS migration evaluation: assess whether to replace SM-2 with FSRS (spec Phase 4, data model supports it)
+- Data export: Anki-compatible card export, CSV learning history export (spec Section 12)
+- Offline/degraded mode: dashboard read-only without main process (spec Section 12)
+
+**Acceptance criteria:**
+- Analytics page shows meaningful learning data
+- Concept detail page provides full per-concept view
+- Audio generation produces listenable podcasts
+- Scaffolding adapts based on success rate
+- Stale activities flagged and regenerable
+
+---
+
+## 5. Risk Register
+
+| Risk | Impact | Likelihood | Mitigation | Sprint |
+|------|--------|------------|------------|--------|
+| Web channel study sessions conflict with existing draft review sessions | High | Medium | Separate JID namespace (`web:study:` vs `web:review:`), separate SSE endpoints | S5 |
+| Generator agent produces low-quality activities | Medium | High | Quality validation in generator.ts, anti-pattern rejection, iterative CLAUDE.md tuning | S3 |
+| Container 30-min timeout too short for deep study sessions | Medium | Low | Timeout resets on activity (existing behavior). If needed, make configurable per-group. | S5 |
+| Dashboard + main process concurrent SQLite writes | Medium | Low | WAL mode + `busy_timeout = 5000` on both processes. Two Node.js processes (Next.js + main), not two users. | S0, S1 |
+| Drizzle migration breaks existing data | High | Low | Pre-migration DB backup (S0.0). Baseline migration matches current schema exactly. Test on copy first. | S0 |
+| Drizzle schema drift from raw SQL in tests/scripts | Low | Medium | Grep for raw SQL after S0 completion. All DB access must go through Drizzle. | S0 |
+| Container concurrency during study + generation | Low | Low | Study agent (long-lived) + generator (single-turn) + Telegram = 3 concurrent. MAX_CONCURRENT_CONTAINERS=5 has headroom. | S3, S5 |
+| Mastery model parameters need tuning (threshold, decay half-life) | Low | High | All constants in `mastery.ts`, easy to adjust. Log raw data for analysis. | S1, ongoing |
+| Ingestion agent doesn't produce good domain/subdomain values | Medium | Medium | Make domain/subdomain warnings (not errors) in validator. Allow null, classify at approval. | S2 |
+| Session builder produces unbalanced sessions with few concepts | Low | Medium | Graceful degradation: skip blocks with no eligible activities, min 1 activity per session | S3 |
+| Chat transcript storage grows large | Low | Low | Only store for AI-evaluated activities. Truncate after configurable limit. | S5 |
+
+---
+
+## 6. Definition of Done
+
+A sprint is complete when:
+
+1. All checklist items checked off
+2. All new code has tests (per testing strategy: TDD for algorithms, unit for orchestration, integration for flows)
+3. Existing tests still pass (`npm test`)
+4. Dashboard features manually verified in browser
+5. No regressions in ingestion pipeline, RAG indexing, or existing dashboard pages
+6. Sub-plan document updated with any deviations from this master plan

--- a/docs/superpowers/plans/2026-04-14-s0-drizzle-migration.md
+++ b/docs/superpowers/plans/2026-04-14-s0-drizzle-migration.md
@@ -1,0 +1,638 @@
+# S0: Drizzle ORM Migration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the entire data layer from raw SQL (better-sqlite3 with hand-written queries) to Drizzle ORM. All 12 existing tables, ~45 query functions, dashboard DB access, and test infrastructure converted. Baseline migration generated and committed. Zero raw SQL remains.
+
+**Architecture:** Drizzle wraps the existing better-sqlite3 connection (synchronous, zero overhead). Schema files in `src/db/schema/` define tables in TypeScript — the single source of truth for types and DDL. `drizzle-kit generate` produces SQL migration files committed to git. All query functions rewritten with Drizzle's query builder, maintaining identical function signatures so callers don't change. Dashboard gets its own Drizzle instance pointing to the same SQLite file.
+
+**Tech Stack:** drizzle-orm + drizzle-kit (new), better-sqlite3 (existing), SQLite, Vitest
+
+**Master plan:** `docs/superpowers/plans/2026-04-13-study-system-master-plan.md` § 1.7 + Sprint S0
+
+**Essential reading before implementing:**
+- `src/db.ts` — the entire file. This is what you're replacing. Understand every function, every table, every ALTER TABLE migration.
+- `src/types.ts` — `NewMessage`, `ScheduledTask`, `TaskRunLog`, `RegisteredGroup` interfaces. Your Drizzle schemas must produce compatible types.
+- `src/shared/db-reader.ts` — middleman module that wraps `src/db.ts` functions. It uses no raw SQL itself.
+- `dashboard/src/lib/ingestion-db.ts` — dashboard's independent DB access with its own raw SQL. This needs a full Drizzle rewrite.
+- `src/db.test.ts` — the main DB test file. Understand what behavior is being verified.
+- `src/db-migration.test.ts` — tests the migration from legacy schemas. Needs rewriting for Drizzle.
+
+---
+
+## Why Drizzle, and Why Now
+
+The current `src/db.ts` is 1100 lines of hand-written SQL with 16 try-catch ALTER TABLE migrations for columns added after initial release. Every new table or column means more raw SQL strings with no type checking and another try-catch migration block. The study system (S1+) adds 7+ new tables — doing that with raw SQL would be unmaintainable.
+
+Drizzle gives us:
+- **Schema-as-code** — TypeScript table definitions are the single source of truth. Types and DDL come from the same place.
+- **Generated migrations** — `drizzle-kit generate` diffs your schema against the last migration and produces SQL. No hand-written ALTER TABLE.
+- **Type-safe queries** — the query builder catches column name typos, wrong types, missing required fields at compile time.
+- **Zero overhead** — Drizzle's better-sqlite3 driver is a thin wrapper. Same synchronous API, same performance.
+
+The migration happens now (S0) because everything in S1–S8 depends on it. If we build study tables on raw SQL, we'd have to migrate them later anyway.
+
+---
+
+## Key Decisions
+
+Read these before writing any code. They explain WHY the implementation looks the way it does.
+
+### 1. Snake_case property names in Drizzle schemas
+
+The existing TypeScript types (`NewMessage`, `ScheduledTask`, `ChatInfo`) use snake_case: `chat_jid`, `is_from_me`, `last_message_time`. If we used camelCase in Drizzle schemas, every function would need mapping code to convert between Drizzle's return types and the existing interfaces.
+
+**Decision:** S0 schemas use snake_case property names matching the DB column names. This means `typeof chats.$inferSelect` produces types compatible with existing interfaces — no mapping code, no caller changes.
+
+**Tradeoff:** Not idiomatic TypeScript. S1+ study tables can use camelCase since they're new code with no backwards compatibility concern.
+
+### 2. Idempotent baseline migration
+
+Drizzle's migration runner (`migrate()`) tracks applied migrations in a `__drizzle_migrations` table. On an existing database that predates Drizzle, this table doesn't exist, so Drizzle tries to run the baseline migration — which would `CREATE TABLE` for tables that already exist, and fail.
+
+**Decision:** After generating the baseline migration with `drizzle-kit generate`, manually edit the SQL to add `IF NOT EXISTS` to all `CREATE TABLE` and `CREATE INDEX` statements. This makes it safe everywhere:
+- Fresh database: tables don't exist → creates them
+- Existing database: tables already exist → no-op, Drizzle records it as applied
+
+**Why not runtime detection?** We considered checking for pre-existing tables and marking the baseline as applied in `__drizzle_migrations`. That requires reading Drizzle's journal format and computing hashes. The idempotent approach is simpler, has no edge cases, and the edit is a one-time committed change.
+
+### 3. Barrel re-export strategy
+
+25 files import from `src/db.ts` (11 production + 14 test). Changing all import paths at once is risky. Instead:
+
+- Build `src/db/index.ts` with all migrated functions
+- Convert `src/db.ts` to a thin barrel: `export { ... } from './db/index.js'`
+- All existing `from './db.js'` imports continue to work unchanged
+- Optionally update import paths later (low priority, no behavior change)
+
+This means the switch-over is atomic: one file change (`src/db.ts` → barrel), full test suite verifies everything.
+
+### 4. Dashboard schema duplication
+
+The dashboard runs as a separate Next.js process. Its existing code (`dashboard/src/lib/ingestion-db.ts`) has a comment: "Next.js/Turbopack cannot bundle TypeScript source from outside the project root." The dashboard can't `import from '../../src/db/schema/'`.
+
+**Decision:** Dashboard gets `dashboard/src/lib/db/schema.ts` with Drizzle definitions for just the 2 tables it uses (ingestion_jobs, settings). These must match the main schemas exactly. The dashboard creates its own Drizzle instance pointing to the same `store/messages.db`.
+
+**Why not a shared package?** Overkill for a single-developer project with 2 shared tables. If the dashboard needs more tables later, consider a workspace package then.
+
+### 5. No `integer({ mode: 'boolean' })` in S0
+
+Drizzle can auto-convert 0/1 integers to booleans with `{ mode: 'boolean' }`. But the existing code does manual conversion everywhere:
+```typescript
+requiresTrigger: row.requires_trigger === null ? undefined : row.requires_trigger === 1,
+```
+
+If we use `mode: 'boolean'`, Drizzle returns `true/false/null` instead of `0/1/null`. That `=== 1` check would silently break (it'd compare `true === 1` which is `false` in strict equality).
+
+**Decision:** Plain `integer()` for all boolean-like columns. Conversion logic stays in functions unchanged. Switch to `mode: 'boolean'` when types are updated (S1+ or later cleanup).
+
+### 6. Use `sql` template only when the builder can't express it
+
+Drizzle's `sql` tagged template is an escape hatch for SQL that the query builder can't represent. It should be used for:
+- `MAX()`, `COALESCE()` in ON CONFLICT SET clauses
+- `excluded.column_name` references in upserts
+- `datetime('now')` (SQLite function) in defaults and updates
+
+It should NOT be used for comparisons, conditions, or logic that Drizzle has operators for (`eq`, `gt`, `lte`, `ne`, `like`, `and`, `or`, `inArray`, etc.). If you find yourself writing `sql`column <= value``, use `lte(column, value)` instead.
+
+---
+
+## File Structure
+
+### New files
+
+```
+drizzle.config.ts                    — Drizzle Kit configuration
+src/db/
+  schema/
+    chats.ts                         — chats, messages tables
+    tasks.ts                         — scheduled_tasks, task_run_logs tables
+    ingestion.ts                     — ingestion_jobs table
+    rag.ts                           — rag_index_tracker table
+    groups.ts                        — registered_groups, sessions tables
+    state.ts                         — router_state, settings, zotero_sync tables
+    citations.ts                     — citation_edges table
+    index.ts                         — re-exports all schema tables
+  index.ts                           — Drizzle instance, init, all query functions
+  migrate.ts                         — Migration runner
+drizzle/
+  migrations/                        — Generated SQL (committed to git)
+dashboard/src/lib/db/
+  schema.ts                          — Dashboard-side schema (ingestion_jobs, settings only)
+  index.ts                           — Dashboard Drizzle instance
+```
+
+### Modified files
+
+```
+src/db.ts                            — Converted to re-export barrel for ./db/index.js
+dashboard/src/lib/ingestion-db.ts    — Raw SQL → Drizzle queries
+src/db-migration.test.ts             — Rewritten for Drizzle migration path
+src/ingestion/db-ingestion.test.ts   — getDb().prepare() → getDb().all(sql`...`)
+package.json                         — drizzle-orm (dep), drizzle-kit (devDep)
+dashboard/package.json               — drizzle-orm (dep)
+```
+
+### Unchanged files (25 total — verified by existing tests)
+
+All consumer files — import paths unchanged because `src/db.ts` barrel re-exports everything:
+
+**Production (11):** `src/index.ts`, `src/ipc.ts`, `src/task-scheduler.ts`, `src/channels/web.ts`, `src/shared/db-reader.ts`, `src/rag/indexer.ts`, `src/ingestion/{pipeline,index,citation-linker,job-recovery,zotero-watcher}.ts`
+
+**Tests (14):** 12 files using `_initTestDatabase()` (function signature preserved), `src/ingestion/zotero-watcher.test.ts` (vi.mock), `src/db-migration.test.ts` (rewritten in Task 8)
+
+---
+
+## Task 1: Dependencies, Backup, and Config
+
+**Files:** `package.json`, `dashboard/package.json`, `drizzle.config.ts` (new)
+
+- [ ] **Step 1:** Backup the database: `cp store/messages.db store/messages.db.pre-drizzle-backup`
+- [ ] **Step 2:** Install: `npm install drizzle-orm && npm install -D drizzle-kit && cd dashboard && npm install drizzle-orm`
+- [ ] **Step 3:** Create `drizzle.config.ts` at project root:
+
+```typescript
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  dialect: 'sqlite',
+  schema: './src/db/schema/*',
+  out: './drizzle/migrations',
+  dbCredentials: {
+    url: './store/messages.db',
+  },
+});
+```
+
+The `dbCredentials.url` is only used by `drizzle-kit studio` (dev tooling) — the app resolves the path from `STORE_DIR` at runtime.
+
+- [ ] **Step 4:** Verify: `npx tsc --noEmit` passes
+- [ ] **Step 5:** Commit
+
+---
+
+## Task 2: Schema Definitions
+
+**Files:** All files in `src/db/schema/`
+
+Define every existing table as a Drizzle schema. The source of truth is `src/db.ts:17-263` — the `createSchema()` function plus all the ALTER TABLE try-catch blocks below it. Every column, constraint, default, and index must match exactly.
+
+**Important context:** The current schema evolved through 16 ALTER TABLE migrations wrapped in try-catch (lines 112-263). The Drizzle schemas must represent the FINAL state — all columns present, no migration logic. The Drizzle baseline migration replaces all that incremental ALTER TABLE code.
+
+### How to define each schema file
+
+Use `sqliteTable` from `drizzle-orm/sqlite-core`. Key patterns:
+
+- **Column naming:** Property name = DB column name (snake_case). Write `jid: text('jid')` — the string argument is the SQL column name.
+- **Primary keys:** Single-column: `.primaryKey()` on the column. Composite: `primaryKey({ columns: [table.col1, table.col2] })` in the third argument.
+- **NOT NULL:** Add `.notNull()`. Check the original CREATE TABLE — only columns explicitly marked NOT NULL or part of a PRIMARY KEY get this.
+- **Defaults:** `.default(0)` for literals, `.default(sql`(datetime('now'))`)` for SQL expressions. The parentheses matter for SQLite expression defaults.
+- **Foreign keys:** `.references(() => otherTable.column)` — works for same-file references (messages → chats, taskRunLogs → scheduledTasks).
+- **Indexes:** In the third argument: `index('idx_name').on(table.column)`. Multi-column: `.on(table.col1, table.col2)`. Use the exact index names from the current schema.
+- **UNIQUE:** `.unique()` on the column (e.g., `registered_groups.folder`).
+- **AUTOINCREMENT:** `integer('id').primaryKey({ autoIncrement: true })` (only `task_run_logs.id`).
+
+### Schema file inventory
+
+Create these files based on the table groupings. Read `src/db.ts:17-263` to get exact columns.
+
+| File | Tables | Notable details |
+|------|--------|-----------------|
+| `chats.ts` | `chats`, `messages` | messages has composite PK `(id, chat_jid)`, FK to chats.jid, index on timestamp |
+| `tasks.ts` | `scheduled_tasks`, `task_run_logs` | task_run_logs has AUTOINCREMENT, FK to scheduled_tasks.id, composite index on `(task_id, run_at)` |
+| `ingestion.ts` | `ingestion_jobs` | 16 columns (most added via ALTER TABLE), 3 indexes, `datetime('now')` defaults |
+| `rag.ts` | `rag_index_tracker` | All columns NOT NULL, index on doc_id |
+| `groups.ts` | `registered_groups`, `sessions` | folder is UNIQUE, defaults on requires_trigger and is_main |
+| `state.ts` | `router_state`, `settings`, `zotero_sync` | settings has `datetime('now')` default on updated_at |
+| `citations.ts` | `citation_edges` | Composite PK `(source_slug, target_slug)`, index on target_slug |
+| `index.ts` | — | Re-exports all tables from the other files |
+
+- [ ] **Step 1:** Create all 8 schema files based on `src/db.ts:17-263`
+- [ ] **Step 2:** Verify: `npx tsc --noEmit` passes
+- [ ] **Step 3:** Commit
+
+---
+
+## Task 3: Generate Baseline Migration
+
+**Files:** `drizzle/migrations/` (generated)
+
+- [ ] **Step 1:** Run `npx drizzle-kit generate` — produces SQL and `meta/_journal.json` in `drizzle/migrations/`
+- [ ] **Step 2:** Make the baseline idempotent — edit the generated SQL:
+  - `CREATE TABLE ` → `CREATE TABLE IF NOT EXISTS `
+  - `CREATE INDEX ` → `CREATE INDEX IF NOT EXISTS `
+  - `CREATE UNIQUE INDEX ` → `CREATE UNIQUE INDEX IF NOT EXISTS `
+
+  (See Key Decision #2 for why.)
+
+- [ ] **Step 3:** Verify the generated SQL matches the current schema. Spot-check:
+  - `messages` has composite PK and FK to chats
+  - `task_run_logs` has AUTOINCREMENT and FK to scheduled_tasks
+  - `ingestion_jobs` has all 16 columns with correct defaults
+  - `registered_groups.folder` has UNIQUE
+  - All index names and columns match `src/db.ts`
+- [ ] **Step 4:** Commit
+
+---
+
+## Task 4: Drizzle Instance and Migration Runner
+
+**Files:** `src/db/migrate.ts` (new), `src/db/index.ts` (new — initial version)
+
+### Migration runner (`src/db/migrate.ts`)
+
+A simple function that calls Drizzle's `migrate()` with the path to the migrations folder. Uses `import.meta.url` to resolve the path relative to the module (works in ESM). The function takes a `BetterSQLite3Database` — the Drizzle instance.
+
+### Initial `src/db/index.ts`
+
+This file will eventually contain all ~45 query functions. Start with just the infrastructure:
+
+- Module-level variables: `db` (Drizzle instance, type `BetterSQLite3Database`) and `rawSqlite` (the underlying better-sqlite3 connection, needed for `_closeDatabase` and pragmas)
+- `initDatabase()` — creates better-sqlite3 connection, sets WAL mode + FK pragma, wraps with `drizzle()`, calls `runMigrations()`, calls `migrateJsonState()`
+- `_initTestDatabase()` — creates in-memory better-sqlite3, wraps with Drizzle, runs migrations. Same name and signature as the current version — all 12 test files call this in `beforeEach`.
+- `_closeDatabase()` — closes the underlying better-sqlite3 connection
+- `getDb()` — returns the Drizzle instance (type changes from `Database.Database` to `BetterSQLite3Database` — see Gotcha #1)
+- `migrateJsonState()` — copy from current `src/db.ts:1038-1096`. It calls `setRouterState`, `setSession`, `setRegisteredGroup` which are Drizzle functions you'll add in Task 6. The file won't compile until those functions exist.
+- Import `* as schema from './schema/index.js'` — all schema tables available as `schema.chats`, `schema.messages`, etc.
+
+**Note on `_initTestDatabase`:** The current version calls `createSchema(db)` (raw DDL). The new version calls `runMigrations(db)` (Drizzle migrations). The migrations create the same tables. This is the mechanism that makes all 12 existing test files work unchanged — they call `_initTestDatabase()` in beforeEach and get a fresh in-memory DB with correct schema.
+
+- [ ] **Step 1:** Create `src/db/migrate.ts`
+- [ ] **Step 2:** Create `src/db/index.ts` with infrastructure functions (no query functions yet)
+- [ ] **Step 3:** Commit
+
+---
+
+## Task 5: Migrate All Query Functions
+
+**Files:** `src/db/index.ts`
+
+This is the bulk of the work. You're converting ~45 functions from raw SQL (`.prepare().run()`, `.prepare().get()`, `.prepare().all()`) to Drizzle's query builder. The function signatures, parameter types, and return types must not change — callers don't know the implementation switched.
+
+### Conversion patterns
+
+Read `src/db.ts` thoroughly. Every function follows one of these patterns:
+
+#### Pattern A: Simple SELECT
+
+```typescript
+// OLD: db.prepare('SELECT * FROM x WHERE id = ?').get(id) as T | undefined
+// NEW: db.select().from(schema.x).where(eq(schema.x.id, id)).get() as T | undefined
+
+// OLD: db.prepare('SELECT * FROM x ORDER BY y DESC').all() as T[]
+// NEW: db.select().from(schema.x).orderBy(desc(schema.x.y)).all() as T[]
+```
+
+The `as T` casts match what the old code does. Drizzle's return types are nullable (`string | null`) while existing interfaces use non-null (`string`). The cast bridges this — same pattern as before.
+
+For column subsets, use named selections:
+```typescript
+db.select({ id: schema.x.id, status: schema.x.status }).from(schema.x).where(...)
+```
+
+#### Pattern B: INSERT
+
+```typescript
+// OLD: db.prepare('INSERT INTO x (a, b) VALUES (?, ?)').run(a, b)
+// NEW: db.insert(schema.x).values({ a, b }).run()
+```
+
+#### Pattern C: Upsert (INSERT OR REPLACE / ON CONFLICT)
+
+Most "INSERT OR REPLACE" calls become `onConflictDoUpdate` which is actually safer (no cascading deletes, no row recreation):
+
+```typescript
+// Simple upsert — replace a value
+db.insert(schema.routerState)
+  .values({ key, value })
+  .onConflictDoUpdate({ target: schema.routerState.key, set: { value } })
+  .run();
+
+// INSERT OR IGNORE
+db.insert(schema.citationEdges)
+  .values({ source_slug, target_slug, created_at })
+  .onConflictDoNothing()
+  .run();
+```
+
+**Tricky case — `storeChatMetadata`:** Uses `MAX()` and `COALESCE()` in the ON CONFLICT SET clause. These require `sql` template because the query builder can't express SQL functions in upsert sets. The `excluded.column_name` syntax refers to the proposed (conflicting) row's values — this is raw SQLite, written as a string inside `sql`:
+
+```typescript
+.onConflictDoUpdate({
+  target: schema.chats.jid,
+  set: {
+    name: sql`excluded.name`,
+    last_message_time: sql`MAX(${schema.chats.last_message_time}, excluded.last_message_time)`,
+    channel: sql`COALESCE(excluded.channel, ${schema.chats.channel})`,
+  },
+})
+```
+
+In `sql` templates: `${schema.chats.column}` resolves to the current row's column reference. Plain text like `excluded.name` stays as raw SQL.
+
+**The `storeChatMetadata` function has two code paths** (with name vs. without name) that produce different SET clauses. Read the original carefully and preserve both paths.
+
+#### Pattern D: UPDATE with dynamic fields
+
+`updateTask` and `updateIngestionJob` build SET clauses dynamically from a partial updates object. In Drizzle, build a plain object and pass it to `.set()`:
+
+```typescript
+const set: Record<string, unknown> = {};
+if (updates.status !== undefined) set.status = updates.status;
+if (updates.error !== undefined) set.error = updates.error;
+// ... etc
+db.update(schema.x).set(set).where(eq(schema.x.id, id)).run();
+```
+
+For `updateIngestionJob`, always include `updated_at: sql`datetime('now')`` in the set. When `status === 'completed'`, also set `completed_at: sql`datetime('now')`` — this mirrors the original logic.
+
+#### Pattern E: Conditional status in UPDATE
+
+`updateTaskAfterRun` sets status to 'completed' only when `nextRun` is null. Don't use a SQL CASE expression — express this in TypeScript:
+
+```typescript
+const set: Record<string, unknown> = {
+  next_run: nextRun,
+  last_run: now,
+  last_result: lastResult,
+};
+if (nextRun === null) {
+  set.status = 'completed';
+}
+db.update(schema.scheduledTasks).set(set).where(eq(schema.scheduledTasks.id, id)).run();
+```
+
+Drizzle only updates columns present in the `set` object — omitted columns are left unchanged. This is cleaner than a CASE expression.
+
+#### Pattern F: DELETE
+
+```typescript
+// OLD: db.prepare('DELETE FROM x WHERE id = ?').run(id)
+// NEW: db.delete(schema.x).where(eq(schema.x.id, id)).run()
+```
+
+Note: `deleteTask` must delete from `task_run_logs` first (FK constraint), then from `scheduled_tasks`. Same order as the original.
+
+#### Pattern G: Message queries with reverse
+
+`getNewMessages` and `getMessagesSince` use a subquery pattern: get the N most recent messages (ORDER BY DESC LIMIT N), then return them in chronological order. Replace the subquery with `.reverse()`:
+
+```typescript
+db.select({ /* specific columns — NOT is_bot_message */ })
+  .from(schema.messages)
+  .where(and(
+    gt(schema.messages.timestamp, sinceTimestamp),
+    eq(schema.messages.is_bot_message, 0),
+    not(like(schema.messages.content, `${botPrefix}:%`)),
+    ne(schema.messages.content, ''),
+    isNotNull(schema.messages.content),
+    // For getNewMessages: inArray(schema.messages.chat_jid, jids)
+    // For getMessagesSince: eq(schema.messages.chat_jid, chatJid)
+  ))
+  .orderBy(desc(schema.messages.timestamp))
+  .limit(limit)
+  .all()
+  .reverse()
+```
+
+The `.reverse()` produces identical results to the original subquery — it's O(n) on an already-small array.
+
+### Drizzle operators to import
+
+```typescript
+import { eq, and, gt, lte, ne, like, not, isNotNull, inArray, desc, sql } from 'drizzle-orm';
+```
+
+Use these instead of `sql` template for all comparisons and conditions.
+
+### Function inventory
+
+Every function listed here must be migrated. Check them off as you go. Read the original implementation in `src/db.ts` for each one.
+
+**Chat & messages** (8 functions + ChatInfo interface):
+- [ ] `storeChatMetadata` — Pattern C (complex upsert with MAX/COALESCE, two code paths)
+- [ ] `updateChatName` — Pattern C (simple upsert)
+- [ ] `getAllChats` — Pattern A
+- [ ] `getLastGroupSync` — Pattern A (special `__group_sync__` sentinel JID)
+- [ ] `setLastGroupSync` — Pattern C (upsert sentinel)
+- [ ] `storeMessage` — Pattern C (upsert on composite PK `[messages.id, messages.chat_jid]`)
+- [ ] `storeMessageDirect` — delegate to `storeMessage` (same logic, keep wrapper for API compat)
+- [ ] `getNewMessages` — Pattern G (reverse) + dynamic IN clause via `inArray`
+- [ ] `getMessagesSince` — Pattern G (reverse)
+
+**Tasks** (9 functions):
+- [ ] `createTask` — Pattern B
+- [ ] `getTaskById` — Pattern A
+- [ ] `getTasksForGroup` — Pattern A
+- [ ] `getAllTasks` — Pattern A
+- [ ] `updateTask` — Pattern D (dynamic update)
+- [ ] `deleteTask` — Pattern F (two deletes, order matters for FK)
+- [ ] `getDueTasks` — Pattern A (use `lte()` for the `<= now` comparison, NOT `sql`)
+- [ ] `updateTaskAfterRun` — Pattern E (conditional status)
+- [ ] `logTaskRun` — Pattern B
+
+**Router state & sessions** (5 functions):
+- [ ] `getRouterState` — Pattern A
+- [ ] `setRouterState` — Pattern C (simple upsert)
+- [ ] `getSession` — Pattern A
+- [ ] `setSession` — Pattern C (simple upsert)
+- [ ] `getAllSessions` — Pattern A (build Record from rows)
+
+**Registered groups** (3 functions):
+- [ ] `getRegisteredGroup` — Pattern A + post-processing (JSON.parse container_config, boolean conversion, folder validation). Read `src/db.ts:686-724` carefully — the mapping logic is non-trivial.
+- [ ] `setRegisteredGroup` — Pattern C (upsert with all columns in SET, JSON.stringify container_config, folder validation)
+- [ ] `getAllRegisteredGroups` — Pattern A + same mapping as getRegisteredGroup, with folder validation logging
+
+**Ingestion** (11 functions):
+- [ ] `getIngestionJobByPath` — Pattern A (ORDER BY + LIMIT 1)
+- [ ] `getCompletedJobByHash` — Pattern A
+- [ ] `getIngestionJobByZoteroKey` — Pattern A (NOT IN via `not(inArray(..., ['dismissed', 'failed']))`)
+- [ ] `deleteIngestionJob` — Pattern F
+- [ ] `createIngestionJob` — Pattern B
+- [ ] `getIngestionJobById` — Pattern A (returns `unknown`)
+- [ ] `getIngestionJobs` — Pattern A (optional status filter)
+- [ ] `getJobsByStatus` — Pattern A
+- [ ] `updateIngestionJob` — Pattern D (dynamic update with `datetime('now')` side effects)
+- [ ] `getRecentlyCompletedJobs` — Pattern A
+
+**Settings** (2 functions):
+- [ ] `getSetting` — Pattern A (returns default if not found)
+- [ ] `setSetting` — Pattern C (upsert with `datetime('now')` in updated_at)
+
+**RAG tracker** (3 functions + TrackedDoc interface):
+- [ ] `getTrackedDoc` — Pattern A (return null, not undefined, for miss)
+- [ ] `upsertTrackedDoc` — Pattern C (upsert with all columns)
+- [ ] `deleteTrackedDoc` — Pattern F
+
+**Citations** (4 functions):
+- [ ] `insertCitationEdge` — Pattern C (`onConflictDoNothing` for INSERT OR IGNORE)
+- [ ] `deleteCitationEdges` — Pattern F
+- [ ] `getCites` — Pattern A (map rows to string array)
+- [ ] `getCitedBy` — Pattern A (map rows to string array)
+
+**Zotero** (2 functions):
+- [ ] `getZoteroSyncVersion` — Pattern A (parseInt on value)
+- [ ] `setZoteroSyncVersion` — Pattern C (upsert, String(version))
+
+- [ ] **Step 1:** Migrate functions group by group, verifying `npx tsc --noEmit` after each group
+- [ ] **Step 2:** Ensure `migrateJsonState()` (from Task 4) compiles — it references `setRouterState`, `setSession`, `setRegisteredGroup`
+- [ ] **Step 3:** Commit after each group or when the file compiles cleanly
+
+---
+
+## Task 6: Switch Over — Convert `src/db.ts` to Barrel
+
+**Files:** `src/db.ts`, `src/ingestion/db-ingestion.test.ts`
+
+This is the moment of truth. All ~45 functions exist in `src/db/index.ts`. Now swap the old implementation for a barrel re-export.
+
+- [ ] **Step 1:** Replace the entire contents of `src/db.ts` with re-exports from `./db/index.js`. Export every function, interface, and type that was previously exported. The barrel must be complete — any missing export breaks a consumer.
+
+  Cross-reference: grep for every `import { ... } from './db.js'` and `import { ... } from '../db.js'` in the codebase. Every imported symbol must be in the barrel.
+
+- [ ] **Step 2:** Fix `src/ingestion/db-ingestion.test.ts` — one test calls `getDb().prepare()` which is raw better-sqlite3 API. `getDb()` now returns a Drizzle instance. Change it to use Drizzle's `sql` template:
+
+  ```typescript
+  import { sql } from 'drizzle-orm';
+  // ...
+  it('does not have a review_items table', () => {
+      const db = getDb();
+      expect(() => {
+        db.all(sql`SELECT * FROM review_items`);
+      }).toThrow();
+  });
+  ```
+
+- [ ] **Step 3:** Run `npm run build` — must succeed
+- [ ] **Step 4:** Run `npm test` — all 665 tests must pass
+
+  If tests fail, common causes:
+  - Missing export in the barrel (symbol not found)
+  - Drizzle returning `null` where old code returned `undefined` (check function return types)
+  - Column name mismatch in a select (Drizzle uses schema property names)
+  - `sql` template syntax error in an ON CONFLICT clause
+  - Boolean-like integer handling (0/1 comparisons)
+
+- [ ] **Step 5:** Commit
+
+---
+
+## Task 7: Migrate Dashboard DB Access
+
+**Files:** `dashboard/src/lib/db/schema.ts` (new), `dashboard/src/lib/db/index.ts` (new), `dashboard/src/lib/ingestion-db.ts`
+
+The dashboard currently has its own raw SQL in `dashboard/src/lib/ingestion-db.ts` — a completely separate DB access layer that opens its own better-sqlite3 connection to `store/messages.db`. This needs the same Drizzle treatment.
+
+### Dashboard schema (`dashboard/src/lib/db/schema.ts`)
+
+Define Drizzle schemas for ONLY the 2 tables the dashboard uses: `ingestion_jobs` and `settings`. These must be identical to the main schemas in `src/db/schema/ingestion.ts` and `src/db/schema/state.ts`. Copy the table definitions — same columns, same types, same defaults.
+
+### Dashboard Drizzle instance (`dashboard/src/lib/db/index.ts`)
+
+Same pattern as the current `dashboard/src/lib/ingestion-db.ts` connection setup: read `STORE_DIR` env var (fallback to `../store`), create better-sqlite3 connection, set WAL + FK + busy_timeout pragmas, wrap with `drizzle()`. Lazy singleton pattern (create on first `getDb()` call).
+
+### Rewrite `dashboard/src/lib/ingestion-db.ts`
+
+Replace all raw SQL with Drizzle queries. The dashboard has 7 functions:
+
+- [ ] `getRecentJobs` — select from ingestion_jobs with optional status filter, limit 100
+- [ ] `getJobDetail` — select by id, parse `promoted_paths` JSON
+- [ ] `getJobSourcePath` — select source_path by id
+- [ ] `retryJob` — select + validate status + update (reset to appropriate stage)
+- [ ] `dismissJob` — select + validate status + update to 'dismissed'
+- [ ] `getSettings` — select from settings, parseInt + clamp
+- [ ] `updateSettings` — upsert into settings
+
+The `rowToSummary` helper maps snake_case DB columns to camelCase `JobSummary` — this stays, but reads from Drizzle result objects instead of raw `DbRow`.
+
+- [ ] **Step 1:** Create dashboard schema and Drizzle instance
+- [ ] **Step 2:** Rewrite `ingestion-db.ts` functions to use Drizzle
+- [ ] **Step 3:** Run `cd dashboard && npm run build`
+- [ ] **Step 4:** Run `cd dashboard && npm test` (if tests exist)
+- [ ] **Step 5:** Commit
+
+---
+
+## Task 8: Update `src/db-migration.test.ts`
+
+**Files:** `src/db-migration.test.ts`
+
+The existing test creates a legacy database (only the `chats` table, pre-migration) and verifies that `initDatabase()` upgrades it. With Drizzle, the baseline migration creates all tables with all columns — there are no ALTER TABLE upgrades. The test should verify:
+
+1. **Fresh database:** Running `initDatabase()` on an empty DB produces correct schema (all tables exist)
+2. **Existing database:** Running `initDatabase()` on a DB that already has tables preserves existing data (idempotent baseline)
+
+For test #2: create a "pre-Drizzle" database with a `chats` table and data, then call `initDatabase()` and verify the data survives.
+
+Both tests use the dynamic import pattern (create temp dir, chdir, `vi.resetModules()`, `await import('./db.js')`) — same pattern as the current test.
+
+- [ ] **Step 1:** Rewrite both test cases
+- [ ] **Step 2:** Run `npx vitest run src/db-migration.test.ts`
+- [ ] **Step 3:** Commit
+
+---
+
+## Task 9: Final Verification and Cleanup
+
+- [ ] **Step 1:** Verify zero raw SQL remains:
+  ```bash
+  grep -rn '\.prepare(' src/ --include='*.ts' | grep -v node_modules | grep -v '.test.ts'
+  grep -rn '\.prepare(' dashboard/src/ --include='*.ts' | grep -v node_modules
+  ```
+  Expected: No results.
+
+- [ ] **Step 2:** Run full test suite: `npm test` — all 665 tests pass
+- [ ] **Step 3:** Run build: `npm run build`
+- [ ] **Step 4:** Dashboard build: `cd dashboard && npm run build`
+- [ ] **Step 5:** Verify Drizzle Kit studio: `npx drizzle-kit studio` — opens browser showing all 12 tables
+- [ ] **Step 6:** Test on existing database:
+  ```bash
+  cp store/messages.db.pre-drizzle-backup store/messages.db
+  npm run dev  # Verify startup succeeds, Ctrl+C after confirming
+  ```
+- [ ] **Step 7:** Commit any remaining cleanup
+
+---
+
+## Acceptance Criteria
+
+From the master plan — all must be true before S0 is complete:
+
+- [ ] Zero raw SQL remaining in `src/db.ts`, `src/db/index.ts`, or dashboard DB files
+- [ ] `drizzle/migrations/` contains baseline migration committed to git
+- [ ] All 665+ existing tests pass with Drizzle (`npm test`)
+- [ ] `npm run build` succeeds
+- [ ] Dashboard `npm run build` succeeds
+- [ ] New install (empty DB) runs migrations and produces correct schema
+- [ ] Existing install (populated DB) runs migrations without data loss
+- [ ] `npx drizzle-kit studio` can browse the database
+
+---
+
+## Note on S0.9 (Startup Sequence)
+
+The master plan S0.9 says to "replace `initDatabase()` call with Drizzle migration runner." Because this plan preserves `initDatabase()` as the entry point (re-exported through the barrel) with Drizzle internals, the startup call in `src/index.ts` requires **no change**. The same `initDatabase()` call works — it now creates a Drizzle instance and calls `runMigrations()` internally.
+
+---
+
+## Parallelization
+
+Per master plan § Parallelization:
+
+| Session A (backend) | Session B (dashboard) |
+|---------------------|-----------------------|
+| Tasks 1–6, 8–9 | Task 7 (after Task 2 — needs schema defs) |
+
+Task 7 (dashboard) is independent of the backend function migration and can run in parallel once schema files exist.
+
+---
+
+## Notes for S1
+
+After S0 is complete, S1 adds study system tables:
+
+1. Create `src/db/schema/study.ts` with new table definitions (camelCase property names OK for new tables)
+2. Run `npx drizzle-kit generate` → produces a new migration in `drizzle/migrations/`
+3. The migration runner picks it up automatically on next startup
+4. Study query functions go in `src/study/` modules (not `src/db/index.ts`)
+5. Types derived from Drizzle schema: `typeof concepts.$inferSelect`

--- a/docs/superpowers/plans/2026-04-14-s1-study-engine.md
+++ b/docs/superpowers/plans/2026-04-14-s1-study-engine.md
@@ -1,0 +1,911 @@
+# S1: Study Engine Foundation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Your role:** You are the engineer implementing this. The plan tells you *what* to build and *why*. You decide *how* within the stated constraints. If you disagree with an approach or see a better alternative, flag it before implementing — don't silently deviate and don't silently comply with something you think is wrong.
+
+**Goal:** Create the study system database tables, SM-2 scheduling algorithm, weighted evidence mastery model, study query functions, and group directory scaffolds — everything downstream sprints (S2-S8) depend on.
+
+**Architecture:** Study tables defined as Drizzle schema in `src/db/schema/study.ts`, migration generated via `drizzle-kit generate`. Pure algorithm modules (`sm2.ts`, `mastery.ts`) have zero DB or side-effect dependencies. Query functions live in `src/study/queries.ts` using the existing Drizzle `getDb()` pattern from `src/db/index.ts`. Types derived from Drizzle schemas via `$inferSelect`/`$inferInsert` — no hand-written row interfaces.
+
+**Tech Stack:** Drizzle ORM (better-sqlite3), Vitest, TypeScript
+
+**Branch:** Create `feat/s1-study-engine` off `main`. S0 (Drizzle migration) is already merged via PR #27.
+
+**Spec:** `docs/superpowers/specs/2026-04-12-multi-method-study-system-design.md` (v2.1, Sections 3.1, 3.2, 4.1, 4.2)
+
+**Master plan:** `docs/superpowers/plans/2026-04-13-study-system-master-plan.md` (S1 checklist)
+
+**Spec deviations (intentional — do not "fix" these to match the spec):**
+- **D3:** The spec's SQL shows `bloom_ceiling INTEGER DEFAULT 1`. This plan uses `DEFAULT 0` (meaning "no level mastered yet"). The spec's comment says "highest Bloom's level with sufficient mastery" which is 0 when nothing is mastered. The default value in the spec SQL is a minor error; this plan's value is correct.
+- **`SM2Result` type:** Defined in `sm2.ts` alongside the algorithm, NOT in `types.ts`. This keeps the SM-2 module self-contained with zero imports from the study subsystem. `types.ts` holds mastery types and forward-declared types for later sprints.
+
+---
+
+## Essential Reading
+
+Study these files before writing any code. You need to understand the patterns and conventions in the existing codebase — not just what this plan says.
+
+| File | Why |
+|------|-----|
+| `src/db/schema/tasks.ts` | Drizzle table definition pattern: `sqliteTable()`, column types, index builder, FK references |
+| `src/db/schema/chats.ts` | Same, plus composite primary key pattern |
+| `src/db/index.ts` | `getDb()` accessor, `_initTestDatabase()` / `_closeDatabase()` test helpers, existing query function patterns (how CRUD is structured, how `onConflictDoUpdate` is used, how transactions could work) |
+| `src/db/migrate.ts` | Migration runner (called on startup, reads from `drizzle/migrations/`) |
+| `drizzle.config.ts` | Drizzle Kit config — schema glob path, migration output dir |
+| `src/db-migration.test.ts` | Migration test pattern — creates fresh DB, checks tables and columns exist |
+| `vitest.config.ts` | Test file discovery pattern (`src/**/*.test.ts`) |
+| Spec Section 3.1 (lines 248-441) | The SQL CREATE TABLE statements these schemas must match |
+| Spec Section 4.1-4.2 (lines 511-571) | The SM-2 and mastery algorithm pseudocode |
+
+---
+
+## Key Decisions
+
+### D1: Study queries live in `src/study/`, not `src/db/`
+
+`src/db/index.ts` contains all existing NanoClaw query functions (~45 functions, ~1100 lines). The study system adds another ~25 functions. Rather than growing that file further, study queries live in their own module at `src/study/queries.ts`.
+
+**Tradeoff:** Consumers now have two import paths for DB functions (`src/db/index.js` for NanoClaw core, `src/study/queries.js` for study). This is acceptable because the study system is a self-contained subsystem — downstream sprint code (S2-S8) imports from `src/study/` exclusively.
+
+### D2: camelCase Drizzle properties for new study tables
+
+Existing schemas use snake_case properties that mirror SQL column names (`group_folder`, `last_message_time`). New study tables use camelCase properties (`conceptId`, `vaultNotePath`) while still mapping to snake_case SQL columns via `text('vault_note_path')`.
+
+**Why:** The existing tables were a 1:1 transliteration of raw SQL during S0 migration — matching snake_case was the lowest-risk approach. New tables have no legacy to match. camelCase properties are more ergonomic in TypeScript and are Drizzle's recommended convention. The study subsystem is self-contained, so the inconsistency is scoped — you'll never mix `schema.scheduled_tasks.group_folder` and `schema.concepts.vaultNotePath` in the same query.
+
+**Constraint:** SQL column names MUST remain snake_case (the `text('column_name')` argument). Only the TypeScript property names are camelCase.
+
+**This is an explicit user instruction, not an oversight.** Do not "fix" the naming to snake_case to match existing schemas. The schema in Task 2 shows the exact property names to use.
+
+### D3: Bloom ceiling = highest mastered level (not next level)
+
+The spec says: "highest Bloom's level with sufficient mastery." If L1 is mastered, `bloom_ceiling = 1`. If nothing is mastered, `bloom_ceiling = 0`. The engine (S3) will use `bloom_ceiling + 1` to recommend the next level to work toward.
+
+**Why:** The ceiling describes *current state* ("where are you"), not a *directive* ("what to work on next"). State belongs in the DB; directives belong in the engine logic.
+
+### D4: `completeActivity` is a transaction in the query layer
+
+Activity completion touches 3-4 tables (learning_activities SM-2 update, activity_log insert, concepts mastery update, optionally study_sessions count increment). This must be atomic — partial writes produce inconsistent mastery scores.
+
+**Why not a separate service layer?** The study system has exactly one multi-table write operation right now. Adding a service layer for one function is premature abstraction. If S3+ adds more complex workflows, refactor then.
+
+### D5: Types derived from Drizzle, not hand-written
+
+DB row types use `$inferSelect` / `$inferInsert` on the Drizzle schema tables. Non-DB types (algorithm inputs/outputs, enums) live in `src/study/types.ts`. No hand-written interfaces that duplicate column definitions.
+
+**Why:** Single source of truth. When a column is added or renamed in the schema, the type updates automatically.
+
+---
+
+## File Map
+
+### New files
+
+| File | Responsibility |
+|------|---------------|
+| `src/db/schema/study.ts` | Drizzle table definitions: concepts, concept_prerequisites, learning_activities, activity_concepts, activity_log, study_sessions, study_plans, study_plan_concepts |
+| `src/study/types.ts` | Non-DB types: enums/unions, algorithm result interfaces, forward-declared types for later sprints |
+| `src/study/sm2.ts` | Pure SM-2 algorithm |
+| `src/study/sm2.test.ts` | SM-2 tests (TDD) |
+| `src/study/mastery.ts` | Pure weighted evidence mastery |
+| `src/study/mastery.test.ts` | Mastery tests (TDD) |
+| `src/study/queries.ts` | All study CRUD + transactional `completeActivity` |
+| `src/study/queries.test.ts` | Query function tests |
+| `src/study/index.ts` | Barrel re-exports |
+| `groups/study/CLAUDE.md` | Placeholder study agent prompt |
+| `groups/study-generator/CLAUDE.md` | Placeholder generator agent prompt |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/db/schema/index.ts` | Add `export * from './study.js'` |
+| `src/db-migration.test.ts` | Add study tables to expected tables list |
+
+---
+
+## Task 1: Study Types
+
+**Files:** Create `src/study/types.ts`
+
+Define all non-DB types. DB row types come from Drizzle `$inferSelect` in `queries.ts` (Task 6).
+
+**Agent discretion:** Naming, JSDoc detail level, whether to use `type` aliases or `enum` for the union types. The values themselves are fixed by the spec.
+
+- [ ] **Step 1: Create type definitions**
+
+```typescript
+// === Enums / Unions ===
+// Values from spec Section 3.2 (activity types) and Section 3.1 (status fields)
+
+/** Activity types — spec Section 3.2 */
+export type ActivityType =
+  | 'card_review' | 'elaboration' | 'self_explain' | 'concept_map'
+  | 'comparison' | 'case_analysis' | 'synthesis' | 'socratic';
+
+export type CardType = 'cloze' | 'basic' | 'reversed';
+export type BloomLevel = 1 | 2 | 3 | 4 | 5 | 6;
+export type MasteryState = 'new' | 'learning' | 'reviewing' | 'mastered';
+export type EvaluationMethod = 'self_rated' | 'ai_rated' | 'hybrid';
+export type SessionType = 'daily' | 'weekly' | 'monthly' | 'free';
+export type PlanStrategy = 'open' | 'exam-prep' | 'weekly-review' | 'exploration';
+export type Surface = 'dashboard_chat' | 'dashboard_ui' | 'telegram';
+export type ConceptStatus = 'pending' | 'active' | 'skipped' | 'archived';
+export type ActivityAuthor = 'system' | 'student';
+
+// === Algorithm I/O types ===
+
+/** Per-Bloom's-level mastery evidence */
+export interface MasteryLevels {
+  L1: number; L2: number; L3: number;
+  L4: number; L5: number; L6: number;
+}
+
+/** Full mastery computation result */
+export interface MasteryResult {
+  levels: MasteryLevels;
+  overall: number;       // 0.0 - 1.0
+  bloomCeiling: number;  // 0-6 (D3: highest mastered level, 0 = none)
+}
+
+/** Single activity log entry as mastery computation input */
+export interface MasteryActivityInput {
+  bloomLevel: BloomLevel;
+  quality: number;       // 0-5
+  reviewedAt: string;    // ISO datetime
+}
+
+// === Forward-declared types for later sprints ===
+// Stubs so downstream code can reference them. S3 will flesh these out.
+
+/** Generator agent output (S3 will expand) */
+export interface GeneratedActivity {
+  activityType: ActivityType;
+  prompt: string;
+  referenceAnswer: string;
+  bloomLevel: BloomLevel;
+  cardType?: CardType;
+  sourceNotePath?: string;
+}
+
+/** Session builder output (S3 will expand) */
+export interface SessionComposition {
+  sessionId: string;
+  activities: Array<{ activityId: string; block: 'new' | 'review' | 'stretch' }>;
+  estimatedMinutes: number;
+}
+
+/** Bloom advancement check result (S3 will expand) */
+export interface BloomAdvancement {
+  conceptId: string;
+  previousCeiling: number;
+  newCeiling: number;
+  generationNeeded: boolean;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/study/types.ts
+git commit -m "feat(study): add non-DB types for study system (S1.1)"
+```
+
+---
+
+## Task 2: Drizzle Schema — Study Tables
+
+**Files:** Create `src/db/schema/study.ts`, modify `src/db/schema/index.ts`
+
+**Constraint (hard):** SQL column names, types, defaults, indexes, and foreign keys MUST match spec Section 3.1 exactly. The Drizzle schema is the source of truth for the database — get this wrong and everything downstream breaks.
+
+**Convention (D2):** Use camelCase for Drizzle property names, snake_case for SQL column names. Follow the existing patterns in `src/db/schema/tasks.ts` for table structure (index builder in third arg, FK via `.references()`).
+
+- [ ] **Step 1: Create `src/db/schema/study.ts`**
+
+8 tables. Defined in FK-dependency order: concepts first (referenced by everything), then plans (referenced by sessions), then sessions (referenced by activity_log), then activities and log.
+
+```typescript
+import {
+  index, integer, primaryKey, real, sqliteTable, text,
+} from 'drizzle-orm/sqlite-core';
+
+// ====================================================================
+// Concepts — the central learning entity
+// ====================================================================
+
+export const concepts = sqliteTable(
+  'concepts',
+  {
+    id: text('id').primaryKey(),
+    title: text('title').notNull(),
+    domain: text('domain'),
+    subdomain: text('subdomain'),
+    course: text('course'),
+    vaultNotePath: text('vault_note_path'),
+
+    status: text('status').default('active'),
+
+    // Weighted evidence mastery (per Bloom's level)
+    masteryL1: real('mastery_L1').default(0.0),
+    masteryL2: real('mastery_L2').default(0.0),
+    masteryL3: real('mastery_L3').default(0.0),
+    masteryL4: real('mastery_L4').default(0.0),
+    masteryL5: real('mastery_L5').default(0.0),
+    masteryL6: real('mastery_L6').default(0.0),
+    masteryOverall: real('mastery_overall').default(0.0),
+
+    // Progression state (D3: highest mastered level, 0 = none)
+    bloomCeiling: integer('bloom_ceiling').default(0),
+
+    createdAt: text('created_at').notNull(),
+    lastActivityAt: text('last_activity_at'),
+  },
+  (table) => ({
+    idxConceptsDomain: index('idx_concepts_domain').on(table.domain),
+    idxConceptsStatus: index('idx_concepts_status').on(table.status),
+  }),
+);
+
+// ====================================================================
+// Concept Prerequisites
+// ====================================================================
+
+export const conceptPrerequisites = sqliteTable(
+  'concept_prerequisites',
+  {
+    conceptId: text('concept_id').notNull().references(() => concepts.id),
+    prerequisiteId: text('prerequisite_id').notNull().references(() => concepts.id),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.conceptId, table.prerequisiteId] }),
+  }),
+);
+
+// ====================================================================
+// Study Plans
+// ====================================================================
+
+export const studyPlans = sqliteTable('study_plans', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  domain: text('domain'),
+  course: text('course'),
+  strategy: text('strategy').notNull().default('open'),
+
+  learningObjectives: text('learning_objectives'),  // JSON array
+  desiredOutcomes: text('desired_outcomes'),
+
+  implementationIntention: text('implementation_intention'),
+  obstacle: text('obstacle'),
+  studySchedule: text('study_schedule'),
+
+  config: text('config'),  // JSON
+  checkpointIntervalDays: integer('checkpoint_interval_days').default(14),
+  nextCheckpointAt: text('next_checkpoint_at'),
+  createdAt: text('created_at').notNull(),
+  updatedAt: text('updated_at').notNull(),
+  status: text('status').default('active'),
+});
+
+// ====================================================================
+// Study Plan <-> Concept join
+// ====================================================================
+
+export const studyPlanConcepts = sqliteTable(
+  'study_plan_concepts',
+  {
+    planId: text('plan_id').notNull().references(() => studyPlans.id),
+    conceptId: text('concept_id').notNull().references(() => concepts.id),
+    targetBloom: integer('target_bloom').default(6),
+    sortOrder: integer('sort_order').default(0),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.planId, table.conceptId] }),
+  }),
+);
+
+// ====================================================================
+// Study Sessions
+// ====================================================================
+
+export const studySessions = sqliteTable('study_sessions', {
+  id: text('id').primaryKey(),
+  startedAt: text('started_at').notNull(),
+  endedAt: text('ended_at'),
+  sessionType: text('session_type').notNull(),
+  planId: text('plan_id').references(() => studyPlans.id),
+
+  preConfidence: text('pre_confidence'),    // JSON
+  postReflection: text('post_reflection'),
+  calibrationScore: real('calibration_score'),
+
+  activitiesCompleted: integer('activities_completed').default(0),
+  totalTimeMs: integer('total_time_ms'),
+  surface: text('surface'),
+});
+
+// ====================================================================
+// Learning Activities — schedulable study units
+// ====================================================================
+
+export const learningActivities = sqliteTable(
+  'learning_activities',
+  {
+    id: text('id').primaryKey(),
+    conceptId: text('concept_id').notNull().references(() => concepts.id),
+
+    activityType: text('activity_type').notNull(),
+    prompt: text('prompt').notNull(),
+    referenceAnswer: text('reference_answer'),
+    bloomLevel: integer('bloom_level').notNull(),
+    difficultyEstimate: integer('difficulty_estimate').default(5),
+
+    cardType: text('card_type'),
+    author: text('author').default('system'),
+
+    sourceNotePath: text('source_note_path'),
+    sourceChunkHash: text('source_chunk_hash'),
+    generatedAt: text('generated_at').notNull(),
+
+    // SM-2 scheduling
+    easeFactor: real('ease_factor').default(2.5),
+    intervalDays: integer('interval_days').default(1),
+    repetitions: integer('repetitions').default(0),
+    dueAt: text('due_at').notNull(),
+    lastReviewed: text('last_reviewed'),
+    lastQuality: integer('last_quality'),
+    masteryState: text('mastery_state').default('new'),
+  },
+  (table) => ({
+    idxActivitiesDue: index('idx_activities_due').on(table.dueAt),
+    idxActivitiesConcept: index('idx_activities_concept').on(table.conceptId),
+    idxActivitiesType: index('idx_activities_type').on(table.activityType),
+  }),
+);
+
+// ====================================================================
+// Activity <-> Concept join (multi-concept activities)
+// ====================================================================
+
+export const activityConcepts = sqliteTable(
+  'activity_concepts',
+  {
+    activityId: text('activity_id').notNull().references(() => learningActivities.id),
+    conceptId: text('concept_id').notNull().references(() => concepts.id),
+    role: text('role').default('related'),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.activityId, table.conceptId] }),
+  }),
+);
+
+// ====================================================================
+// Activity Log — every interaction
+// ====================================================================
+
+export const activityLog = sqliteTable(
+  'activity_log',
+  {
+    id: text('id').primaryKey(),
+    activityId: text('activity_id').notNull().references(() => learningActivities.id),
+    conceptId: text('concept_id').notNull(),
+    activityType: text('activity_type').notNull(),
+    bloomLevel: integer('bloom_level').notNull(),
+
+    quality: integer('quality').notNull(),
+    responseText: text('response_text'),
+    responseTimeMs: integer('response_time_ms'),
+    confidenceRating: integer('confidence_rating'),
+
+    scaffoldingLevel: integer('scaffolding_level').default(0),
+    evaluationMethod: text('evaluation_method').default('self_rated'),
+    aiQuality: integer('ai_quality'),
+    aiFeedback: text('ai_feedback'),
+
+    methodUsed: text('method_used'),
+
+    surface: text('surface'),
+    sessionId: text('session_id').references(() => studySessions.id),
+    reviewedAt: text('reviewed_at').notNull(),
+  },
+  (table) => ({
+    idxLogConcept: index('idx_log_concept').on(table.conceptId),
+    idxLogSession: index('idx_log_session').on(table.sessionId),
+    idxLogBloom: index('idx_log_bloom').on(table.bloomLevel),
+  }),
+);
+```
+
+- [ ] **Step 2: Re-export from `src/db/schema/index.ts`**
+
+Add `export * from './study.js';`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/db/schema/study.ts src/db/schema/index.ts
+git commit -m "feat(study): add Drizzle schema for all study tables (S1.2)"
+```
+
+---
+
+## Task 3: Generate and Verify Migration
+
+**Files:** Generated `drizzle/migrations/0001_*.sql`
+
+- [ ] **Step 1: Generate migration**
+
+```bash
+npx drizzle-kit generate
+```
+
+Expected: new file `drizzle/migrations/0001_*.sql` with CREATE TABLE + CREATE INDEX for all 8 study tables.
+
+- [ ] **Step 2: Verify on existing DB**
+
+Build and run `initDatabase()`. Check all 20 tables exist (12 original + 8 study). Spot-check `concepts` has `mastery_L1`, `bloom_ceiling`, `vault_note_path`. Spot-check `learning_activities` has `ease_factor`, `bloom_level`, `mastery_state`.
+
+- [ ] **Step 3: Verify on fresh DB**
+
+Create a fresh in-memory or temp-file DB, run all migrations from scratch, verify same table list.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add drizzle/migrations/
+git commit -m "feat(study): add study tables migration (S1.3)"
+```
+
+---
+
+## Task 4: SM-2 Algorithm (TDD)
+
+**Files:** Create `src/study/sm2.test.ts`, then `src/study/sm2.ts`
+
+**Constraint (hard):** The algorithm MUST match the spec pseudocode in Section 4.1 exactly. This is not a place for creative interpretation.
+
+**Agent discretion:** Interface naming, JSDoc style, whether to export the input type.
+
+- [ ] **Step 1: Write failing tests**
+
+The SM-2 function takes `{ quality, repetitions, easeFactor, intervalDays }` and returns `{ easeFactor, intervalDays, repetitions }`. Also provide a `computeDueDate(intervalDays, fromDate?) → 'YYYY-MM-DD'` helper.
+
+Test cases that MUST be covered:
+
+| Scenario | quality | reps in | EF in | Expected interval | Expected reps | Expected EF |
+|----------|---------|---------|-------|-------------------|---------------|-------------|
+| First correct | 4 | 0 | 2.5 | 1 | 1 | ~2.5 |
+| Second correct | 4 | 1 | 2.5 | 6 | 2 | ~2.5 |
+| Third correct | 4 | 2 | 2.5 | 15 (round(6*2.5)) | 3 | ~2.5 |
+| Incorrect resets | 2 | 5 | 2.5 | 1 | 0 | (calculated) |
+| EF floor | 0 | 0 | 1.3 | 1 | 0 | 1.3 |
+| Perfect q=5 | 5 | 0 | 2.5 | 1 | 1 | 2.6 |
+| Barely correct q=3 | 3 | 0 | 2.5 | 1 | 1 | 2.36 |
+| Blackout q=0 | 0 | 0 | 2.5 | 1 | 0 | 1.7 |
+| All quality values 0-5 | each | 0 | 2.5 | ≥1 | ≥0 | ≥1.3 |
+
+`computeDueDate`: verify it adds days correctly, handles month boundaries, defaults to today.
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+npx vitest run src/study/sm2.test.ts
+```
+
+- [ ] **Step 3: Implement**
+
+The SM-2 formula (spec Section 4.1):
+
+```
+EF' = EF + (0.1 - (5 - q) * (0.08 + (5 - q) * 0.02))
+EF' = max(EF', 1.3)
+
+if quality >= 3:
+  rep 0: interval = 1
+  rep 1: interval = 6
+  rep 2+: interval = round(interval * EF')
+  repetitions += 1
+else:
+  repetitions = 0, interval = 1
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/study/sm2.ts src/study/sm2.test.ts
+git commit -m "feat(study): implement SM-2 scheduling algorithm with tests (S1.6)"
+```
+
+---
+
+## Task 5: Weighted Evidence Mastery (TDD)
+
+**Files:** Create `src/study/mastery.test.ts`, then `src/study/mastery.ts`
+
+**Constraint (hard):** Algorithm MUST match spec Section 4.2 pseudocode. Constants are non-negotiable: `BLOOM_WEIGHTS = { 1: 1.0, 2: 1.5, 3: 2.0, 4: 2.5, 5: 3.0, 6: 4.0 }`, `MASTERY_THRESHOLD = 10.0`, `DECAY_HALF_LIFE_DAYS = 30`.
+
+**Constraint (hard, D3):** `computeBloomCeiling` returns the highest level WHERE evidence ≥ 70% of threshold. Returns 0 if no level is mastered. Levels must be contiguous — a gap at L2 caps the ceiling at 1 regardless of L3+ evidence.
+
+Three pure functions needed:
+
+1. `computeMastery(activities: MasteryActivityInput[], now?: string) → MasteryLevels`
+   - For each Bloom level, sum: `(quality / 5.0) * 0.5^(daysSince / 30)`
+2. `computeBloomCeiling(levels: MasteryLevels) → number`
+   - Walk L1→L6, stop at first level where `evidence / MASTERY_THRESHOLD < 0.7`
+   - Return the last level that passed, or 0
+3. `computeOverallMastery(levels: MasteryLevels) → number`
+   - Weighted sum: `Σ min(evidence/threshold, 1.0) * weight[level]` / `Σ weights`
+
+Also export a convenience `computeFullMastery(activities, now?) → MasteryResult` that calls all three and returns the composite `MasteryResult` from types.ts.
+
+- [ ] **Step 1: Write failing tests**
+
+Test cases that MUST be covered:
+
+| Function | Scenario | Expected |
+|----------|----------|----------|
+| `computeMastery` | No activities | All zeros |
+| `computeMastery` | Two L1 activities (q=5, q=3) today | L1 ≈ 1.6 |
+| `computeMastery` | Activity 30 days ago (q=5) | L1 ≈ 0.5 (half-life) |
+| `computeMastery` | Activities at different Bloom levels | Only respective levels have evidence |
+| `computeBloomCeiling` | No mastery | 0 |
+| `computeBloomCeiling` | L1 at 7.0 (≥70% of 10) | 1 |
+| `computeBloomCeiling` | L1-L3 at 7.0+ | 3 |
+| `computeBloomCeiling` | All levels at threshold | 6 |
+| `computeBloomCeiling` | Gap at L2 (L1=8, L2=1, L3=9) | 1 (gap caps it) |
+| `computeOverallMastery` | No evidence | 0 |
+| `computeOverallMastery` | All levels fully mastered | 1.0 |
+| `computeOverallMastery` | L6-only vs L1-only mastered | L6 produces higher overall |
+| `computeOverallMastery` | Evidence above threshold | Capped at 1.0 per level |
+
+- [ ] **Step 2: Run tests, verify they fail**
+- [ ] **Step 3: Implement**
+- [ ] **Step 4: Run tests, verify they pass**
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/study/mastery.ts src/study/mastery.test.ts
+git commit -m "feat(study): implement weighted evidence mastery model with tests (S1.7)"
+```
+
+---
+
+## Task 6: Study Query Functions
+
+**Files:** Create `src/study/queries.ts`
+
+**Pattern:** Follow the existing CRUD pattern in `src/db/index.ts`. Study the functions there — `storeChatMetadata`, `getRegisteredGroup`, `updateTask`, `deleteTask` show the insert/select/update/delete patterns with Drizzle. Your functions should feel like they belong in the same codebase.
+
+**Constraint (hard):** Multi-table writes MUST use `getDb().transaction()`. Specifically, `completeActivity` touches learning_activities + activity_log + concepts + optionally study_sessions — all within one transaction.
+
+**Constraint (hard):** Use Drizzle's query builder operators (`eq`, `and`, `lte`, `desc`, `inArray`, `isNull`, etc.) — not raw `sql` template strings — for operations the builder supports. Use `sql` only for things like `datetime('now')` or `activitiesCompleted + 1` where no builder operator exists.
+
+**Agent discretion:** Function signatures, grouping, whether to add convenience wrappers beyond the listed functions. If you see a query that would naturally be useful for S2-S3 consumers, add it.
+
+### Derive these types from Drizzle schema
+
+```typescript
+export type Concept = typeof schema.concepts.$inferSelect;
+export type NewConcept = typeof schema.concepts.$inferInsert;
+// ... same pattern for LearningActivity, ActivityLogEntry, StudySession, StudyPlan
+```
+
+### Required functions
+
+**Concepts:**
+- `createConcept(concept: NewConcept): void`
+- `getConceptById(id: string): Concept | undefined`
+- `getConceptsByDomain(domain: string): Concept[]` — ordered by title
+- `getConceptsByStatus(status: string): Concept[]` — ordered by title
+- `getPendingConcepts(): Concept[]` — convenience wrapper
+- `getActiveConcepts(): Concept[]` — convenience wrapper
+- `updateConceptStatus(id: string, status: string): void`
+- `updateConceptMastery(id, masteryLevels, overall, bloomCeiling): void` — also sets `lastActivityAt`
+
+**Learning Activities:**
+- `createActivity(activity: NewLearningActivity): void`
+- `getActivityById(id: string): LearningActivity | undefined`
+- `getDueActivities(beforeDate?: string): LearningActivity[]` — ordered by dueAt asc, defaults to now
+- `getActivitiesByConceptAndType(conceptId, activityType): LearningActivity[]`
+- `updateActivitySM2(id, sm2Fields, quality, masteryState): void` — also sets `lastReviewed`
+
+**Activity Log:**
+- `createActivityLogEntry(entry: NewActivityLogEntry): void`
+- `getLogsByConceptAndLevel(conceptId, bloomLevel?): ActivityLogEntry[]` — ordered by reviewedAt desc
+- `getLogsBySession(sessionId): ActivityLogEntry[]` — ordered by reviewedAt asc
+
+**Study Sessions:**
+- `createStudySession(session: NewStudySession): void`
+- `getStudySessionById(id): StudySession | undefined`
+- `updateStudySession(id, partialUpdates): void`
+- `getActiveSession(): StudySession | undefined` — most recent where endedAt IS NULL
+
+**Study Plans:**
+- `createStudyPlan(plan: NewStudyPlan): void`
+- `getStudyPlanById(id): StudyPlan | undefined`
+- `getAllStudyPlans(): StudyPlan[]` — ordered by createdAt desc
+- `updateStudyPlan(id, partialUpdates): void`
+- `addConceptsToPlan(planId, conceptIds, targetBloom?): void` — use `onConflictDoNothing`, wrap in transaction if >1 concept
+- `getPlanConcepts(planId): Concept[]` — join through study_plan_concepts, ordered by sort_order
+
+### The `completeActivity` transaction (exact code — this is the complex one)
+
+This is the one function that warrants full implementation in the plan because it orchestrates SM-2 + mastery + logging atomically:
+
+```typescript
+export interface CompleteActivityInput {
+  activityId: string;
+  quality: number;  // 0-5
+  sessionId?: string;
+  responseText?: string;
+  responseTimeMs?: number;
+  confidenceRating?: number;
+  evaluationMethod?: string;
+  aiQuality?: number;
+  aiFeedback?: string;
+  methodUsed?: string;
+  surface?: string;
+}
+
+export interface CompleteActivityResult {
+  logEntryId: string;
+  newDueAt: string;
+  masteryUpdated: boolean;
+  bloomCeilingBefore: number;
+  bloomCeilingAfter: number;
+}
+
+/**
+ * Complete an activity atomically:
+ * 1. Look up the activity (throw if not found)
+ * 2. Compute SM-2 update from current state + quality
+ * 3. Determine mastery state (new/learning/reviewing/mastered)
+ * 4. Update activity's SM-2 fields
+ * 5. Insert activity_log entry
+ * 6. Recompute concept mastery from ALL logs for this concept
+ * 7. Update concept's mastery fields + bloomCeiling
+ * 8. Increment session activity count if sessionId provided
+ * All within db.transaction().
+ */
+export function completeActivity(input: CompleteActivityInput): CompleteActivityResult {
+  return getDb().transaction((tx) => {
+    // Step 1: get activity
+    const activity = tx.select().from(schema.learningActivities)
+      .where(eq(schema.learningActivities.id, input.activityId)).get();
+    if (!activity) throw new Error(`Activity not found: ${input.activityId}`);
+
+    // Step 2: SM-2
+    const sm2 = computeSM2({
+      quality: input.quality,
+      repetitions: activity.repetitions ?? 0,
+      easeFactor: activity.easeFactor ?? 2.5,
+      intervalDays: activity.intervalDays ?? 1,
+    });
+    const newDueAt = computeDueDate(sm2.intervalDays);
+
+    // Step 3: mastery state heuristic
+    let masteryState: MasteryState = 'learning';
+    if (sm2.repetitions === 0) masteryState = 'learning';
+    else if (sm2.intervalDays >= 21) masteryState = 'mastered';
+    else masteryState = 'reviewing';
+
+    // Step 4: update activity
+    tx.update(schema.learningActivities).set({
+      easeFactor: sm2.easeFactor, intervalDays: sm2.intervalDays,
+      repetitions: sm2.repetitions, dueAt: newDueAt,
+      lastReviewed: new Date().toISOString(), lastQuality: input.quality,
+      masteryState,
+    }).where(eq(schema.learningActivities.id, input.activityId)).run();
+
+    // Step 5: log entry
+    const logEntryId = crypto.randomUUID();
+    tx.insert(schema.activityLog).values({
+      id: logEntryId,
+      activityId: input.activityId,
+      conceptId: activity.conceptId,
+      activityType: activity.activityType,
+      bloomLevel: activity.bloomLevel,
+      quality: input.quality,
+      responseText: input.responseText ?? null,
+      responseTimeMs: input.responseTimeMs ?? null,
+      confidenceRating: input.confidenceRating ?? null,
+      evaluationMethod: input.evaluationMethod ?? 'self_rated',
+      aiQuality: input.aiQuality ?? null,
+      aiFeedback: input.aiFeedback ?? null,
+      methodUsed: input.methodUsed ?? null,
+      surface: input.surface ?? null,
+      sessionId: input.sessionId ?? null,
+      reviewedAt: new Date().toISOString(),
+    }).run();
+
+    // Step 6: recompute concept mastery from all logs
+    const concept = tx.select().from(schema.concepts)
+      .where(eq(schema.concepts.id, activity.conceptId)).get();
+    const bloomCeilingBefore = concept?.bloomCeiling ?? 0;
+
+    const allLogs = tx.select().from(schema.activityLog)
+      .where(eq(schema.activityLog.conceptId, activity.conceptId)).all();
+
+    const masteryInput: MasteryActivityInput[] = allLogs.map((log) => ({
+      bloomLevel: log.bloomLevel as BloomLevel,
+      quality: log.quality,
+      reviewedAt: log.reviewedAt,
+    }));
+
+    const levels = computeMastery(masteryInput);
+    const overall = computeOverallMastery(levels);
+    const bloomCeiling = computeBloomCeiling(levels);
+
+    // Step 7: update concept
+    tx.update(schema.concepts).set({
+      masteryL1: levels.L1, masteryL2: levels.L2, masteryL3: levels.L3,
+      masteryL4: levels.L4, masteryL5: levels.L5, masteryL6: levels.L6,
+      masteryOverall: overall, bloomCeiling,
+      lastActivityAt: new Date().toISOString(),
+    }).where(eq(schema.concepts.id, activity.conceptId)).run();
+
+    // Step 8: increment session count
+    if (input.sessionId) {
+      tx.update(schema.studySessions).set({
+        activitiesCompleted: sql`${schema.studySessions.activitiesCompleted} + 1`,
+      }).where(eq(schema.studySessions.id, input.sessionId)).run();
+    }
+
+    return { logEntryId, newDueAt, masteryUpdated: true, bloomCeilingBefore, bloomCeilingAfter: bloomCeiling };
+  });
+}
+```
+
+- [ ] **Step 1: Create `src/study/queries.ts`** — types, CRUD functions, `completeActivity` transaction
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/study/queries.ts
+git commit -m "feat(study): add study query functions with transactional completion (S1.4)"
+```
+
+---
+
+## Task 7: Study Query Tests
+
+**Files:** Create `src/study/queries.test.ts`
+
+**Pattern:** Use `beforeEach(() => _initTestDatabase())` and `afterEach(() => _closeDatabase())` — same as existing DB tests. Create test fixtures (a concept, an activity) in `beforeEach` where multiple describe blocks need them.
+
+**Constraint (hard):** `completeActivity` MUST have thorough tests — it's the most complex function and touches 4 tables. Test the happy path, non-existent activity error, session count increment, and transaction atomicity (all-or-nothing on failure).
+
+**Agent discretion:** Test organization, fixture naming, whether to add extra edge case tests beyond the required set. More coverage is welcome if you see gaps.
+
+### Required test coverage
+
+| Describe block | Test cases |
+|---------------|------------|
+| concept queries | create + retrieve, not-found returns undefined, query by domain, pending vs active filtering, status update |
+| activity queries | create + retrieve (verify SM-2 defaults: EF=2.5, reps=0, state='new'), getDueActivities with cutoff date (verify ordering), getByConceptAndType filtering |
+| activity log queries | create + query by concept, filter by bloom level, query by session |
+| session queries | create + retrieve, find active (non-ended) session, update partial fields |
+| plan queries | create + retrieve, add concepts to plan + retrieve them, list all ordered by date desc |
+| completeActivity | updates SM-2 fields + creates log + updates mastery, throws on non-existent activity, increments session count when sessionId provided, verify transaction rolls back on failure |
+
+- [ ] **Step 1: Write tests**
+- [ ] **Step 2: Run tests, verify they pass**
+
+```bash
+npx vitest run src/study/queries.test.ts
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/study/queries.test.ts
+git commit -m "test(study): add query function tests with transaction rollback (S1.5)"
+```
+
+---
+
+## Task 8: Update Migration Test
+
+**Files:** Modify `src/db-migration.test.ts`
+
+- [ ] **Step 1: Add study tables to expected tables list**
+
+The existing test has an `expectedTables` array. Add: `activity_concepts`, `activity_log`, `concept_prerequisites`, `concepts`, `learning_activities`, `study_plan_concepts`, `study_plans`, `study_sessions`. Keep the array alphabetically sorted.
+
+Also add spot-checks for study table columns (same pattern as the existing ingestion/chat checks):
+- `concepts`: has `mastery_L1`, `bloom_ceiling`, `vault_note_path`
+- `learning_activities`: has `ease_factor`, `bloom_level`, `mastery_state`
+
+- [ ] **Step 2: Run test**
+
+```bash
+npx vitest run src/db-migration.test.ts
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/db-migration.test.ts
+git commit -m "test(db): add study tables to migration test (S1)"
+```
+
+---
+
+## Task 9: Barrel Exports and Group Scaffolds
+
+**Files:** Create `src/study/index.ts`, `groups/study/CLAUDE.md`, `groups/study-generator/CLAUDE.md`
+
+- [ ] **Step 1: Create `src/study/index.ts`**
+
+Re-export everything from `types.ts`, `sm2.ts`, `mastery.ts`, and `queries.ts`. This is the public API for the study subsystem — S2+ imports from `src/study/index.js`.
+
+**Agent discretion:** Organize exports however makes sense. Prefer named re-exports over `export *` for clarity.
+
+- [ ] **Step 2: Create `groups/study/CLAUDE.md`**
+
+Placeholder for the interactive study agent (expanded in S5). Include:
+- Role: study tutor for university courses
+- Core principles: brain-first, desirable difficulties, suggest strongly enforce nothing
+- Note: "Full prompt designed in S5"
+
+- [ ] **Step 3: Create `groups/study-generator/CLAUDE.md`**
+
+Placeholder for the batch generator agent (expanded in S3). Include:
+- Role: generate learning activities from vault content
+- Output format: structured JSON
+- Quality rules: Wozniak's 20 Rules, Matuschak's 5 Attributes
+- Note: "Full prompt designed in S3"
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/study/index.ts groups/study/CLAUDE.md groups/study-generator/CLAUDE.md
+git commit -m "feat(study): add barrel exports and group directory scaffolds (S1.8, S1.9)"
+```
+
+---
+
+## Task 10: Full Verification
+
+- [ ] **Step 1: Run all study tests**
+
+```bash
+npx vitest run src/study/
+```
+
+- [ ] **Step 2: Run full project test suite**
+
+```bash
+npm test
+```
+
+No regressions. All existing + new tests pass.
+
+- [ ] **Step 3: Build check**
+
+```bash
+npm run build
+```
+
+No TypeScript errors.
+
+- [ ] **Step 4: Fresh DB migration check**
+
+Create a temp DB, run all migrations from scratch, verify all 20 tables exist.
+
+---
+
+## Acceptance Criteria
+
+From master plan S1 (non-negotiable):
+
+- [ ] All 8 study tables created with correct schema (verified by migration test)
+- [ ] SM-2 produces correct intervals for all quality values 0-5 across multiple repetitions
+- [ ] Mastery correctly computes per-level evidence with time decay
+- [ ] Bloom ceiling returns highest mastered level (0 if none); gap at any level caps it
+- [ ] `completeActivity` atomically updates SM-2 + log + mastery within a transaction
+- [ ] All tests pass (`npm test`)
+- [ ] Clean build (`npm run build`)

--- a/docs/superpowers/plans/2026-04-15-s2-concept-lifecycle.md
+++ b/docs/superpowers/plans/2026-04-15-s2-concept-lifecycle.md
@@ -1,0 +1,448 @@
+# S2: Concept Lifecycle — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Your role:** You are the engineer implementing this. The plan tells you *what* to build and *why*. You decide *how* within the stated constraints. If you disagree with an approach or see a better alternative, flag it before implementing — don't silently deviate and don't silently comply with something you think is wrong.
+
+**Goal:** Concepts flow from vault ingestion → pending → active, with a dashboard page for browsing and batch-approving concepts. First user-visible part of the study system.
+
+**Architecture:** Concept discovery hooks into `handlePromotion()` in the ingestion pipeline. When vault notes promote to `concepts/`, a synchronous frontmatter reader creates pending concept rows. The dashboard reads SQLite via its own Drizzle instance. A one-time migration script backfills 899 existing vault concept notes.
+
+**Tech Stack:** TypeScript, Drizzle ORM (better-sqlite3), gray-matter, Vitest, Next.js (dashboard), Tailwind CSS
+
+**Branch:** Create `feat/s2-concept-lifecycle` off `main`. S1 merged via PR #28.
+
+**Spec:** `docs/superpowers/specs/2026-04-12-multi-method-study-system-design.md` (v2.1, Sections 3.1, 5.3)
+
+**Master plan:** `docs/superpowers/plans/2026-04-13-study-system-master-plan.md` (S2 checklist)
+
+---
+
+## Codebase Conventions (Hard Constraints)
+
+These apply to **every task**. Subagents must follow these — they're not obvious from context alone.
+
+1. **`.js` extensions on all relative imports in `src/`.** The backend uses Node ESM resolution. Write `import { foo } from './bar.js'`, not `'./bar'`. **Exception:** Dashboard (`dashboard/src/`) does NOT use `.js` extensions — Next.js/Turbopack handles resolution. Follow the existing pattern in `dashboard/src/lib/ingestion-db.ts` (imports from `'./db/index'` without `.js`).
+2. **camelCase Drizzle properties, snake_case SQL columns** (backend `src/db/schema/study.ts`). Dashboard schema uses snake_case properties matching SQL column names (different convention — see D3 below).
+3. **Drizzle query builder operators** (`eq`, `and`, `lte`, `desc`, `asc`, `count`, `sql`) — not raw SQL strings — for operations the builder supports. Use `sql` template only for things like `datetime('now')` or computed expressions.
+4. **Vitest** for all tests. Pattern: `describe` → `it` → `expect`. Test file discovery: `src/**/*.test.ts`.
+5. **`parseFrontmatter()` from `src/vault/frontmatter.ts`** for all YAML frontmatter reading. Returns `{ data: Record<string, unknown>, content: string }`.
+6. **Dashboard API routes** use `Response.json()` + try/catch. See `dashboard/src/app/api/ingestion/jobs/route.ts` for the exact pattern.
+7. **Dashboard pages** are `'use client'` components with `useState`/`useEffect` for data fetching. Tailwind CSS. Dark theme (bg-gray-950, text-gray-100). See `dashboard/src/app/upload/page.tsx`.
+8. **Commit messages** use conventional commits: `feat(study):`, `test(study):`, `feat(dashboard):`.
+
+---
+
+## Spec Deviations
+
+- **No prerequisite extraction from wikilinks.** The spec (Section 5.3) mentions "suggested prerequisites (from wikilinks)." Deferred to S3 — no code consumes prerequisites yet.
+- **No DB group registration.** Master plan S2.10 says register study group in `registered_groups`. That table requires a non-null `trigger_pattern`, which study groups don't have. Deferred to S5 when web channel routing is implemented. The CLAUDE.md files were already scaffolded in S1 (Task 9) — nothing is lost by deferring the DB row.
+
+---
+
+## Key Decisions
+
+### D1: Discovery reads frontmatter, not LLM
+Concept discovery reads promoted notes' YAML frontmatter with `parseFrontmatter()`. No LLM call — the ingestion agent already writes domain/subdomain during generation.
+
+### D2: Domain/subdomain are should-fix warnings, not must-fix
+Draft validator treats missing domain/subdomain as `should-fix` severity. 899 existing notes lack these fields. Must-fix would block re-ingestion of old documents.
+
+### D3: Dashboard duplicates study schema (snake_case properties)
+Dashboard defines its own Drizzle tables in `dashboard/src/lib/db/schema.ts` with snake_case property names (matching SQL column names). It cannot import from `src/db/schema/` — Next.js can't bundle TS from outside the project root.
+
+### D4: Deduplication by vault_note_path
+Discovery checks for existing concepts by `vaultNotePath`, not title. Multiple notes can share titles across sources.
+
+### D5: Topic-to-domain heuristic for migration
+Migration script maps topic keywords → domain/subdomain using a static rule table. ~70-80% classification rate; rest get `null`. Student classifies remainder from dashboard.
+
+---
+
+## Essential Reading
+
+> **For coordinators:** Extract relevant patterns from these files and inline them into subagent prompts. Subagents won't read the files themselves.
+
+| File | Why |
+|------|-----|
+| `src/study/queries.ts` | `createConcept()`, `getConceptsByStatus()`, `updateConceptStatus()` — the S1 query API this sprint calls |
+| `src/db/schema/study.ts` | Concepts table schema — `vaultNotePath`, `domain`, `subdomain`, `status` fields |
+| `src/ingestion/index.ts:506-645` | `handlePromotion()` — insertion point for discovery hook |
+| `src/ingestion/draft-validator.ts:206-253` | Concept note frontmatter validation — insertion point for domain/subdomain warnings |
+| `groups/review_agent/CLAUDE.md:20-45` | Concept note frontmatter schema — where domain/subdomain fields go |
+| `src/vault/frontmatter.ts` | `parseFrontmatter()` — the utility for reading note YAML |
+| `dashboard/src/lib/ingestion-db.ts` | Dashboard query pattern to replicate for study-db.ts |
+| `dashboard/src/lib/db/schema.ts` | Dashboard schema — add study tables here |
+| `dashboard/src/app/layout.tsx` | Nav bar — add "Study" link |
+| `vault/concepts/action-research.md` | Existing frontmatter format: `title`, `type`, `topics`, `source_doc`. No `domain`/`subdomain` |
+
+---
+
+## Task Numbering
+
+This plan uses its own sequential task IDs (S2.1-S2.9) that don't map 1:1 to the master plan's S2.1-S2.10 checklist because some master plan items are merged and one is deferred. Commit messages reference **this plan's** task IDs.
+
+| Plan task | Master plan items | What |
+|-----------|-------------------|------|
+| S2.1 | S2.1 + S2.2 | Discovery module + tests (TDD) |
+| S2.2 | S2.3 | Pipeline hook |
+| S2.3 | S2.4 | Agent prompt update |
+| S2.4 | S2.5 | Draft validator update |
+| S2.5 | S2.6 (partial) | Dashboard schema |
+| S2.6 | S2.6 (partial) | Dashboard query functions |
+| S2.7 | S2.7 + S2.8 | API routes + /study page |
+| S2.8 | S2.9 | Migration script |
+| S2.9 | — | Barrel export + verification |
+| — | S2.10 | Deferred (see Spec Deviations) |
+
+**Master plan errata:** S2.3 references `src/ingestion/pipeline.ts` — the actual file is `src/ingestion/index.ts`. S2.4 references `src/ingestion/agent-processor.ts` — the actual prompt template is in `groups/review_agent/CLAUDE.md`.
+
+---
+
+## Parallelization & Model Recommendations
+
+**Dependencies:**
+- S2.1 → S2.2 (discovery module before pipeline hook)
+- S2.2 → S2.8 (need `getConceptByVaultPath` from S2.2 for migration script)
+- S2.5 → S2.6 → S2.7 (dashboard: schema → queries → routes+page)
+
+**Parallel opportunities:**
+- S2.3 + S2.4 (agent prompt + validator — fully independent)
+- S2.5 + S2.8 (dashboard schema + migration script — independent codepaths)
+- S2.3 + S2.4 can start as soon as S2.1 is done (no dependency on S2.2)
+
+| Task | Can parallel with | Model | Rationale |
+|------|-------------------|-------|-----------|
+| S2.1 | — (first task) | Sonnet | Mechanical: read frontmatter, filter, map |
+| S2.2 | — (depends on S2.1) | Sonnet | Small insertion into existing function |
+| S2.3 | S2.4 | Sonnet | Editing a markdown file |
+| S2.4 | S2.3 | Sonnet | Adding 2 warning checks to existing validator |
+| S2.5 | S2.8 | Sonnet | Schema declaration, must match backend exactly |
+| S2.6 | — (depends on S2.5) | Sonnet | CRUD queries following existing pattern |
+| S2.7 | — (depends on S2.6) | Sonnet | API routes + page following existing patterns |
+| S2.8 | S2.5 | Sonnet | Script with heuristic map |
+| S2.9 | — | Sonnet | Barrel export + test suite runs |
+
+**Skip two-stage review for:** S2.3, S2.4, S2.9 (trivial edits). Full review for: S2.1, S2.2, S2.6, S2.7.
+
+---
+
+## S2.1: Concept Discovery Module (TDD)
+
+**Files:** Create `src/study/concept-discovery.ts` + `src/study/concept-discovery.test.ts`
+
+**Return type:** `NewConcept[]` (from `src/study/queries.ts` — this is `typeof schema.concepts.$inferInsert`). The caller (S2.2) passes each item directly to `createConcept()`. No wrapper type needed.
+
+```typescript
+import type { NewConcept } from './queries.js';
+
+export function discoverConcepts(
+  promotedPaths: string[],
+  vaultDir: string,
+): NewConcept[]
+```
+
+**Algorithm:**
+1. For each path in `promotedPaths`: skip if not `concepts/*`. Read file contents with `readFileSync()`, parse with `parseFrontmatter()`. Skip if `type !== 'concept'` or no `title`. Map frontmatter fields → `NewConcept` with `status: 'pending'`, `id: randomUUID()`, `createdAt: new Date().toISOString()`. Return array.
+
+**Agent discretion:** Error handling style, whether to log skipped notes, internal helpers.
+
+**Required test cases:**
+
+| Scenario | Input | Expected |
+|----------|-------|----------|
+| Full frontmatter | concept note with domain+subdomain | 1 result with all fields populated |
+| Missing domain/subdomain | concept note without domain | 1 result with `domain: null`, `subdomain: null` |
+| Source note (type=source) | `sources/vaswani.md` | 0 results (skipped) |
+| Path not in concepts/ | `sources/some-note.md` with type=concept | 0 results |
+| Nonexistent file | `concepts/ghost.md` | 0 results |
+| Multiple paths mixed | 2 concepts + 1 source | 2 results |
+| Missing title | concept note without title | 0 results |
+| Course field | note with `course: 'BI-2081'` | result has `course: 'BI-2081'` |
+
+**Test setup:** Create temp vault dir in `beforeEach` with `mkdirSync`, write mock `.md` files with gray-matter compatible frontmatter, `rmSync` in `afterEach`.
+
+- [ ] **Step 1:** Write failing tests covering all cases above
+- [ ] **Step 2:** Run tests, verify they fail (`npx vitest run src/study/concept-discovery.test.ts`)
+- [ ] **Step 3:** Implement `discoverConcepts()` — make tests pass
+- [ ] **Step 4:** Run tests, verify all pass
+- [ ] **Step 5:** Commit: `feat(study): add concept discovery from vault frontmatter (S2.1)`
+
+---
+
+## S2.2: Hook Discovery into Ingestion Pipeline
+
+**Files:** Modify `src/ingestion/index.ts`, modify `src/study/queries.ts`
+
+**Prerequisite:** Add `getConceptByVaultPath(path: string): Concept | undefined` to `src/study/queries.ts`. Pattern: same as `getConceptById` but filters on `schema.concepts.vaultNotePath`.
+
+**Insertion point in `handlePromotion()`:** After the citation linking block (around line 587) and before `// Move source file to processed/` (around line 589). The block:
+1. Calls `discoverConcepts(promotedPaths, this.vaultDir)`
+2. For each result, checks `getConceptByVaultPath()` — skip if exists
+3. Calls `createConcept()` for new ones
+4. Entire block wrapped in try/catch — logs warning on failure, never fails the promotion
+
+**Agent discretion:** Log format, whether to count and report insertions.
+
+- [ ] **Step 1:** Add `getConceptByVaultPath` to `src/study/queries.ts`
+- [ ] **Step 2:** Add imports to `src/ingestion/index.ts`: `discoverConcepts`, `createConcept`, `getConceptByVaultPath`
+- [ ] **Step 3:** Insert discovery block at the specified location in `handlePromotion()`
+- [ ] **Step 4:** Run ingestion tests: `npx vitest run src/ingestion/` — no regressions
+- [ ] **Step 5:** Commit: `feat(study): hook concept discovery into ingestion promotion (S2.2)`
+
+---
+
+## S2.3: Update Ingestion Agent Prompt
+
+**Files:** Modify `groups/review_agent/CLAUDE.md`
+
+**Parallelizable with S2.4.**
+
+Two changes:
+1. Add `domain` and `subdomain` fields to the concept note YAML schema example (after `type:`, before `topics:`). Example values: `domain: "Artificial Intelligence"`, `subdomain: "Deep Learning Architectures"`.
+2. Add a guidance paragraph below the schema explaining what domain/subdomain mean: domain = broad knowledge area, subdomain = specific topic within it. Give 5-6 example domains from Simon's courses.
+
+**Agent discretion:** Exact wording of guidance text, example domains chosen.
+
+- [ ] **Step 1:** Edit the concept note schema block (around line 24-36)
+- [ ] **Step 2:** Add guidance paragraph after the schema
+- [ ] **Step 3:** Commit: `feat(study): add domain/subdomain to ingestion agent concept schema (S2.3)`
+
+---
+
+## S2.4: Update Draft Validator
+
+**Files:** Modify `src/ingestion/draft-validator.ts`
+
+**Parallelizable with S2.3.**
+
+**Insertion point:** INSIDE the `for (const conceptFile of manifest.concept_notes)` loop, after the `type !== 'concept'` check (line 252), before the loop's closing `}` (line 253). The `conceptFile` variable is only in scope inside this loop — inserting outside it would be a reference error.
+
+Add two warnings for missing `domain` and `subdomain` frontmatter on concept notes. Push to the `warnings` array (not `errors`). `ValidationWarning` has no `severity` field — items in `warnings` are inherently non-blocking. Pattern:
+
+```typescript
+warnings.push({
+  check: 'concept-domain',
+  message: `Concept note "${conceptFile}" is missing "domain" frontmatter field. ...`,
+  file: conceptFile,
+});
+```
+
+**Constraint:** Push to `warnings`, NOT `errors`. See D2. The `warnings` type (`ValidationWarning`) has fields `{ check, message, file? }` — no severity field.
+
+- [ ] **Step 1:** Add domain + subdomain warnings inside the loop, after line 252
+- [ ] **Step 3:** Run validator tests: `npx vitest run src/ingestion/draft-validator.test.ts` — update any assertion that counts exact warnings
+- [ ] **Step 4:** Commit: `feat(study): add domain/subdomain warnings to draft validator (S2.4)`
+
+---
+
+## S2.5: Dashboard Study Schema
+
+**Files:** Modify `dashboard/src/lib/db/schema.ts`
+
+**Parallelizable with S2.8.**
+
+Add `concepts` and `learning_activities` table definitions. These MUST match the SQL column names from `src/db/schema/study.ts` exactly. But property names use snake_case (dashboard convention — see D3).
+
+**Design decision — schema definitions (use these exactly):**
+
+```typescript
+// Add `real` to the existing import from 'drizzle-orm/sqlite-core'
+
+export const concepts = sqliteTable('concepts', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  domain: text('domain'),
+  subdomain: text('subdomain'),
+  course: text('course'),
+  vault_note_path: text('vault_note_path'),
+  status: text('status').default('active'),
+  mastery_L1: real('mastery_L1').default(0.0),
+  mastery_L2: real('mastery_L2').default(0.0),
+  mastery_L3: real('mastery_L3').default(0.0),
+  mastery_L4: real('mastery_L4').default(0.0),
+  mastery_L5: real('mastery_L5').default(0.0),
+  mastery_L6: real('mastery_L6').default(0.0),
+  mastery_overall: real('mastery_overall').default(0.0),
+  bloom_ceiling: integer('bloom_ceiling').default(0),
+  created_at: text('created_at').notNull(),
+  last_activity_at: text('last_activity_at'),
+});
+
+export const learning_activities = sqliteTable('learning_activities', {
+  id: text('id').primaryKey(),
+  concept_id: text('concept_id').notNull(),
+  activity_type: text('activity_type').notNull(),
+  bloom_level: integer('bloom_level').notNull(),
+  due_at: text('due_at').notNull(),
+  mastery_state: text('mastery_state').default('new'),
+});
+```
+
+The `learning_activities` definition is a minimal subset — only columns needed for the S2 due count query (`SELECT count(*) ... WHERE concept_id = ? AND due_at <= ?`). The full table has 17+ columns; S4 will extend this definition when the session UI needs additional fields like `prompt`, `reference_answer`, `ease_factor`.
+
+- [ ] **Step 1:** Add `real` to import, append both table definitions
+- [ ] **Step 2:** Verify: `cd dashboard && npx tsc --noEmit`
+- [ ] **Step 3:** Commit: `feat(dashboard): add study table schemas for concept queries (S2.5)`
+
+---
+
+## S2.6: Dashboard Study Query Functions
+
+**Files:** Create `dashboard/src/lib/study-db.ts`
+
+**Pattern to follow:** `dashboard/src/lib/ingestion-db.ts` — own import of `getDb()` from `./db/index` (no `.js` extension — dashboard convention), function-per-query, own response interfaces. Note the `rowToSummary()` mapper function pattern in that file — you'll need the same approach here because the dashboard schema uses snake_case properties (`vault_note_path`, `mastery_overall`) but the response interfaces use camelCase (`vaultNotePath`, `masteryOverall`).
+
+**Required functions:**
+
+| Function | Signature | Notes |
+|----------|-----------|-------|
+| `getActiveConcepts` | `() → ConceptSummary[]` | Join with `learning_activities` for due count (count where `due_at <= today`). Two queries + Map merge. |
+| `getPendingConcepts` | `() → PendingGroup[]` | Group by domain. `PendingGroup = { domain: string|null, concepts: Array<{id, title, subdomain, createdAt}> }` |
+| `approveConcepts` | `(ids: string[]) → number` | Update status pending→active. Return count changed. |
+| `approveDomain` | `(domain: string) → string[]` | Find all pending in domain, approve, return IDs. |
+| `getConceptStats` | `() → ConceptStats` | `{ total, pending, active, domains }`. Count by status + count distinct domains. |
+
+**`ConceptSummary` interface (design decision):**
+```typescript
+export interface ConceptSummary {
+  id: string;
+  title: string;
+  domain: string | null;
+  subdomain: string | null;
+  course: string | null;
+  vaultNotePath: string | null;
+  status: string;
+  masteryOverall: number;
+  bloomCeiling: number;
+  dueCount: number;
+  createdAt: string;
+  lastActivityAt: string | null;
+}
+```
+
+**Agent discretion:** Internal helpers, query optimization approach, whether to add `skipConcepts(ids)` for future use.
+
+- [ ] **Step 1:** Create `study-db.ts` with interfaces and all functions
+- [ ] **Step 2:** Verify: `cd dashboard && npx tsc --noEmit`
+- [ ] **Step 3:** Commit: `feat(dashboard): add study DB query functions (S2.6)`
+
+---
+
+## S2.7: Dashboard API Routes + /study Page + Nav Link
+
+**Files:** Create 3 API routes, create `dashboard/src/app/study/page.tsx`, modify `dashboard/src/app/layout.tsx`
+
+This task combines S2.7 and S2.8 from the master plan — the API routes are only testable with the page, so building them together avoids a dead commit.
+
+### API Routes
+
+Follow the pattern in `dashboard/src/app/api/ingestion/jobs/route.ts`.
+
+| Route | Method | Handler | Response |
+|-------|--------|---------|----------|
+| `/api/study/concepts` | GET | `getActiveConcepts()` + `getConceptStats()` | `{ concepts, stats }` |
+| `/api/study/concepts/pending` | GET | `getPendingConcepts()` | `{ groups }` |
+| `/api/study/concepts/approve` | POST | Body: `{ conceptIds?: string[], domain?: string }` | `{ approved: number }` or `{ approved: number, ids: string[] }` |
+
+Directory structure:
+```
+dashboard/src/app/api/study/concepts/
+  route.ts            — GET active concepts
+  pending/route.ts    — GET pending grouped by domain
+  approve/route.ts    — POST approve
+```
+
+### /study Page
+
+**Layout:** Two sections in a `max-w-4xl` container.
+
+**Section 1 — Pending Approval:** Shows when pending concepts exist. Groups by domain. Each group is a card with domain name, concept count, "Approve all" button (for non-null domains), and a row of concept chips that are individually clickable to approve. After approval, refetch data.
+
+**Section 2 — Active Concepts:** Table with columns: Concept (title), Domain, Bloom (L1-L6 label from `bloomCeiling`), Mastery (progress bar + percentage from `masteryOverall`), Due (count from `dueCount`). Empty state message if no active concepts.
+
+**Stats bar:** Top right — `{active} active · {pending} pending · {domains} domains`.
+
+### Nav Link
+
+Add `<a href="/study" className="hover:text-gray-100">Study</a>` to `dashboard/src/app/layout.tsx` after the "Book" link.
+
+**Agent discretion:** Component decomposition (single file vs. extracted components), loading state UX, exact Tailwind classes, whether mastery bar uses gradient colors.
+
+- [ ] **Step 1:** Create directory structure: `mkdir -p dashboard/src/app/api/study/concepts/pending dashboard/src/app/api/study/concepts/approve`
+- [ ] **Step 2:** Create the three API route files
+- [ ] **Step 3:** Add "Study" nav link in layout.tsx
+- [ ] **Step 4:** Create `/study` page
+- [ ] **Step 5:** Start dashboard dev server (`cd dashboard && npm run dev`), verify page renders at `http://localhost:3100/study`
+- [ ] **Step 6:** Commit: `feat(dashboard): add /study page with concept approval UI (S2.7, S2.8)`
+
+---
+
+## S2.8: Vault Concept Migration Script
+
+**Files:** Create `scripts/migrate-vault-concepts.ts`
+
+**Parallelizable with S2.5.**
+
+**Algorithm:**
+1. Call `initDatabase()` from `src/db/index.js` (initializes DB + runs migrations)
+2. Read all `.md` files from `vault/concepts/`
+3. For each file: check `getConceptByVaultPath()` — skip if exists. Read frontmatter. Skip if no `title`. Infer domain from `topics` if not in frontmatter. Insert with `createConcept()`, `status: 'pending'`.
+4. Print summary: inserted, skipped, classified, errors.
+
+**Domain inference:** A static array of rules, each with `keywords: string[]`, `domain: string`, `subdomain: string`. First matching keyword wins. Cover Simon's main areas:
+
+| Keywords (substring match on joined topics) | Domain | Subdomain |
+|---------------------------------------------|--------|-----------|
+| `knowledge-management`, `km-`, `tacit-knowledge`, `explicit-knowledge`, `seci`, `nonaka`, `knowledge-creation`, `knowledge-sharing` | Knowledge Management | KM Theory |
+| `organizational-learning`, `learning-organization`, `absorptive-capacity` | Knowledge Management | Organizational Learning |
+| `cognitive-load`, `working-memory`, `instructional-design`, `sweller` | Cognitive Psychology | Cognitive Load Theory |
+| `spaced-repetition`, `retrieval-practice`, `metacognition`, `self-regulated-learning` | Cognitive Psychology | Learning & Memory |
+| `digital-transformation`, `digitalization`, `digital-strategy` | Digital Transformation | DT Strategy |
+| `business-process`, `bpm`, `workflow`, `process-improvement` | Digital Transformation | Business Process Management |
+| `research-methodology`, `scientific-methods`, `qualitative-research`, `quantitative-research`, `action-research`, `case-study-research` | Research Methods | Research Design |
+| `philosophy-of-science`, `epistemology`, `ontology`, `paradigm` | Research Methods | Philosophy of Science |
+| `information-systems`, `sociotechnical`, `technology-acceptance` | Information Systems | IS Theory |
+| `artificial-intelligence`, `ai-`, `machine-learning`, `deep-learning`, `neural-network`, `llm`, `transformer` | Artificial Intelligence | AI Foundations |
+
+**Agent discretion:** Additional keyword rules, subdomain granularity, output formatting.
+
+**Constraint:** Must be idempotent — running it twice inserts 0 the second time.
+
+**Usage:** `npx tsx scripts/migrate-vault-concepts.ts`
+
+- [ ] **Step 1:** Create the script
+- [ ] **Step 2:** Verify it compiles: `npx tsx --check scripts/migrate-vault-concepts.ts`
+- [ ] **Step 3:** Run it: `npx tsx scripts/migrate-vault-concepts.ts` — expect ~899 inserted
+- [ ] **Step 4:** Run again — expect 0 inserted, ~899 skipped (idempotency)
+- [ ] **Step 5:** Check dashboard `/study` — pending concepts should appear
+- [ ] **Step 6:** Commit: `feat(study): add vault concept migration script (S2.8)`
+
+---
+
+## S2.9: Barrel Export + Full Verification
+
+**Files:** Modify `src/study/index.ts`
+
+- [ ] **Step 1:** Add `export * from './concept-discovery.js';` to `src/study/index.ts`
+- [ ] **Step 2:** Run study tests: `npx vitest run src/study/`
+- [ ] **Step 3:** Run ingestion tests: `npx vitest run src/ingestion/`
+- [ ] **Step 4:** Run full test suite: `npm test`
+- [ ] **Step 5:** Build check: `npm run build`
+- [ ] **Step 6:** Dashboard build: `cd dashboard && npx tsc --noEmit`
+- [ ] **Step 7:** Manual verify: start dashboard, check `/study`, approve a concept, verify it moves to active table
+- [ ] **Step 8:** Commit: `feat(study): export concept-discovery from barrel (S2.9)`
+
+---
+
+## Acceptance Criteria
+
+From master plan S2 (non-negotiable):
+
+- [ ] Ingesting a new PDF produces pending concepts visible on `/study`
+- [ ] Domain-batch approval moves concepts to active status
+- [ ] Migration script correctly creates entries for existing vault notes (idempotent)
+- [ ] No regressions in ingestion pipeline (existing tests pass)
+- [ ] All tests pass (`npm test`)
+- [ ] Clean build (`npm run build`)
+- [ ] Dashboard `/study` page renders with pending + active sections

--- a/docs/superpowers/plans/2026-04-15-s4-study-session-ui.md
+++ b/docs/superpowers/plans/2026-04-15-s4-study-session-ui.md
@@ -1,0 +1,579 @@
+# S4: Study Session UI — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Your role:** You are the engineer implementing this. The plan tells you *what* to build and *why*. You decide *how* within the stated constraints. If you disagree with an approach or see a better alternative, flag it before implementing — don't silently deviate and don't silently comply with something you think is wrong.
+
+**Goal:** End-to-end study loop on the dashboard for self-rated activities (L1-L2). Student can start a session, complete card/elaboration activities, self-rate, see mastery progress, and trigger post-session generation — all from `/study/session`. Concept approval now triggers initial activity generation so new concepts aren't empty.
+
+**Architecture:** The dashboard handles all structured study operations via direct SQLite access (master plan Flow 1). SM-2 and mastery algorithms are ported as pure functions to the dashboard (~130 lines including constants and helpers). Session composition, activity completion, and session CRUD all run in the dashboard process with its own Drizzle instance. The only cross-process call is for container operations: generation triggers use IPC files that the main process watcher picks up.
+
+**Tech Stack:** Next.js (dashboard), Drizzle ORM (better-sqlite3), Tailwind CSS, TypeScript
+
+**Branch:** Create `feat/s4-study-session-ui` off `main`. S3 merged via PR #30.
+
+**Spec:** `docs/superpowers/specs/2026-04-12-multi-method-study-system-design.md` (v2.1, Sections 4.5, 7.2, 7.4)
+
+**Master plan:** `docs/superpowers/plans/2026-04-13-study-system-master-plan.md` (S4 checklist)
+
+---
+
+## Codebase Conventions (Hard Constraints)
+
+These apply to **every task**. Subagents must follow these — they're not obvious from context alone.
+
+1. **`.js` extensions on all relative imports in `src/`.** The backend uses Node ESM resolution. Write `import { foo } from './bar.js'`, not `'./bar'`. **Exception:** Dashboard (`dashboard/src/`) does NOT use `.js` extensions — Next.js handles resolution.
+2. **camelCase Drizzle properties, snake_case SQL columns** (backend `src/db/schema/study.ts`). Dashboard schema uses snake_case properties matching SQL column names (different convention — see D1).
+3. **Drizzle query builder operators** (`eq`, `and`, `lte`, `desc`, `asc`, `count`, `sql`, `inArray`, `gte`) — not raw SQL strings.
+4. **Dashboard API routes** use `Response.json()` + try/catch. Pattern: `dashboard/src/app/api/study/concepts/route.ts`.
+5. **Dashboard pages** are `'use client'` components with `useState`/`useEffect` for data fetching. Tailwind CSS. Dark theme (bg-gray-950, text-gray-100). Pattern: `dashboard/src/app/study/page.tsx`.
+6. **Dashboard imports** do NOT use `.js` extensions. Follow existing patterns in `dashboard/src/lib/study-db.ts` and `dashboard/src/lib/db/index.ts`.
+7. **Commit messages** use conventional commits: `feat(study):`, `feat(dashboard):`.
+8. **Next.js API conventions may differ from training data.** Read the relevant guide in `node_modules/next/dist/docs/` before writing API routes (especially dynamic `[id]` params).
+
+---
+
+## Spec Deviations
+
+- **No AI evaluation in session UI.** S4 handles only self-rated activities (L1-L2). AI evaluation for L3+ activities is deferred to S5. The session page shows all activity types but the rating flow is always self-rated.
+- **Simplified calibration.** The spec says "correlation(confidence, performance)" (Zimmerman 2002). S4 uses a simpler metric: average absolute difference between per-concept confidence (1-5 normalized to 0-1) and average quality (0-5 normalized to 0-1). Full statistical correlation requires more data points than a single session provides.
+- **No 7-day analytics.** S4 implements a streak counter (consecutive days with a completed session). Full analytics dashboard (retention trends, calibration curves, Bloom's distribution) deferred to S8.
+- **No plan-based sessions.** `study_sessions.plan_id` exists but is always null in S4. Plan-aware sessions are S6.
+
+---
+
+## Key Decisions
+
+### D1: Dashboard schema convention — snake_case properties
+Consistent with S2's dashboard schema. The dashboard Drizzle instance uses `row.concept_id`, not `row.conceptId`. Mapper functions (like `rowToSummary()` in study-db.ts) convert to camelCase for API responses.
+
+### D2: Ported algorithms for direct SQLite writes (Flow 1)
+The dashboard ports SM-2 and mastery pure functions (~80 lines) to `dashboard/src/lib/study-algorithms.ts`. The dashboard's `completeActivity()` transaction mirrors the backend's — all within its own Drizzle instance. No HTTP proxy to the main process for core study operations.
+
+**Why:** Master plan Flow 1 explicitly assigns "activity completion writes" to direct SQLite access. The algorithms are deterministic and validated by 133 backend tests.
+
+**Tradeoff:** ~130 lines of duplicated pure functions (including constants like `BLOOM_WEIGHTS`, `MASTERY_THRESHOLD`, `DECAY_HALF_LIFE_DAYS` and helpers like `daysSince`, `decayFactor`). If the mastery formula changes, both copies must update. Acceptable because SM-2 is a published algorithm and the mastery model is mathematically defined.
+
+### D3: Generation triggers via IPC file writes
+The dashboard writes JSON request files to `data/ipc/study-generator/tasks/`. The main process IPC watcher picks these up. Two new IPC message types: `study_generation_request` and `study_post_session_generation`.
+
+**Why IPC files, not HTTP?** The IPC watcher already monitors this directory. No new server, port, or dependency. The dashboard writes a file; the main process processes it asynchronously.
+
+### D4: Session page is a single-page state machine
+`/study/session` handles: PRE_SESSION → IN_PROGRESS → POST_SESSION → COMPLETE. State held client-side. URL doesn't change between phases.
+
+**Why not separate routes?** A study session is a continuous flow — the student shouldn't see URL changes or full-page reloads between activities.
+
+### D5: Enriched session composition
+The session GET route returns activities with `prompt`, `referenceAnswer`, and `cardType` appended. The backend's `SessionActivity` type intentionally omits these (session builder doesn't need them). Enrichment happens in the API route by looking up each activity's full record.
+
+---
+
+## Essential Reading
+
+> **For coordinators:** Extract relevant patterns from these files and inline them into subagent prompts. Subagents won't read the files themselves.
+
+| File | Why |
+|------|-----|
+| `src/study/sm2.ts` | SM-2 algorithm to port — `sm2()`, `computeDueDate()`, `SM2Input`, `SM2Result` |
+| `src/study/mastery.ts` | Mastery functions to port — `computeMastery()`, `computeBloomCeiling()`, `computeOverallMastery()` |
+| `src/study/queries.ts:412-560` | `completeActivity()` transaction — dashboard mirrors this logic |
+| `src/study/engine.ts:133-210` | `processCompletion()` + `getDeEscalationAdvice()` — dashboard mirrors these |
+| `src/study/session-builder.ts` | Session composition algorithm — dashboard reimplements this |
+| `src/study/types.ts` | `SessionComposition`, `SessionBlock`, `SessionActivity`, `CompletionResult` types |
+| `src/db/schema/study.ts` | Full backend schema — dashboard schema must match SQL columns |
+| `dashboard/src/lib/study-db.ts` | Existing dashboard queries — extend this file |
+| `dashboard/src/lib/db/schema.ts` | Dashboard schema — extend with full learning_activities + study_sessions + activity_log |
+| `dashboard/src/app/study/page.tsx` | Existing /study page — update with session card and streak |
+| `dashboard/src/app/api/study/concepts/approve/route.ts` | Approve route — wire to generation trigger |
+| `src/ipc.ts:265-400` | `processTaskIpc()` — add cases for generation requests |
+
+---
+
+## Task Numbering
+
+| Plan task | Master plan items | What |
+|-----------|-------------------|------|
+| S4.1 | — | Dashboard schema extension |
+| S4.2 | — | Port algorithms + completion logic |
+| S4.3 | — | Dashboard session builder + session CRUD |
+| S4.4 | — (S3 bootstrapping gap) | Generation triggers + wire approval |
+| S4.5 | S4.1 | Study session API routes |
+| S4.6 | S4.2 + S4.5 | Update /study overview page |
+| S4.7 | S4.3 + S4.4 | Create /study/session page |
+| S4.8 | — | Verification |
+
+**Master plan errata:** S4.5 says "Add 'Study' link to dashboard nav" — already done in S2.
+
+---
+
+## Parallelization & Model Recommendations
+
+**Dependencies:**
+- S4.1 → S4.2, S4.3 (schema before queries)
+- S4.2 + S4.3 can run in parallel (independent modules, both need S4.1)
+- S4.4 is fully independent (backend IPC + dashboard file write — no schema dependency)
+- S4.5 depends on S4.2 + S4.3 + S4.4 (routes call these)
+- S4.6 + S4.7 can run in parallel (separate pages, both need S4.5)
+
+**Parallel opportunities:**
+- S4.1 + S4.4 (dashboard schema + backend IPC — independent codebases)
+- S4.2 + S4.3 (algorithms + session builder — independent modules)
+- S4.6 + S4.7 (overview page + session page — separate files)
+
+| Task | Can parallel with | Model | Rationale |
+|------|-------------------|-------|-----------|
+| S4.1 | S4.4 | Sonnet | Schema declarations — exact code |
+| S4.2 | S4.3 | Sonnet | Port pure functions + transaction following backend pattern |
+| S4.3 | S4.2 | Sonnet | Session builder from spec algorithm + CRUD |
+| S4.4 | S4.1 | Sonnet | IPC handler case + file write utility |
+| S4.5 | — | Sonnet | API routes following existing pattern |
+| S4.6 | S4.7 | Sonnet | Page update following existing pattern |
+| S4.7 | S4.6 | Sonnet | UI state machine, well-specified requirements |
+| S4.8 | — | Sonnet | Mechanical verification |
+
+**Skip two-stage review for:** S4.1, S4.4, S4.8 (schema, IPC handler, verification). Full review for: S4.2, S4.3, S4.5, S4.7.
+
+---
+
+## S4.1: Dashboard Schema Extension
+
+**Files:** Modify `dashboard/src/lib/db/schema.ts`
+
+**Parallelizable with S4.4.**
+
+The S2 plan noted: "The `learning_activities` definition is a minimal subset. S4 will extend this definition when the session UI needs additional fields."
+
+**Extend `learning_activities`** — add all missing columns from the backend schema (`src/db/schema/study.ts:learningActivities`). The columns to add: `prompt` (text, notNull), `reference_answer` (text), `difficulty_estimate` (integer, default 5), `card_type` (text), `author` (text, default 'system'), `source_note_path` (text), `source_chunk_hash` (text), `generated_at` (text, notNull), `ease_factor` (real, default 2.5), `interval_days` (integer, default 1), `repetitions` (integer, default 0), `last_reviewed` (text), `last_quality` (integer).
+
+**Add `study_sessions` table** — design decision (exact schema):
+```typescript
+export const study_sessions = sqliteTable('study_sessions', {
+  id: text('id').primaryKey(),
+  started_at: text('started_at').notNull(),
+  ended_at: text('ended_at'),
+  session_type: text('session_type').notNull(),
+  plan_id: text('plan_id'),
+  pre_confidence: text('pre_confidence'),
+  post_reflection: text('post_reflection'),
+  calibration_score: real('calibration_score'),
+  activities_completed: integer('activities_completed').default(0),
+  total_time_ms: integer('total_time_ms'),
+  surface: text('surface'),
+});
+```
+
+**Add `activity_log` table** — design decision (exact schema):
+```typescript
+export const activity_log = sqliteTable('activity_log', {
+  id: text('id').primaryKey(),
+  activity_id: text('activity_id').notNull(),
+  concept_id: text('concept_id').notNull(),
+  activity_type: text('activity_type').notNull(),
+  bloom_level: integer('bloom_level').notNull(),
+  quality: integer('quality').notNull(),
+  response_text: text('response_text'),
+  response_time_ms: integer('response_time_ms'),
+  confidence_rating: integer('confidence_rating'),
+  scaffolding_level: integer('scaffolding_level').default(0),
+  evaluation_method: text('evaluation_method').default('self_rated'),
+  ai_quality: integer('ai_quality'),
+  ai_feedback: text('ai_feedback'),
+  method_used: text('method_used'),
+  surface: text('surface'),
+  session_id: text('session_id'),
+  reviewed_at: text('reviewed_at').notNull(),
+});
+```
+
+- [ ] **Step 1:** Extend `learning_activities` with all missing columns
+- [ ] **Step 2:** Add `study_sessions` table definition
+- [ ] **Step 3:** Add `activity_log` table definition
+- [ ] **Step 4:** Verify: `cd dashboard && npx tsc --noEmit`
+- [ ] **Step 5:** Commit: `feat(dashboard): extend study schema for session UI (S4.1)`
+
+---
+
+## S4.2: Port Algorithms + Completion Logic
+
+**Files:** Create `dashboard/src/lib/study-algorithms.ts`, modify `dashboard/src/lib/study-db.ts`
+
+**Parallelizable with S4.3** (after S4.1).
+
+### Algorithms to port
+
+Create `dashboard/src/lib/study-algorithms.ts`. Port these pure functions **verbatim** from the backend:
+
+| Source file | Functions + dependencies | Approx lines |
+|-------------|------------------------|-------------|
+| `src/study/sm2.ts` | `sm2()`, `computeDueDate()`, `SM2Input`, `SM2Result` | ~30 |
+| `src/study/mastery.ts` | `computeMastery()`, `computeBloomCeiling()`, `computeOverallMastery()` + constants (`BLOOM_WEIGHTS`, `MASTERY_THRESHOLD`, `DECAY_HALF_LIFE_DAYS`) + helpers (`daysSince`, `decayFactor`) | ~100 |
+
+**Constraint:** Port the exact algorithm logic. Do NOT simplify, optimize, or refactor. Differences between the two copies would produce divergent mastery scores. Copy the function bodies AND all constants/helpers they depend on (e.g., `BLOOM_WEIGHTS`, `MASTERY_THRESHOLD`, `DECAY_HALF_LIFE_DAYS`, `daysSince`, `decayFactor`).
+
+### Completion logic in study-db.ts
+
+Add two functions:
+
+**`completeActivity(input): CompleteActivityResult`** — mirror the backend's transaction from `src/study/queries.ts:447-560`:
+1. Look up the activity (throw if not found)
+2. Compute SM-2 update → call ported `sm2()` + `computeDueDate()`
+3. Mastery state heuristic: `repetitions === 0` → 'learning', `intervalDays >= 21` → 'mastered', else → 'reviewing'
+4. Update activity row: `ease_factor`, `interval_days`, `repetitions`, `due_at`, `last_reviewed`, `last_quality`, AND `mastery_state` (from step 3)
+5. Insert activity_log entry with `crypto.randomUUID()` for ID. Default `evaluation_method` to `'self_rated'`, `ai_quality`/`ai_feedback`/`method_used` to null.
+6. Recompute concept mastery from ALL logs → ported `computeMastery()` + `computeBloomCeiling()` + `computeOverallMastery()`
+7. Update concept's mastery fields + bloomCeiling
+8. Increment session `activities_completed` if sessionId provided
+All within `getDb().transaction()`.
+
+**Interfaces:**
+```typescript
+export interface CompleteActivityInput {
+  activityId: string;
+  quality: number;
+  sessionId?: string;
+  responseText?: string;
+  responseTimeMs?: number;
+  confidenceRating?: number;
+  surface?: string;
+}
+export interface CompleteActivityResult {
+  logEntryId: string;
+  newDueAt: string;
+  bloomCeilingBefore: number;
+  bloomCeilingAfter: number;
+}
+```
+
+**`processCompletion(input): CompletionResult`** — mirror `src/study/engine.ts:133-210`:
+1. Look up activity to get conceptId
+2. Call `completeActivity(input)`
+3. If `bloomCeilingAfter > bloomCeilingBefore`: look up concept for title, check if activities exist at new level, build advancement object
+4. De-escalation: get last 5 logs for this concept, if avg quality < 2.5 and ceiling > 1 → return advice string
+5. Return CompletionResult
+
+```typescript
+export interface CompletionResult {
+  logEntryId: string;
+  newDueAt: string;
+  advancement: { conceptId: string; conceptTitle: string; previousCeiling: number; newCeiling: number; generationNeeded: boolean } | null;
+  generationNeeded: boolean;
+  deEscalation: string | null;
+}
+```
+
+**Agent discretion:** Internal helpers, whether to extract de-escalation into a standalone function.
+
+- [ ] **Step 1:** Create `dashboard/src/lib/study-algorithms.ts` — port sm2 + mastery
+- [ ] **Step 2:** Add `completeActivity` transaction to study-db.ts
+- [ ] **Step 3:** Add `processCompletion` wrapper to study-db.ts
+- [ ] **Step 4:** Verify: `cd dashboard && npx tsc --noEmit`
+- [ ] **Step 5:** Commit: `feat(dashboard): add study algorithms and completion logic (S4.2)`
+
+---
+
+## S4.3: Dashboard Session Builder + Session CRUD
+
+**Files:** Create `dashboard/src/lib/session-builder.ts`, modify `dashboard/src/lib/study-db.ts`
+
+**Parallelizable with S4.2** (after S4.1).
+
+### Session Builder
+
+Create `dashboard/src/lib/session-builder.ts` implementing `buildSessionComposition(options?)`.
+
+Follow the same algorithm as the backend's `src/study/session-builder.ts` (spec Section 4.5):
+
+1. Get all due activities (where `due_at <= today`). Get all active concepts → Map by id.
+2. Enrich each activity with concept metadata. Skip activities whose concept is missing.
+3. If `domainFocus` set, filter to matching domain.
+4. Target count: `targetActivities ?? 20`.
+
+**Block composition:**
+- **New material (~30%):** bloomLevel 1-2, concept's bloomCeiling < 3. Group by domain for topic coherence.
+- **Review (~50%):** Everything NOT in new block. Sort by: most overdue first, lowest ease_factor. Interleave: never 2 consecutive with same conceptId (best-effort — skip and append).
+- **Stretch (~20%):** bloomLevel >= 4, concept's bloomCeiling >= 4. NOT already in review.
+
+5. Domain coverage: if an active domain with due activities is missing, swap lowest-priority review activity.
+6. If total < target, fill from remaining pool.
+7. Estimate minutes: card_review 1.5, elaboration 3, self_explain/comparison/case_analysis/concept_map 5, synthesis/socratic 7.
+
+**Return type** — define interfaces locally (same shape as backend's `types.ts`):
+```typescript
+export interface SessionBlock { type: 'new' | 'review' | 'stretch'; activities: SessionActivity[] }
+export interface SessionActivity { activityId: string; conceptId: string; conceptTitle: string; domain: string | null; activityType: string; bloomLevel: number }
+export interface SessionComposition { blocks: SessionBlock[]; totalActivities: number; estimatedMinutes: number; domainsCovered: string[] }
+export interface SessionOptions { targetActivities?: number; domainFocus?: string }
+```
+
+**Constraint:** No due activities → return `{ blocks: [], totalActivities: 0, estimatedMinutes: 0, domainsCovered: [] }`.
+**Constraint:** Activities without a matching concept are silently skipped.
+
+### DB queries needed
+
+Add to study-db.ts:
+
+| Function | Signature | Notes |
+|----------|-----------|-------|
+| `getDueActivities` | `() → ActivityRow[]` | `due_at <= today`, all columns (session builder + enrichment need them) |
+| `getActivityById` | `(id: string) → ActivityRow \| undefined` | Full activity row |
+| `getActivitiesByConceptId` | `(conceptId: string) → ActivityRow[]` | For advancement checks in processCompletion |
+| `getRecentLogs` | `(conceptId: string, limit: number) → LogRow[]` | For de-escalation check |
+
+### Session CRUD
+
+Add to study-db.ts:
+
+| Function | Signature | Notes |
+|----------|-----------|-------|
+| `createSession` | `(session: NewSession) → void` | Insert into study_sessions |
+| `getSessionById` | `(id: string) → SessionRow \| undefined` | Read session |
+| `updateSession` | `(id: string, updates: Partial<SessionRow>) → void` | Update endedAt, postReflection, etc. |
+| `getRecentSessions` | `(limit: number) → SessionRow[]` | Ordered by started_at desc |
+| `getStreakDays` | `() → number` | Consecutive days from today with at least one completed session (endedAt != null) |
+| `getActiveSession` | `() → SessionRow \| undefined` | Most recent session with `ended_at = null`, for resume-on-refresh |
+| `getLogsBySession` | `(sessionId: string) → LogRow[]` | Activity logs for a session, ordered by reviewed_at |
+
+**Agent discretion:** Helper types, whether to define row→interface mappers, exact streak algorithm.
+
+- [ ] **Step 1:** Add query functions to study-db.ts
+- [ ] **Step 2:** Add session CRUD functions to study-db.ts
+- [ ] **Step 3:** Create `dashboard/src/lib/session-builder.ts`
+- [ ] **Step 4:** Verify: `cd dashboard && npx tsc --noEmit`
+- [ ] **Step 5:** Commit: `feat(dashboard): add session builder and session CRUD (S4.3)`
+
+---
+
+## S4.4: Generation Triggers via IPC + Wire Approval
+
+**Files:** Modify `src/ipc.ts`, create `dashboard/src/lib/generation-trigger.ts`, modify `dashboard/src/app/api/study/concepts/approve/route.ts`
+
+**Parallelizable with S4.1.**
+
+Solves the S3 bootstrapping gap: newly approved concepts have zero activities.
+
+### IPC Handler (backend)
+
+Add two new cases to `processTaskIpc()` in `src/ipc.ts`:
+
+**Case `study_generation_request`:** Payload `{ type, conceptId: string, bloomLevel: number }`. Call `generateActivities(conceptId, bloomLevel)` from `src/study/generator.js`. Try/catch — log on error, don't crash.
+
+**Case `study_post_session_generation`:** Payload `{ type, sessionId: string }`. Call `triggerPostSessionGeneration(sessionId)` from `src/study/engine.js`. Try/catch.
+
+**Constraint:** These new IPC cases must NOT include `isMain` authorization checks. The `study-generator` directory is not a registered group — `isMain` will be `undefined`/`false`. These are system-internal operations triggered by the dashboard, not group-originated commands.
+
+**Constraint:** Verify the IPC watcher monitors `data/ipc/study-generator/tasks/` at startup (even without an active container). The watcher scans ALL subdirectories of `data/ipc/`, so the directory just needs to exist. The dashboard's `fs.mkdirSync({ recursive: true })` ensures this.
+
+### Dashboard Trigger Helper
+
+Create `dashboard/src/lib/generation-trigger.ts`:
+
+Two exported functions:
+- `requestGeneration(conceptId: string, bloomLevel: number): void` — writes `{ type: "study_generation_request", conceptId, bloomLevel }` as JSON to `{projectRoot}/data/ipc/study-generator/tasks/gen-req-{conceptId}-{timestamp}.json`
+- `requestPostSessionGeneration(sessionId: string): void` — writes `{ type: "study_post_session_generation", sessionId }` to same directory
+
+Project root: `path.join(process.cwd(), '..')` (same pattern as `dashboard/src/lib/db/index.ts` uses for store dir).
+
+**Constraint:** Create the target directory if it doesn't exist (`fs.mkdirSync({ recursive: true })`). Use unique filenames with timestamps to avoid collisions.
+
+### Wire Approval Route
+
+Modify `dashboard/src/app/api/study/concepts/approve/route.ts`: After each successful approval, call `requestGeneration(conceptId, 1)` for each approved concept. For `approveDomain()` path: iterate over returned IDs. For `approveConcepts()` path: iterate over input `conceptIds`.
+
+**Constraint:** Generation requests are fire-and-forget. If `requestGeneration()` throws, log a warning but still return the successful approval response. Concepts are approved regardless.
+
+**Known behavior:** There's a 30-60 second latency between approval and activities being available (container startup + LLM generation). If a user approves concepts and immediately starts a session, the newly approved concepts will have zero activities and won't appear. This is acceptable — the session builder silently skips concepts without due activities.
+
+- [ ] **Step 1:** Add both cases to `processTaskIpc()` in `src/ipc.ts`
+- [ ] **Step 2:** Create `dashboard/src/lib/generation-trigger.ts`
+- [ ] **Step 3:** Modify approve route to call `requestGeneration()` after approval
+- [ ] **Step 4:** Run backend tests: `npx vitest run src/ipc` — no regressions
+- [ ] **Step 5:** Commit: `feat(study): add IPC generation triggers and wire approval (S4.4)`
+
+---
+
+## S4.5: Study Session API Routes
+
+**Files:** Create API routes under `dashboard/src/app/api/study/`
+
+**Depends on:** S4.2, S4.3, S4.4.
+
+**Directory structure:**
+```
+dashboard/src/app/api/study/
+  session/
+    route.ts                 — GET (build) + POST (create)
+    [id]/
+      reflect/
+        route.ts             — POST (reflection)
+  complete/
+    route.ts                 — POST (complete activity)
+```
+
+### GET /api/study/session
+
+Call `buildSessionComposition()`. Enrich each activity by looking up the full record via `getActivityById()` — append `prompt`, `referenceAnswer` (mapped from `reference_answer`), and `cardType` (mapped from `card_type`). If activity not found, skip it.
+
+Response: `{ session: EnrichedSessionComposition }`
+
+### POST /api/study/session
+
+Body: `{ sessionType?: string, preConfidence?: Record<string, number> }`
+
+First check for an active session (`getActiveSession()`). If one exists, end it (`endedAt = now`) before creating the new one — prevents orphaned sessions.
+
+Generate UUID. Create session with `startedAt: new Date().toISOString()`, `sessionType: body.sessionType ?? 'daily'`, `preConfidence: JSON.stringify(body.preConfidence ?? {})`, `surface: 'dashboard_ui'`.
+
+Response: `{ sessionId: string }`
+
+### POST /api/study/complete
+
+Body: `{ activityId, quality, sessionId?, responseText?, responseTimeMs?, confidenceRating? }`
+
+Call `processCompletion(body)`. If `result.generationNeeded`, also call `requestGeneration()` with the advancement's conceptId and newCeiling.
+
+Response: the `CompletionResult` object.
+
+### POST /api/study/session/[id]/reflect
+
+Body: `{ reflection: string }`
+
+1. Get session by ID (from URL param). 404 if not found.
+2. Compute calibration: parse `preConfidence` JSON, get session's activity logs via `getLogsBySession()`, group logs by conceptId, compute per-concept average quality, compare with confidence. Score = 1 - avg(|confidence/5 - avgQuality/5|). Lower difference = higher score (better calibrated).
+3. Update session: `ended_at = now, post_reflection = reflection, calibration_score = computed, total_time_ms = now - started_at`.
+4. Call `requestPostSessionGeneration(sessionId)`.
+
+Response: `{ calibrationScore: number, activitiesCompleted: number }`
+
+**Constraint:** Check Next.js dynamic route params API in `node_modules/next/dist/docs/` before implementing the `[id]` route.
+
+- [ ] **Step 1:** Create directory structure
+- [ ] **Step 2:** Create GET + POST `/api/study/session` route
+- [ ] **Step 3:** Create POST `/api/study/complete` route
+- [ ] **Step 4:** Create POST `/api/study/session/[id]/reflect` route
+- [ ] **Step 5:** Verify: `cd dashboard && npx tsc --noEmit`
+- [ ] **Step 6:** Commit: `feat(dashboard): add study session API routes (S4.5)`
+
+---
+
+## S4.6: Update /study Overview Page
+
+**Files:** Modify `dashboard/src/app/study/page.tsx`, modify `dashboard/src/lib/study-db.ts`
+
+**Parallelizable with S4.7.**
+
+### Per-level mastery in ConceptSummary
+
+Update `rowToSummary()` in study-db.ts and the `ConceptSummary` interface to include `masteryL1` through `masteryL6` (already in the DB, not currently returned).
+
+### Today's Session Card
+
+Add above the "Pending Approval" section:
+- Fetch from `GET /api/study/session` on mount
+- Show: total activity count, activity breakdown by type, estimated time, domains covered
+- "Start Session" button → navigate to `/study/session`
+- If no activities due: "All caught up! No activities due today."
+
+### Streak Indicator
+
+Show alongside the stats bar. Call `getStreakDays()` via a new endpoint or include in the concepts stats response. Display "N-day streak" if > 0, hide if 0.
+
+**Agent discretion:** Whether streak is a separate API call or included in existing stats, exact card layout, Tailwind styling, mastery bar design (tiny bars vs. heatmap).
+
+- [ ] **Step 1:** Add per-level mastery to ConceptSummary + rowToSummary
+- [ ] **Step 2:** Add session card to /study page
+- [ ] **Step 3:** Add streak indicator
+- [ ] **Step 4:** Start dashboard: `cd dashboard && npm run dev`. Verify at http://localhost:3100/study
+- [ ] **Step 5:** Commit: `feat(dashboard): add session card, streak, per-level mastery to /study (S4.6)`
+
+---
+
+## S4.7: Create /study/session Page
+
+**Files:** Create `dashboard/src/app/study/session/page.tsx`
+
+**Parallelizable with S4.6.**
+
+### State Machine
+
+```
+LOADING → PRE_SESSION → IN_PROGRESS → POST_SESSION → COMPLETE
+```
+
+**LOADING:** First check for an active session via `GET /api/study/session?resume=true` (or a separate endpoint). If an active session exists (endedAt = null), resume it: fetch the session's composition, check which activities have logs (already completed), and jump to IN_PROGRESS at the next uncompleted activity. If no active session, fetch a fresh composition. If no activities due, show "Nothing to study today" with link to /study.
+
+**PRE_SESSION:** Show unique concepts from composition. For each: concept title + 1-5 confidence buttons ("How well do you know this?"). "Begin Session" button → `POST /api/study/session` with preConfidence map → receive sessionId → transition.
+
+**IN_PROGRESS:** One activity at a time. Flatten blocks into a sequential list but show block labels ("New Material", "Review", "Stretch") when entering a new block.
+
+Activity flow:
+1. Show concept title + domain + Bloom level badge (e.g., "L1")
+2. Show activity prompt text
+3. Text area for response (or text input for card_review)
+4. "Submit" button → reveals reference answer below with visual separator
+5. Self-rating buttons: 0 (Blackout), 1 (Wrong but recognized), 2 (Wrong but easy recall), 3 (Correct with difficulty), 4 (Correct with hesitation), 5 (Perfect)
+6. On rating → `POST /api/study/complete` with quality, sessionId, responseText, responseTimeMs
+7. Show result: advancement badge if bloom advanced, de-escalation hint if struggling
+8. "Next" button → advance
+9. "Skip" button (before submission) → `POST /api/study/complete` with quality=0 (counts toward `activities_completed` — SM-2 treats this as a failed recall, resetting interval to 1 day)
+
+Track `responseTimeMs`: `Date.now()` delta from prompt display to Submit click.
+
+Progress bar: `{current} / {total}` with visual bar at top.
+
+**POST_SESSION** (fulfills master plan S4.4 — post-session reflection):
+- Summary: activities completed, average quality, time spent
+- Calibration: per-concept "Predicted X, scored Y" with over/under feedback. Compute client-side from the preConfidence map (stored in state from PRE_SESSION) and completion results (accumulated during IN_PROGRESS). "Underestimated!" if scored higher, "Overconfident" if scored lower.
+- Reflection text area: "What did you find surprising or difficult?"
+- "Complete" → `POST /api/study/session/{id}/reflect`
+
+**COMPLETE:** Summary stats, link to /study.
+
+### Design
+
+- Dark theme: bg-gray-950, text-gray-100 (consistent with dashboard)
+- Activity card: bg-gray-900, rounded, generous padding
+- Reference answer: bg-gray-800, visual separator
+- Rating buttons: horizontal row, selected state highlight
+- Progress bar: thin colored bar at top
+- Block labels: subtle divider with text
+
+**Agent discretion:** Component decomposition, exact Tailwind, animations, mobile responsiveness, keyboard shortcuts.
+
+- [ ] **Step 1:** Create page with state machine skeleton
+- [ ] **Step 2:** Implement LOADING + PRE_SESSION phases
+- [ ] **Step 3:** Implement IN_PROGRESS phase
+- [ ] **Step 4:** Implement POST_SESSION + COMPLETE phases
+- [ ] **Step 5:** Start dashboard, test full flow at http://localhost:3100/study/session
+- [ ] **Step 6:** Commit: `feat(dashboard): add /study/session page with full study loop (S4.7)`
+
+---
+
+## S4.8: Verification
+
+- [ ] **Step 1:** Run backend tests: `npm test` — all pass, no regressions
+- [ ] **Step 2:** Build: `npm run build` — clean
+- [ ] **Step 3:** Dashboard types: `cd dashboard && npx tsc --noEmit` — clean
+- [ ] **Step 4:** Start dashboard, navigate to /study — session card visible
+- [ ] **Step 5:** Click "Start Session" — pre-confidence renders
+- [ ] **Step 6:** Complete a card_review: type answer → submit → rate 5 → verify reference reveals
+- [ ] **Step 7:** Complete an elaboration: type explanation → submit → rate → verify
+- [ ] **Step 8:** Skip an activity → verify quality=0 logged
+- [ ] **Step 9:** Complete session → reflection form + calibration feedback
+- [ ] **Step 10:** Submit reflection → verify redirect to /study, mastery updated
+- [ ] **Step 11:** Commit: `chore(study): verify study session end-to-end (S4.8)`
+
+---
+
+## Acceptance Criteria
+
+From master plan S4 (non-negotiable):
+
+- [ ] Student can start a session, complete card + elaboration activities, rate themselves
+- [ ] SM-2 schedules update after each completion (due dates change)
+- [ ] Mastery bars update after session
+- [ ] Pre/post metacognition flow works (confidence → calibration feedback → reflection)
+- [ ] Session recorded in study_sessions table
+- [ ] Concept approval triggers initial L1-L2 activity generation (bootstrapping resolved)
+- [ ] All existing tests pass (`npm test`)
+- [ ] Clean build (`npm run build`, `cd dashboard && npx tsc --noEmit`)

--- a/docs/superpowers/plans/2026-04-16-s6-planning-system.md
+++ b/docs/superpowers/plans/2026-04-16-s6-planning-system.md
@@ -1,0 +1,957 @@
+# S6: Planning System — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Your role:** You are the engineer implementing this. The plan tells you *what* to build and *why*. You decide *how* within the stated constraints. If you disagree with an approach or see a better alternative, flag it before implementing — don't silently deviate and don't silently comply with something you think is wrong.
+
+**Goal:** Add collaborative study plan creation, plan-aware session building, and plan progress tracking to the study system. Students can create plans (quick form or guided chat dialogue), associate concepts, set deadlines, and see plan-scoped progress. Sessions can be scoped to a plan so the session builder prioritizes plan concepts.
+
+**Architecture:** S6 builds on top of existing infrastructure. The `study_plans` and `study_plan_concepts` tables already exist (S1). Backend `queries.ts` already has basic plan CRUD (`createStudyPlan`, `getStudyPlanById`, `getAllStudyPlans`, `updateStudyPlan`, `addConceptsToPlan`, `getPlanConcepts`). S6 adds: (1) new query functions for plan progress and plan-scoped activity fetching, (2) plan-aware session builder option (`planId`), (3) dashboard schema tables for plans, (4) dashboard DB functions for plan management, (5) dashboard API routes for plan CRUD, (6) `/study/plan` page with plan list + create + detail views, (7) plan creation dialogue instructions in the study agent CLAUDE.md, (8) `plan_id` wired into existing session creation flow.
+
+**Tech Stack:** TypeScript/Node.js (backend), Next.js + React (dashboard), Drizzle ORM (SQLite), container agents (Claude via NanoClaw)
+
+**Branch:** Create `feat/s6-planning-system` off `main`. S5 merged via PR #32.
+
+**Spec:** `docs/superpowers/specs/2026-04-12-multi-method-study-system-design.md` (v2.1, Section 5)
+
+**Master plan:** `docs/superpowers/plans/2026-04-13-study-system-master-plan.md` (S6 checklist)
+
+---
+
+## Codebase Conventions (Hard Constraints)
+
+These apply to **every task**. Subagents must follow these — they're not obvious from context alone.
+
+1. **`.js` extensions on all relative imports in `src/`.** The backend uses Node ESM resolution. Write `import { foo } from './bar.js'`, not `'./bar'`. **Exception:** Dashboard (`dashboard/src/`) does NOT use `.js` extensions — Next.js handles resolution.
+2. **camelCase Drizzle properties, snake_case SQL columns** (backend `src/db/schema/study.ts`). Dashboard schema (`dashboard/src/lib/db/schema.ts`) uses snake_case properties matching SQL column names (different convention — established in S2).
+3. **Drizzle query builder operators** (`eq`, `and`, `lte`, `desc`, `asc`, `count`, `sql`, `inArray`, `gte`) — not raw SQL strings.
+4. **Dashboard API routes** use `Response.json()` + try/catch. Pattern: `dashboard/src/app/api/study/concepts/route.ts`.
+5. **Dashboard pages** are `'use client'` components with `useState`/`useEffect` for data fetching. Tailwind CSS. Dark theme (bg-gray-950, text-gray-100). Pattern: `dashboard/src/app/study/page.tsx`.
+6. **Dashboard imports** do NOT use `.js` extensions. Follow existing patterns in `dashboard/src/lib/study-db.ts` and `dashboard/src/lib/db/index.ts`.
+7. **Commit messages** use conventional commits: `feat(study):`, `feat(dashboard):`.
+8. **Next.js API conventions may differ from training data.** Read the relevant guide in `node_modules/next/dist/docs/` before writing API routes (especially dynamic `[id]` params).
+9. **Test file locations:** Backend tests are colocated: `src/study/foo.test.ts`. Use `createTestDb()` from test helpers. Import from `./foo.js` (ESM extension rule applies in tests too).
+10. **Study query functions** live in `src/study/queries.ts` (not `src/db.ts`). Study is self-contained — never import `getDb()` from `src/db/index.ts` in study modules; use the existing `getDb()` re-export from `queries.ts`.
+
+---
+
+## Spec Deviations
+
+- **No IPC for plan creation.** The spec mentions a `study_plan` IPC message from the study agent after plan dialogue. S6 implements plan creation via direct dashboard API calls instead. The study agent's plan dialogue outputs a structured recommendation that the dashboard extracts from the chat transcript — no new IPC type needed. **Why:** Adding a new IPC type + handler is complex infrastructure for a simple CRUD operation the dashboard can do directly. The chat dialogue helps the student think; the dashboard captures the result.
+- **No `planner.ts` module.** The master plan S6.1 calls for `src/study/planner.ts` with `createQuickPlan()` and `processPlanDialogue()`. S6 skips this file entirely — plan CRUD is handled by dashboard API routes calling `study-db.ts` functions, and plan dialogue happens in the study agent (no transcript parsing needed). **Why:** `planner.ts` would be a thin wrapper around `createStudyPlan()` + `addConceptsToPlan()` in `queries.ts`. Adding a module for two lines of orchestration isn't justified. The dashboard API route does the same work directly.
+- **Checkpoint system is data-only.** The spec describes checkpoint adaptation dialogue (Zimmerman self-reflection). S6 stores `next_checkpoint_at` and computes progress, but the checkpoint review dialogue (where the agent asks "how is the plan going?") is deferred to S8. S6 shows checkpoint dates and progress on the plan detail page.
+- **Plan dialogue is additive, not mandatory.** The spec (Section 5.1) describes three paths: quick (30s), standard (5min), deep (10+min). S6 implements quick (form) and standard (chat with the study agent using method="plan"). The deep 5-phase framework (Discover → Define → Design → Commit → Adapt) is added to the study agent CLAUDE.md as optional depth the agent offers, but the UI doesn't enforce phases.
+
+---
+
+## Key Decisions
+
+### D1: Plan creation via dashboard form, not agent dialogue
+The quick path creates plans entirely through the dashboard: title, select concepts (grouped by domain), set strategy, optional deadline. No container agent needed. The guided path opens `/study/chat?method=plan` where the study agent helps the student think through objectives and strategy — but the student still creates the plan via the dashboard form after the dialogue.
+
+**Why not agent-created plans via IPC?** The plan data is simple (title, concepts, strategy, deadline). Having the agent write IPC that triggers plan creation adds an IPC type, a handler, error paths for invalid concept IDs, and a race condition between the dashboard and the agent both trying to create the same plan. The dialogue adds value by helping the student think — the form captures the result.
+
+**Tradeoff:** The student must manually transfer insights from the dialogue to the form. Acceptable for a single user; the dialogue primes their thinking, they fill in the form with clarity.
+
+### D2: Plan-scoped sessions via `planId` filter on session builder
+When the student starts a session from a plan detail page, the session builder filters due activities to only those belonging to plan concepts. The existing `SessionOptions` interface gets a `planId?: string` field. The session builder joins `learning_activities` → `concepts` → `study_plan_concepts` to filter.
+
+**Why filter, not separate builder?** The block allocation logic (30% new, 50% review, 20% stretch), interleaving, and domain coverage are identical. Only the activity pool differs. One `planId` filter keeps the builder DRY.
+
+### D3: Plan progress computed, not stored
+Plan progress (% of concepts reaching their `target_bloom`) is computed on read from current concept mastery, not stored as a cached field. With <50 concepts per plan and simple column reads, this is fast enough. No staleness issues.
+
+**Why not cache?** Cached progress would need invalidation on every activity completion (mastery changes). The computation is a COUNT query — negligible cost for a single-user app.
+
+### D4: Dashboard schema gets plan tables
+The dashboard schema (`dashboard/src/lib/db/schema.ts`) currently lacks `study_plans` and `study_plan_concepts`. These must be added so dashboard DB functions can query plan data directly. Same pattern as the existing `concepts`, `learning_activities`, `study_sessions`, and `activity_log` tables there.
+
+### D5: Exam-prep mode = deadline + target bloom constraints
+The spec says "exam-prep" is a scheduling constraint. S6 implements it as: `strategy = 'exam-prep'` + `config.exam_date` (ISO date string in the JSON config field). The session builder, when given a plan with exam-prep strategy, prioritizes concepts furthest from their `target_bloom` and increases session size as the deadline approaches. No new algorithm — just priority sorting within the existing builder.
+
+---
+
+## Essential Reading
+
+> **For coordinators:** Extract relevant patterns from these files and inline them into subagent prompts. Subagents won't read the files themselves.
+
+| File | Why |
+|------|-----|
+| `src/study/queries.ts:319-407` | Existing plan CRUD functions. S6 adds progress queries alongside these. |
+| `src/study/session-builder.ts` | Full session builder. S6 adds `planId` filtering. 274 lines. |
+| `dashboard/src/lib/session-builder.ts` | Dashboard copy of session builder. Must also get `planId` support. 294 lines. |
+| `dashboard/src/lib/study-db.ts` | Dashboard DB functions. S6 adds plan queries here. |
+| `dashboard/src/lib/db/schema.ts` | Dashboard schema. S6 adds `study_plans` + `study_plan_concepts` tables. |
+| `src/db/schema/study.ts:70-111` | Backend schema for `studyPlans` and `studyPlanConcepts`. Dashboard schema must match SQL columns. |
+| `dashboard/src/app/api/study/session/route.ts` | Session creation route. S6 wires `planId` into this. |
+| `dashboard/src/app/study/page.tsx` | Study overview. S6 adds plans section here. |
+| `groups/study/CLAUDE.md` | Study agent prompt. S6 adds plan dialogue instructions. |
+
+---
+
+## Task Numbering
+
+| Plan task | Master plan items | What |
+|-----------|-------------------|------|
+| S6.1 | S6.1 (partial) | Backend: plan progress queries + plan-scoped activity queries |
+| S6.2 | S6.5 (partial) | Backend: plan-aware session builder |
+| S6.3 | — | Dashboard: schema + DB functions for plans |
+| S6.4 | S6.2 | Dashboard: plan API routes |
+| S6.5 | S6.3 | Dashboard: /study/plan page |
+| S6.6 | S6.5 (partial) | Dashboard: wire planId into session creation flow |
+| S6.7 | S6.4 | Study agent: plan dialogue instructions in CLAUDE.md |
+| S6.8 | — | Verification |
+
+---
+
+## Parallelization & Model Recommendations
+
+**Dependencies:**
+- S6.1 is independent (backend queries — no dashboard dependency)
+- S6.2 depends on S6.1 (session builder uses new plan queries)
+- S6.3 is independent (dashboard schema/DB — no backend dependency)
+- S6.4 depends on S6.3 (API routes use dashboard DB functions)
+- S6.5 depends on S6.4 (plan page calls API routes)
+- S6.6 depends on S6.3 + S6.4 (session route needs plan DB functions)
+- S6.7 is independent (CLAUDE.md file — no code dependency)
+
+**Parallel opportunities:**
+- **Wave 1:** S6.1 + S6.3 + S6.7 (backend queries, dashboard schema+DB, CLAUDE.md — fully independent)
+- **Wave 2:** S6.2 + S6.4 (session builder, API routes — both depend on Wave 1 but not each other)
+- **Wave 3:** S6.5 + S6.6 (plan page, session wiring — depend on Wave 2)
+- **Wave 4:** S6.8 (verification)
+
+| Task | Can parallel with | Model | Rationale |
+|------|-------------------|-------|-----------|
+| S6.1 | S6.3, S6.7 | Sonnet | Mechanical queries following established pattern |
+| S6.2 | S6.4 | Sonnet | Adds filter to existing builder — well-defined |
+| S6.3 | S6.1, S6.7 | Sonnet | Schema + DB functions following existing pattern |
+| S6.4 | S6.2 | Sonnet | API routes following dashboard pattern |
+| S6.5 | S6.6 | Sonnet | Plan page — clear UI requirements |
+| S6.6 | S6.5 | Sonnet | Small wiring change in session route |
+| S6.7 | S6.1, S6.3 | **Opus** | Creative writing — plan dialogue pedagogy needs judgment |
+| S6.8 | — | Sonnet | Mechanical verification |
+
+**File ownership for parallel waves:**
+
+Wave 1 parallel agents:
+- **S6.1 agent:** Owns `src/study/queries.ts`, `src/study/queries.test.ts`. Do NOT touch dashboard files or `session-builder.ts`.
+- **S6.3 agent:** Owns `dashboard/src/lib/db/schema.ts`, `dashboard/src/lib/study-db.ts`. Do NOT touch `src/study/` files.
+- **S6.7 agent:** Owns `groups/study/CLAUDE.md`. Do NOT touch any `.ts` files.
+
+Wave 2 parallel agents:
+- **S6.2 agent:** Owns `src/study/session-builder.ts`, `src/study/session-builder.test.ts`, `dashboard/src/lib/session-builder.ts`. Do NOT touch `queries.ts` or API routes.
+- **S6.4 agent:** Owns `dashboard/src/app/api/study/plans/` directory. Do NOT touch session-builder files.
+
+Wave 3 parallel agents:
+- **S6.5 agent:** Owns `dashboard/src/app/study/plan/` directory, may modify `dashboard/src/app/study/page.tsx`. Do NOT touch API routes, session route, or `study-db.ts`.
+- **S6.6 agent:** Owns `dashboard/src/app/api/study/session/route.ts`, `dashboard/src/app/study/session/page.tsx`, and `dashboard/src/lib/study-db.ts` (NewSession interface only — do NOT add new plan functions, those were added in S6.3). Do NOT touch plan page files.
+
+---
+
+## S6.1: Backend Plan Progress Queries
+
+**Files:** Modify `src/study/queries.ts`, modify `src/study/types.ts`, create/modify `src/study/queries.test.ts`
+
+**Parallelizable with S6.3, S6.7.**
+
+### New types in `src/study/types.ts`
+
+Add after the existing `SynthesisOpportunity` interface (end of file):
+
+```typescript
+/** Progress summary for a study plan */
+export interface PlanProgress {
+  planId: string;
+  totalConcepts: number;
+  conceptsAtTarget: number;  // concepts where bloomCeiling >= targetBloom
+  progressPercent: number;   // conceptsAtTarget / totalConcepts * 100
+  conceptDetails: PlanConceptProgress[];
+}
+
+/** Per-concept progress within a plan */
+export interface PlanConceptProgress {
+  conceptId: string;
+  conceptTitle: string;
+  domain: string | null;
+  currentBloomCeiling: number;
+  targetBloom: number;
+  masteryOverall: number;
+  atTarget: boolean;
+}
+```
+
+### New query functions in `src/study/queries.ts`
+
+Add these after the closing brace of `getPlanConcepts()` (around line 407, after the `// ====` separator).
+
+**1. `getPlanProgress(planId: string): PlanProgress | null`**
+
+Joins `study_plan_concepts` → `concepts` for the given planId. For each row, checks if `concept.bloomCeiling >= studyPlanConcepts.targetBloom`. Computes aggregate counts.
+
+Pattern:
+```typescript
+export function getPlanProgress(planId: string): PlanProgress | null {
+  const plan = getStudyPlanById(planId);
+  if (!plan) return null;
+
+  const rows = getDb()
+    .select({
+      conceptId: schema.concepts.id,
+      conceptTitle: schema.concepts.title,
+      domain: schema.concepts.domain,
+      bloomCeiling: schema.concepts.bloomCeiling,
+      masteryOverall: schema.concepts.masteryOverall,
+      targetBloom: schema.studyPlanConcepts.targetBloom,
+    })
+    .from(schema.studyPlanConcepts)
+    .innerJoin(schema.concepts, eq(schema.studyPlanConcepts.conceptId, schema.concepts.id))
+    .where(eq(schema.studyPlanConcepts.planId, planId))
+    .orderBy(asc(schema.studyPlanConcepts.sortOrder))
+    .all();
+
+  const details: PlanConceptProgress[] = rows.map(r => ({
+    conceptId: r.conceptId,
+    conceptTitle: r.conceptTitle,
+    domain: r.domain,
+    currentBloomCeiling: r.bloomCeiling ?? 0,
+    targetBloom: r.targetBloom ?? 6,
+    masteryOverall: r.masteryOverall ?? 0,
+    atTarget: (r.bloomCeiling ?? 0) >= (r.targetBloom ?? 6),
+  }));
+
+  const atTarget = details.filter(d => d.atTarget).length;
+
+  return {
+    planId,
+    totalConcepts: details.length,
+    conceptsAtTarget: atTarget,
+    progressPercent: details.length > 0 ? Math.round((atTarget / details.length) * 100) : 0,
+    conceptDetails: details,
+  };
+}
+```
+
+**2. `getActivePlans(): StudyPlan[]`** — filter `getAllStudyPlans()` to status='active'.
+
+```typescript
+export function getActivePlans(): StudyPlan[] {
+  return getDb()
+    .select()
+    .from(schema.studyPlans)
+    .where(eq(schema.studyPlans.status, 'active'))
+    .orderBy(desc(schema.studyPlans.createdAt))
+    .all();
+}
+```
+
+**3. `removeConceptFromPlan(planId: string, conceptId: string): void`** — deletes a single join row.
+
+```typescript
+export function removeConceptFromPlan(planId: string, conceptId: string): void {
+  getDb()
+    .delete(schema.studyPlanConcepts)
+    .where(
+      and(
+        eq(schema.studyPlanConcepts.planId, planId),
+        eq(schema.studyPlanConcepts.conceptId, conceptId),
+      ),
+    )
+    .run();
+}
+```
+
+**4. `getPlanConceptIds(planId: string): string[]`** — returns just the concept IDs for a plan (used by session builder to avoid the full join).
+
+```typescript
+export function getPlanConceptIds(planId: string): string[] {
+  return getDb()
+    .select({ conceptId: schema.studyPlanConcepts.conceptId })
+    .from(schema.studyPlanConcepts)
+    .where(eq(schema.studyPlanConcepts.planId, planId))
+    .all()
+    .map(r => r.conceptId);
+}
+```
+
+### Tests
+
+Write tests for `getPlanProgress`, `getActivePlans`, `removeConceptFromPlan`, `getPlanConceptIds`. Pattern: create test DB, insert a plan + concepts + plan_concepts, verify results. See existing plan tests if any, or follow the concept query test pattern.
+
+- [ ] **Step 1:** Add `PlanProgress` and `PlanConceptProgress` types to `src/study/types.ts`
+- [ ] **Step 2:** Write failing tests for `getPlanProgress` — plan with 3 concepts, 1 at target, verify counts
+- [ ] **Step 3:** Implement `getPlanProgress` in `src/study/queries.ts`
+- [ ] **Step 4:** Run tests — verify pass
+- [ ] **Step 5:** Write tests for `getActivePlans` — 2 active + 1 archived plan, verify only active returned
+- [ ] **Step 6:** Implement `getActivePlans`
+- [ ] **Step 7:** Write tests for `removeConceptFromPlan` — add 3 concepts, remove 1, verify 2 remain
+- [ ] **Step 8:** Implement `removeConceptFromPlan`
+- [ ] **Step 9:** Write test for `getPlanConceptIds`
+- [ ] **Step 10:** Implement `getPlanConceptIds`
+- [ ] **Step 11:** Run full test suite: `npm test` — no regressions
+- [ ] **Step 12:** Verify: `npm run build` — clean
+- [ ] **Step 13:** Commit: `feat(study): add plan progress and plan-scoped query functions (S6.1)`
+
+---
+
+## S6.2: Plan-Aware Session Builder
+
+**Files:** Modify `src/study/session-builder.ts`, modify `src/study/session-builder.test.ts`, modify `src/study/types.ts`, modify `dashboard/src/lib/session-builder.ts`
+
+**Depends on:** S6.1, S6.3 (dashboard session builder imports `getPlanConceptIds` from `study-db.ts`).
+
+**Important:** There are TWO independent `SessionOptions` interfaces — one at `src/study/types.ts:95-98` (backend, used by `src/study/session-builder.ts`) and one at `dashboard/src/lib/session-builder.ts:36-39` (dashboard, local). Both need `planId` added. They are separate type declarations in separate packages.
+
+### Backend session builder changes (`src/study/session-builder.ts`)
+
+**1. Add `planId` to the existing `SessionOptions` in `src/study/types.ts:95-98`:**
+
+```typescript
+// In src/study/types.ts — ADD planId to the existing interface:
+export interface SessionOptions {
+  targetActivities?: number;
+  domainFocus?: string;
+  planId?: string;  // NEW: filter activities to plan concepts only
+}
+```
+
+**2. Filter due activities by plan concepts:**
+
+After fetching `dueActivities` and before enrichment (around line 79-99 in `src/study/session-builder.ts`), add plan filtering:
+
+```typescript
+import { getPlanConceptIds } from './queries.js';
+
+// In buildDailySession(), after dueActivities fetch:
+let filteredActivities = dueActivities;
+if (options?.planId) {
+  const planConceptIds = new Set(getPlanConceptIds(options.planId));
+  filteredActivities = dueActivities.filter(a => planConceptIds.has(a.conceptId));
+}
+```
+
+Then use `filteredActivities` instead of `dueActivities` for the enrichment loop.
+
+**Constraint:** Do NOT change the block allocation logic, interleaving, or domain coverage. Only the input activity pool changes. The rest of the builder works identically.
+
+**3. Exam-prep priority sorting:**
+
+When `planId` is set, also look up the plan to check for exam-prep strategy. If `strategy === 'exam-prep'` and `config` has an `exam_date`:
+
+- Sort activities with concepts furthest from `target_bloom` first (need most work)
+- As deadline approaches (< 7 days), increase target to 30 activities
+
+**Important:** The existing `target` is declared as `const` (line 77: `const target = options?.targetActivities ?? 20`). To allow exam-prep override, change it to `let` and compute the exam-prep adjustment before the block allocation:
+
+```typescript
+import { getStudyPlanById, getPlanConceptIds } from './queries.js';
+
+// At the start of buildDailySession(), change const to let:
+let target = options?.targetActivities ?? 20;
+
+// After plan filtering, before block allocation:
+if (options?.planId) {
+  const plan = getStudyPlanById(options.planId);
+  if (plan?.strategy === 'exam-prep' && plan.config) {
+    const config = JSON.parse(plan.config);
+    if (config.exam_date) {
+      const daysUntilExam = Math.ceil(
+        (new Date(config.exam_date).getTime() - Date.now()) / (1000 * 60 * 60 * 24)
+      );
+      if (daysUntilExam < 7 && !options.targetActivities) {
+        target = 30; // cram mode
+      }
+    }
+  }
+}
+```
+
+**Agent discretion:** Where to insert the exam-prep logic within the function body.
+
+### Dashboard session builder changes (`dashboard/src/lib/session-builder.ts`)
+
+Apply the same `planId` filter to the dashboard's copy of the session builder. **Note:** The dashboard function is `buildSessionComposition()` (NOT `buildDailySession()` like the backend). The `SessionOptions` interface is defined locally at line 36-39, not imported from `types.ts`.
+
+**1. Add `planId` to the local `SessionOptions`** (line 36-39 of `dashboard/src/lib/session-builder.ts`):
+
+```typescript
+export interface SessionOptions {
+  targetActivities?: number;
+  domainFocus?: string;
+  planId?: string;
+}
+```
+
+**2. Add plan filtering** — same pattern as backend. The dashboard builder calls `getDueActivities()` from `study-db.ts` and then filters by plan concept IDs. Add `getPlanConceptIds` to the import:
+
+```typescript
+import { getDueActivities, getActiveConcepts, getPlanConceptIds } from './study-db';
+```
+
+Then filter `dueActivities` by plan concept IDs before enrichment (after line 104 `const dueActivities = getDueActivities()`), same logic as backend.
+
+**Dependency note:** `getPlanConceptIds()` is created in S6.3 (Wave 1). S6.2 is Wave 2. S6.3 must complete before this step.
+
+### Tests
+
+Write tests for plan-scoped session building. Pattern:
+
+1. Create test DB with concepts A, B, C (all active, with due activities)
+2. Create plan P with concepts A and B only
+3. Call `buildDailySession({ planId: P.id })`
+4. Verify: all returned activities belong to concepts A or B, none to C
+5. Verify: block allocation still correct (30/50/20 split)
+
+Also test: empty plan (no concepts), plan with no due activities (returns empty).
+
+- [ ] **Step 1:** Add `planId` to `SessionOptions` in `src/study/types.ts`
+- [ ] **Step 2:** Write failing test: plan-scoped session contains only plan concept activities
+- [ ] **Step 3:** Add plan filtering to `src/study/session-builder.ts`
+- [ ] **Step 4:** Run test — verify pass
+- [ ] **Step 5:** Write test: empty plan returns empty session
+- [ ] **Step 6:** Run tests — verify pass
+- [ ] **Step 7:** Add `planId` to dashboard `SessionOptions` in `dashboard/src/lib/session-builder.ts`
+- [ ] **Step 8:** Add plan filtering to dashboard session builder (import `getPlanConceptIds` from study-db)
+- [ ] **Step 9:** Run full test suite: `npm test` — no regressions
+- [ ] **Step 10:** Verify: `npm run build` — clean
+- [ ] **Step 11:** Verify: `cd dashboard && npx tsc --noEmit` — clean
+- [ ] **Step 12:** Commit: `feat(study): add plan-aware session builder with planId filtering (S6.2)`
+
+---
+
+## S6.3: Dashboard Schema + DB Functions for Plans
+
+**Files:** Modify `dashboard/src/lib/db/schema.ts`, modify `dashboard/src/lib/study-db.ts`
+
+**Parallelizable with S6.1, S6.7.**
+
+### Dashboard schema additions (`dashboard/src/lib/db/schema.ts`)
+
+Add `study_plans` and `study_plan_concepts` tables. **These must match the SQL column names in `src/db/schema/study.ts` exactly.** Dashboard schema uses snake_case properties (not camelCase like the backend schema).
+
+Add after the `activity_log` table definition (end of file):
+
+```typescript
+export const study_plans = sqliteTable('study_plans', {
+  id: text('id').primaryKey(),
+  title: text('title').notNull(),
+  domain: text('domain'),
+  course: text('course'),
+  strategy: text('strategy').notNull().default('open'),
+  learning_objectives: text('learning_objectives'),
+  desired_outcomes: text('desired_outcomes'),
+  implementation_intention: text('implementation_intention'),
+  obstacle: text('obstacle'),
+  study_schedule: text('study_schedule'),
+  config: text('config'),
+  checkpoint_interval_days: integer('checkpoint_interval_days').default(14),
+  next_checkpoint_at: text('next_checkpoint_at'),
+  created_at: text('created_at').notNull(),
+  updated_at: text('updated_at').notNull(),
+  status: text('status').default('active'),
+});
+
+export const study_plan_concepts = sqliteTable('study_plan_concepts', {
+  plan_id: text('plan_id').notNull(),
+  concept_id: text('concept_id').notNull(),
+  target_bloom: integer('target_bloom').default(6),
+  sort_order: integer('sort_order').default(0),
+});
+```
+
+**Constraint:** The column names must match the backend schema SQL columns exactly: `study_plans` table has `learning_objectives` (not `learningObjectives`), `checkpoint_interval_days` (not `checkpointIntervalDays`), etc.
+
+**Constraint:** The dashboard schema uses flat table definitions — no composite primary key callbacks, no `.references()`. This matches the established pattern for `concepts`, `learning_activities`, etc. in this file. For `addConceptsToPlan()`, use a check-before-insert pattern (query existing, skip duplicates) rather than `.onConflictDoNothing()` which requires the primary key definition.
+
+### Dashboard DB functions (`dashboard/src/lib/study-db.ts`)
+
+Add new interfaces and functions for plan management. Add these after the existing session functions (end of file).
+
+**New interfaces:**
+
+```typescript
+export interface PlanSummary {
+  id: string;
+  title: string;
+  domain: string | null;
+  course: string | null;
+  strategy: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  nextCheckpointAt: string | null;
+  conceptCount: number;
+  progressPercent: number;
+}
+
+export interface PlanDetail extends PlanSummary {
+  learningObjectives: string | null;
+  desiredOutcomes: string | null;
+  implementationIntention: string | null;
+  obstacle: string | null;
+  studySchedule: string | null;
+  config: string | null;
+  checkpointIntervalDays: number;
+  concepts: PlanConceptRow[];
+}
+
+export interface PlanConceptRow {
+  conceptId: string;
+  title: string;
+  domain: string | null;
+  bloomCeiling: number;
+  targetBloom: number;
+  masteryOverall: number;
+  atTarget: boolean;
+}
+
+export interface NewPlan {
+  id: string;
+  title: string;
+  domain?: string;
+  course?: string;
+  strategy?: string;
+  learningObjectives?: string;
+  desiredOutcomes?: string;
+  implementationIntention?: string;
+  obstacle?: string;
+  studySchedule?: string;
+  config?: string;
+  checkpointIntervalDays?: number;
+}
+```
+
+**New functions:**
+
+**1. `getAllPlans(): PlanSummary[]`** — list all plans with concept counts and progress.
+
+Query `study_plans`, then for each plan count concepts and compute progress (concepts at target / total). Use a subquery or post-fetch aggregation. Progress = concepts where `bloom_ceiling >= target_bloom` / total concepts.
+
+**2. `getActivePlans(): PlanSummary[]`** — same as `getAllPlans()` but filtered to `status = 'active'`.
+
+**3. `getPlanById(id: string): PlanDetail | null`** — full plan with concept details.
+
+Join `study_plan_concepts` → `concepts` for the concept list. Compute `atTarget` for each concept.
+
+**4. `createPlan(plan: NewPlan, conceptIds: string[], targetBloom?: number): void`** — insert plan + concept associations in a transaction.
+
+```typescript
+export function createPlan(plan: NewPlan, conceptIds: string[], targetBloom?: number): void {
+  const db = getDb();
+  const now = new Date().toISOString();
+  const checkpointDays = plan.checkpointIntervalDays ?? 14;
+  const checkpointDate = new Date(Date.now() + checkpointDays * 86400000).toISOString().slice(0, 10);
+
+  db.transaction((tx) => {
+    tx.insert(study_plans).values({
+      id: plan.id,
+      title: plan.title,
+      domain: plan.domain ?? null,
+      course: plan.course ?? null,
+      strategy: plan.strategy ?? 'open',
+      learning_objectives: plan.learningObjectives ?? null,
+      desired_outcomes: plan.desiredOutcomes ?? null,
+      implementation_intention: plan.implementationIntention ?? null,
+      obstacle: plan.obstacle ?? null,
+      study_schedule: plan.studySchedule ?? null,
+      config: plan.config ?? null,
+      checkpoint_interval_days: checkpointDays,
+      next_checkpoint_at: checkpointDate,
+      created_at: now,
+      updated_at: now,
+      status: 'active',
+    }).run();
+
+    for (let i = 0; i < conceptIds.length; i++) {
+      tx.insert(study_plan_concepts).values({
+        plan_id: plan.id,
+        concept_id: conceptIds[i],
+        target_bloom: targetBloom ?? 6,
+        sort_order: i,
+      }).run();
+    }
+  });
+}
+```
+
+**5. `updatePlan(id: string, updates: Partial<...>): void`** — update plan fields. Sets `updated_at` automatically.
+
+**6. `getPlanConceptIds(planId: string): string[]`** — returns concept IDs for a plan (used by session builder).
+
+**7. `addConceptsToPlan(planId: string, conceptIds: string[], targetBloom?: number): void`** — batch add concepts to an existing plan.
+
+**8. `removeConceptFromPlan(planId: string, conceptId: string): void`** — remove a single concept from a plan.
+
+Import the new tables and `gte` operator (needed for bloom_ceiling >= target_bloom comparisons):
+```typescript
+import { concepts, learning_activities, study_sessions, activity_log, study_plans, study_plan_concepts } from './db/schema';
+// Add gte to the existing drizzle-orm import:
+import { eq, and, lte, asc, desc, count, sql, inArray, isNull, gte } from 'drizzle-orm';
+```
+
+- [ ] **Step 1:** Add `study_plans` and `study_plan_concepts` tables to `dashboard/src/lib/db/schema.ts`
+- [ ] **Step 2:** Add plan interfaces (`PlanSummary`, `PlanDetail`, `PlanConceptRow`, `NewPlan`) to `dashboard/src/lib/study-db.ts`
+- [ ] **Step 3:** Implement `createPlan()` with transaction
+- [ ] **Step 4:** Implement `getAllPlans()` and `getActivePlans()`
+- [ ] **Step 5:** Implement `getPlanById()`
+- [ ] **Step 6:** Implement `updatePlan()`, `getPlanConceptIds()`, `addConceptsToPlan()`, `removeConceptFromPlan()`
+- [ ] **Step 7:** Verify: `cd dashboard && npx tsc --noEmit` — clean
+- [ ] **Step 8:** Commit: `feat(dashboard): add plan schema tables and CRUD functions (S6.3)`
+
+---
+
+## S6.4: Dashboard Plan API Routes
+
+**Files:** Create `dashboard/src/app/api/study/plans/route.ts`, create `dashboard/src/app/api/study/plans/[id]/route.ts`, create `dashboard/src/app/api/study/plans/[id]/concepts/route.ts`
+
+**Depends on:** S6.3.
+
+### GET/POST /api/study/plans (`route.ts`)
+
+**GET:** Returns all plans with progress summaries. Calls `getAllPlans()`.
+
+```typescript
+export async function GET() {
+  try {
+    const plans = getAllPlans();
+    return Response.json({ plans });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}
+```
+
+**POST:** Creates a new plan. Body:
+
+```typescript
+{
+  title: string;
+  conceptIds: string[];
+  domain?: string;
+  course?: string;
+  strategy?: string;           // 'open' | 'exam-prep' | 'weekly-review' | 'exploration'
+  targetBloom?: number;        // default 6
+  examDate?: string;           // ISO date, for exam-prep strategy
+  learningObjectives?: string; // JSON string
+  desiredOutcomes?: string;
+  implementationIntention?: string;
+  obstacle?: string;
+  studySchedule?: string;
+  checkpointIntervalDays?: number;
+}
+```
+
+Validates: `title` required, `conceptIds` must be non-empty array. Generates `id = crypto.randomUUID()`. If `examDate` provided, stores in `config` as JSON: `{ exam_date: examDate }`.
+
+```typescript
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    if (!body.title || !Array.isArray(body.conceptIds) || body.conceptIds.length === 0) {
+      return Response.json({ error: 'title and conceptIds required' }, { status: 400 });
+    }
+
+    const planId = crypto.randomUUID();
+    const config = body.examDate ? JSON.stringify({ exam_date: body.examDate }) : undefined;
+
+    createPlan({
+      id: planId,
+      title: body.title,
+      domain: body.domain,
+      course: body.course,
+      strategy: body.strategy ?? 'open',
+      learningObjectives: body.learningObjectives,
+      desiredOutcomes: body.desiredOutcomes,
+      implementationIntention: body.implementationIntention,
+      obstacle: body.obstacle,
+      studySchedule: body.studySchedule,
+      config,
+      checkpointIntervalDays: body.checkpointIntervalDays,
+    }, body.conceptIds, body.targetBloom);
+
+    return Response.json({ planId });
+  } catch (err) {
+    return Response.json({ error: String(err) }, { status: 500 });
+  }
+}
+```
+
+### GET/PATCH /api/study/plans/[id] (`[id]/route.ts`)
+
+**GET:** Returns full plan detail with concept progress. Calls `getPlanById(id)`.
+
+**PATCH:** Updates plan fields. Body: partial plan fields. Calls `updatePlan(id, updates)`. Can update: `title`, `strategy`, `status`, `learningObjectives`, `desiredOutcomes`, `implementationIntention`, `obstacle`, `studySchedule`, `config`, `checkpointIntervalDays`.
+
+**Constraint:** Read `node_modules/next/dist/docs/` for dynamic route param extraction in this version of Next.js before implementing. The `[id]` param format may differ from standard Next.js patterns.
+
+### POST/DELETE /api/study/plans/[id]/concepts (`[id]/concepts/route.ts`)
+
+**POST:** Add concepts to a plan. Body: `{ conceptIds: string[], targetBloom?: number }`. Calls `addConceptsToPlan()`.
+
+**DELETE:** Remove a concept from a plan. Body: `{ conceptId: string }`. Calls `removeConceptFromPlan()`.
+
+- [ ] **Step 1:** Create `GET /api/study/plans` route
+- [ ] **Step 2:** Create `POST /api/study/plans` route with validation
+- [ ] **Step 3:** Create `GET /api/study/plans/[id]` route
+- [ ] **Step 4:** Create `PATCH /api/study/plans/[id]` route
+- [ ] **Step 5:** Create `POST /api/study/plans/[id]/concepts` route
+- [ ] **Step 6:** Create `DELETE /api/study/plans/[id]/concepts` route
+- [ ] **Step 7:** Verify: `cd dashboard && npx tsc --noEmit` — clean
+- [ ] **Step 8:** Commit: `feat(dashboard): add plan CRUD API routes (S6.4)`
+
+---
+
+## S6.5: Dashboard /study/plan Page
+
+**Files:** Create `dashboard/src/app/study/plan/page.tsx`, modify `dashboard/src/app/study/page.tsx`
+
+**Depends on:** S6.4. **Parallelizable with S6.6.**
+
+### Plan page structure
+
+Single `'use client'` component with three views:
+
+```
+LIST → CREATE → DETAIL
+```
+
+**LIST view (default):**
+- Active plans list. Each card shows: title, strategy badge (`open`/`exam-prep`/`weekly-review`/`exploration`), progress bar (% of concepts at target bloom), concept count, next checkpoint date.
+- Archived/completed plans collapsed below.
+- "New Plan" button → transitions to CREATE.
+- Click on a plan → transitions to DETAIL.
+
+**CREATE view:**
+- Form fields:
+  - Title (text input, required)
+  - Strategy (radio: Open, Exam Prep, Weekly Review, Exploration)
+  - If Exam Prep: exam date picker
+  - Concept selector: list of active concepts grouped by domain, with checkboxes. "Select All in Domain" button per domain group.
+  - Target Bloom (number 1-6, default 6)
+  - Optional fields (collapsible "Advanced" section): learning objectives (textarea), desired outcomes (textarea), study schedule (text), implementation intention (text), obstacle (text), checkpoint interval (number, default 14 days)
+- "Create Plan" button → `POST /api/study/plans` → transitions to DETAIL for new plan
+- "Or: Plan with AI" link → navigates to `/study/chat?method=plan` (S5's chat page with plan method)
+- "Cancel" button → transitions back to LIST
+
+**DETAIL view:**
+- Plan header: title, strategy badge, progress bar, created date, next checkpoint
+- Concept checklist: each concept shows title, domain, current bloom ceiling → target bloom, mastery bar, "at target" checkmark
+- Concepts sorted by: furthest from target first (most work needed)
+- "Start Plan Session" button → navigates to `/study/session?planId={id}` (creates a plan-scoped session)
+- "Edit" button for title/strategy/deadline
+- "Add Concepts" button → concept selector modal
+- "Remove" button per concept (with confirmation)
+- "Archive Plan" button → `PATCH /api/study/plans/[id]` with `{ status: 'archived' }`
+- "Complete Plan" button → `PATCH /api/study/plans/[id]` with `{ status: 'completed' }`
+
+### Study overview page changes (`dashboard/src/app/study/page.tsx`)
+
+Add a "Plans" section between the session card and concept list. Shows:
+- Active plan count
+- Top 2-3 active plans with title + progress bar
+- "View All Plans" link → `/study/plan`
+
+Fetch from `GET /api/study/plans` and filter to active, sorted by most recent.
+
+### Design
+
+- Dark theme: bg-gray-950, text-gray-100 (matching existing study pages)
+- Plan cards: bg-gray-900 border border-gray-800 rounded-lg p-4
+- Progress bar: bg-gray-700 rounded-full h-2, fill with bg-green-500
+- Strategy badges: bg-blue-900 text-blue-300 for open, bg-red-900 text-red-300 for exam-prep, bg-purple-900 text-purple-300 for weekly-review, bg-amber-900 text-amber-300 for exploration
+- Concept checkboxes: green checkmark for at-target, gray circle for in-progress
+- Concept selector: scrollable list with domain group headers
+
+**Agent discretion:** Component decomposition (whether to split PlanList, PlanCreate, PlanDetail into separate components or keep as one file with view state), exact Tailwind classes, animations, mobile responsiveness.
+
+- [ ] **Step 1:** Create `/study/plan/page.tsx` with LIST view — fetch plans, render cards with progress
+- [ ] **Step 2:** Add CREATE view with form fields and concept selector
+- [ ] **Step 3:** Wire form submission to `POST /api/study/plans`
+- [ ] **Step 4:** Add DETAIL view — plan header, concept checklist, action buttons
+- [ ] **Step 5:** Wire concept add/remove buttons to API routes
+- [ ] **Step 6:** Wire "Start Plan Session" button to navigate to `/study/session?planId={id}`
+- [ ] **Step 7:** Add plans section to study overview page (`/study`)
+- [ ] **Step 8:** Start dashboard: `cd dashboard && npm run dev`. Navigate to `/study/plan`, verify plan creation flow works
+- [ ] **Step 9:** Verify: `cd dashboard && npx tsc --noEmit` — clean
+- [ ] **Step 10:** Commit: `feat(dashboard): add /study/plan page with list, create, and detail views (S6.5)`
+
+---
+
+## S6.6: Wire `planId` into Session Creation Flow
+
+**Files:** Modify `dashboard/src/app/api/study/session/route.ts`, modify `dashboard/src/app/study/session/page.tsx`, modify `dashboard/src/lib/study-db.ts` (NewSession interface only)
+
+**Depends on:** S6.3, S6.4. **Parallelizable with S6.5.**
+
+**Note:** The `study_sessions` table in the dashboard schema already has `plan_id` (line 78 of `dashboard/src/lib/db/schema.ts`). Only the `NewSession` interface and `createSession()` function in `study-db.ts` need updating — no schema change.
+
+### Session API changes (`route.ts`)
+
+**GET handler:** Currently calls `buildSessionComposition()` with no options. Accept `planId` query param and pass it through:
+
+```typescript
+export async function GET(request: Request) {
+  try {
+    const url = new URL(request.url);
+    const planId = url.searchParams.get('planId') ?? undefined;
+    const composition = buildSessionComposition({ planId });
+    // ... rest unchanged
+  }
+}
+```
+
+**POST handler:** Currently creates sessions without `plan_id`. Accept `planId` in body and pass to `createSession()`:
+
+```typescript
+const body = (await request.json()) as {
+  sessionType?: string;
+  preConfidence?: Record<string, number>;
+  planId?: string;  // NEW
+};
+
+// In createSession call:
+createSession({
+  id: sessionId,
+  startedAt: new Date().toISOString(),
+  sessionType: body.sessionType ?? 'daily',
+  preConfidence: body.preConfidence ? JSON.stringify(body.preConfidence) : undefined,
+  surface: 'dashboard_ui',
+  planId: body.planId,  // NEW
+});
+```
+
+**Dashboard `createSession` in `study-db.ts`:** Add `planId` to the `NewSession` interface and pass through to the insert:
+
+```typescript
+export interface NewSession {
+  id: string;
+  startedAt: string;
+  sessionType: string;
+  preConfidence?: string;
+  surface?: string;
+  planId?: string;  // NEW
+}
+```
+
+In the `createSession` function, add `plan_id: session.planId ?? null` to the values object.
+
+### Session page changes (`session/page.tsx`)
+
+Read `planId` from URL search params. When present:
+- Pass `planId` in the `GET /api/study/session?planId={id}` request
+- Pass `planId` in the `POST /api/study/session` body
+- Show plan context banner at top: "Studying: {plan title}" with link back to plan detail
+
+```typescript
+const searchParams = useSearchParams();
+const planId = searchParams.get('planId');
+
+// In session fetch:
+const url = planId ? `/api/study/session?planId=${planId}` : '/api/study/session';
+```
+
+- [ ] **Step 1:** Add `planId` to `NewSession` interface in `dashboard/src/lib/study-db.ts`
+- [ ] **Step 2:** Pass `plan_id` through in `createSession()` function
+- [ ] **Step 3:** Update `GET /api/study/session` to accept `planId` query param
+- [ ] **Step 4:** Update `POST /api/study/session` to accept `planId` in body
+- [ ] **Step 5:** Update `/study/session` page to read `planId` from URL and pass to API calls
+- [ ] **Step 6:** Add plan context banner when session is plan-scoped
+- [ ] **Step 7:** Start dashboard, test: navigate from plan detail → start session → verify only plan concepts shown
+- [ ] **Step 8:** Verify: `cd dashboard && npx tsc --noEmit` — clean
+- [ ] **Step 9:** Commit: `feat(dashboard): wire planId into session creation and session page (S6.6)`
+
+---
+
+## S6.7: Study Agent Plan Dialogue Instructions
+
+**Files:** Modify `groups/study/CLAUDE.md`
+
+**Parallelizable with S6.1, S6.3.**
+
+### What to add
+
+Add a new section after the existing method sections (Feynman, Socratic, Case Analysis, Comparison, Synthesis). Add a **Plan Creation Dialogue** section.
+
+**Section content (~40 lines):**
+
+**When:** The student opens a chat with `method=plan`. The first message context will include `Method: plan`.
+
+**Your role:** Help the student think through what they want to study and why. You are a learning advisor, not a form filler. The student will create the actual plan via the dashboard form — your job is to help them clarify their goals, identify the right concepts, and choose an effective strategy.
+
+**Dialogue flow (flexible depth):**
+
+1. **Opening:** Ask what the student wants to focus on. Listen for: domain/course, specific concepts, time pressure (exam), general exploration.
+
+2. **Goal clarification:** Help them articulate what "success" looks like. "When you're done studying this, what will you be able to do?" (Backward design — Wiggins & McTighe). Push for Bloom's-level specificity: "Do you need to recall these models, or apply them to cases?"
+
+3. **Strategy selection:** Based on their goals, recommend a strategy:
+   - `open` — no deadline, mastery-oriented, steady progression
+   - `exam-prep` — deadline, coverage-focused, prioritize weak concepts
+   - `weekly-review` — recurring, maintenance-oriented
+   - `exploration` — curiosity-driven, breadth over depth
+
+4. **Concept identification:** If they mentioned a domain, list available concepts in that domain and help them select. Don't fetch concept lists — suggest they use the dashboard's concept selector.
+
+5. **Optional depth (offer, don't force):** "Want to go deeper?" At any natural pause point, offer to discuss:
+   - Learning objectives (Bloom's-tagged)
+   - Implementation intentions ("When and where will you study?" — Gollwitzer 1999)
+   - Obstacles and mitigation ("What's most likely to get in the way?" — WOOP, Oettingen)
+   - Study schedule
+
+6. **Wrap-up:** Summarize what you've discussed. Suggest they create the plan via the dashboard form with the fields you've discussed. Be specific: "I'd suggest an exam-prep plan titled 'KM Frameworks for BI-2081 Exam', targeting Bloom's L4 for the models and L5 for synthesis."
+
+**Constraints:**
+- Do NOT create plans via IPC. The dashboard handles plan creation.
+- Do NOT fetch concept lists. You don't have access to the study DB. Suggest concepts based on what the student tells you and recommend they select from the dashboard.
+- Keep it conversational. No numbered checklists. No form-like prompts.
+- Brain-first applies: ask the student what they think first, then offer your perspective.
+- The dialogue can be 2 messages or 20 — match the student's depth preference.
+
+**Do NOT include exam tips, study technique tutorials, or motivational speeches. Focus on plan structure and concept selection.**
+
+### Constraints for the writer
+
+- Total CLAUDE.md should stay under 350 lines after this addition. The current file is ~260 lines.
+- Do NOT modify existing method sections. Add the plan section as a new method alongside the others.
+- Follow the existing writing style: direct, concise, pedagogically grounded.
+
+- [ ] **Step 1:** Add plan creation dialogue section to `groups/study/CLAUDE.md`
+- [ ] **Step 2:** Verify total line count is under 350
+- [ ] **Step 3:** Commit: `feat(study): add plan creation dialogue instructions to study agent CLAUDE.md (S6.7)`
+
+---
+
+## S6.8: Verification
+
+**Depends on:** All previous tasks.
+
+- [ ] **Step 1:** Run backend tests: `npm test` — all pass, no regressions
+- [ ] **Step 2:** Build: `npm run build` — clean
+- [ ] **Step 3:** Dashboard types: `cd dashboard && npx tsc --noEmit` — clean
+- [ ] **Step 4:** Start dashboard: `cd dashboard && npm run dev`
+- [ ] **Step 5:** Navigate to `/study/plan` — plan list renders (empty state)
+- [ ] **Step 6:** Click "New Plan" — create form renders with concept selector
+- [ ] **Step 7:** Create a plan: select 3-5 concepts, strategy=open, click Create — redirects to plan detail
+- [ ] **Step 8:** Plan detail: concept checklist shows correct bloom ceilings and target bloom, progress bar at 0%
+- [ ] **Step 9:** Click "Start Plan Session" — navigates to `/study/session?planId={id}`, session contains only plan concepts
+- [ ] **Step 10:** Return to `/study` overview — plans section shows the new plan
+- [ ] **Step 11:** Navigate to `/study/plan`, click plan, click "Archive" — plan moves to archived section
+- [ ] **Step 12:** Create an exam-prep plan with a deadline — verify it shows on plan detail
+- [ ] **Step 13:** Commit: `chore(study): verify S6 planning system end-to-end (S6.8)`
+
+---
+
+## Acceptance Criteria
+
+From master plan S6 (non-negotiable):
+
+- [ ] Quick plan creation works (select concepts + defaults, <30 seconds)
+- [ ] Plans appear on `/study/plan` with concept progress (% at target bloom)
+- [ ] Plan detail shows concept checklist with bloom ceiling vs target
+- [ ] Session builder includes only plan concepts when `planId` is set
+- [ ] `plan_id` saved on `study_sessions` records for plan-scoped sessions
+- [ ] Exam-prep strategy stores `exam_date` in plan config
+- [ ] Study agent CLAUDE.md includes plan dialogue instructions
+- [ ] `/study` overview shows active plans section
+- [ ] All existing tests pass (`npm test`)
+- [ ] Clean build (`npm run build`, `cd dashboard && npx tsc --noEmit`)

--- a/docs/superpowers/specs/2026-04-05-study-plan-system-design.md
+++ b/docs/superpowers/specs/2026-04-05-study-plan-system-design.md
@@ -1,0 +1,549 @@
+# Study Plan System — Design Spec
+
+Personal, adaptive study planning system for universityClaw. Generates science-backed study plans, tracks progress with spaced repetition, and provides interactive learning modules on the web dashboard alongside Telegram-based study sessions with Mr. Rogers.
+
+This spec addresses Non-Goal #1 from the original design spec: "Personalized revision/teaching plan — Auto-generated study plans with summaries, Q&A, quizzes based on current relevance (upcoming exams, weak areas, course progression). Needs its own design cycle for scheduling, spaced repetition, and adaptive difficulty."
+
+---
+
+## Research Foundation
+
+### Vault-Grounded Principles
+
+The Obsidian vault contains extensive research on learning science that directly informs this design. The system must embody these findings rather than contradict them.
+
+**Cognitive Load Theory (Kirschner 2002, van Merrienboer & Sweller 2005):**
+- Three load types: intrinsic (element interactivity), extraneous (bad design), germane (productive schema-building)
+- *Isolated-to-interacting element progression* — start with sub-concepts before requiring integration. Block new material, then interleave for review
+- *Adaptive eLearning* — two-step cycle: assess expertise, then dynamically select next task
+
+**Multimedia Learning (Mayer 2002):**
+- *Personalization effect* — conversational style produces the largest effect size (1.55) of all multimedia effects. Mr. Rogers' persona is pedagogically grounded, not just branding
+- *Cognitive vs. behavioral activity* — cognitive activity (selecting, organizing, integrating) causes meaningful learning, not busywork. Every study activity must demand genuine thinking
+- *Rote vs. meaningful learning* — rote = good retention, poor transfer; meaningful = good both. Transfer tests (apply knowledge to new situations) are the gold standard
+
+**Cognitive Debt from AI Use (Kosmyna et al. 2025 "Your Brain on ChatGPT"):**
+- Habitual AI use causes cumulative cognitive cost — deep encoding and critical evaluation both bypassed
+- 83.3% of LLM users failed to provide correct quotation from their own AI-assisted essay
+- **Design rule: Brain-first, AI-second.** The student must always attempt an answer before the AI provides feedback. Never show the answer first
+
+**Constructivism (Olusegun 2015):**
+- Learners build on prior knowledge; learning is active, not passive
+- The system must connect new concepts to existing knowledge structures
+
+### Evidence-Based Technique Ratings (Dunlosky et al. 2013)
+
+| Utility | Technique | System Implementation |
+|---------|-----------|----------------------|
+| **High** | Practice testing / retrieval practice | Quiz module — AI-generated questions from vault, free-recall format |
+| **High** | Distributed / spaced practice | SM-2 scheduling engine with expanding intervals |
+| **Moderate** | Elaborative interrogation | "Why does this work?" prompts mixed into quiz questions |
+| **Moderate** | Self-explanation | Feynman-style exercises via Mr. Rogers in Telegram (not a separate dashboard module) |
+| **Moderate** | Interleaved practice | Session engine mixes topics across courses during review |
+| **Low** | Summarization | Not used as a primary study mode |
+| **Low** | Highlighting / rereading | Never presented as study activities |
+
+### Additional Research Informing Design
+
+- **Active recall:** Repeated retrieval produces 400% improvement in long-term retention (Karpicke 2012). Open-ended "explain" questions produce stronger effects than recognition-based formats
+- **Interleaving:** Increases cognitive load during training but improves retention and transfer. Default for review sessions; block new material first, then interleave once first successful recall is achieved
+- **Session length:** 25-50 minute focused blocks are optimal. 10-20% of desired retention interval = optimal spacing gap (Cepeda et al. 2008)
+
+---
+
+## Architecture
+
+### LLM Access Pattern
+
+The dashboard is a thin UI over SQLite — it has no Anthropic API key and cannot call Claude directly. All LLM work (quiz generation, answer evaluation) happens in the **main NanoClaw process**, which has access to RAG and the Anthropic SDK via OneCLI. The dashboard reads pre-generated data from the database.
+
+**Quiz flow:**
+1. Plan generation (main process) creates SR cards with pre-generated questions via RAG + Claude
+2. Dashboard reads cards from SQLite and presents them
+3. Student answers; dashboard posts the answer to `/api/study/complete`
+4. Main process evaluates the answer via Claude + RAG (triggered by an internal HTTP endpoint or IPC)
+5. Dashboard polls for the evaluation result
+
+This matches the existing architecture where the dashboard only does SQLite reads/writes and the main process handles all LLM interaction.
+
+```
+                    ┌─────────────────────────────────────┐
+                    │        Dashboard (Next.js)          │
+                    │                                     │
+                    │  /study ─── Active Plans + Session  │
+                    │  /study/quiz ─── Quiz Module        │
+                    │  /read ─── RSVP Reader (+ vault)    │
+                    │                                     │
+                    │  /api/study/* ─── Study API Routes  │
+                    │        (SQLite reads only)          │
+                    └──────────────┬──────────────────────┘
+                                   │ HTTP
+                    ┌──────────────▼──────────────────────┐
+                    │     Main Process (src/study/)       │
+                    │                                     │
+                    │  engine.ts ─── Plan generation,     │
+                    │                card creation,       │
+                    │                answer evaluation    │
+                    │  sm2.ts ───── Spaced repetition     │
+                    │                                     │
+                    │  Uses:                              │
+                    │  ├── RagClient (hybrid retrieval)   │
+                    │  ├── StudentProfile (knowledge map) │
+                    │  ├── VaultUtility (note access)     │
+                    │  └── SQLite (study tables)          │
+                    └──────────────┬──────────────────────┘
+                                   │ IPC (JSON file drop)
+                    ┌──────────────▼──────────────────────┐
+                    │        Mr. Rogers (Agent)           │
+                    │                                     │
+                    │  Daily reminders via scheduled task │
+                    │  In-chat quiz/Q&A + Feynman         │
+                    │  Results written back via IPC        │
+                    └─────────────────────────────────────┘
+```
+
+---
+
+## Data Model
+
+### New SQLite Tables (added to `src/db.ts` via `createSchema()`)
+
+The original design had separate `study_items` and `sr_cards` tables, but these are redundant — both track concepts with difficulty, due dates, and review outcomes. A study plan simply references a set of cards via a join table.
+
+```sql
+-- A study plan: generated per course or cross-course
+CREATE TABLE IF NOT EXISTS study_plans (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  course TEXT,                     -- NULL for cross-course plans
+  strategy TEXT NOT NULL,          -- 'exam-prep' | 'weekly-review'
+  config TEXT,                     -- JSON: exam_date, session_length_min, etc.
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  status TEXT DEFAULT 'active'     -- 'active' | 'completed' | 'archived'
+);
+
+-- Join table: which cards belong to which plan
+CREATE TABLE IF NOT EXISTS study_plan_cards (
+  plan_id TEXT NOT NULL REFERENCES study_plans(id),
+  card_id TEXT NOT NULL REFERENCES sr_cards(id),
+  sort_order INTEGER DEFAULT 0,
+  PRIMARY KEY (plan_id, card_id)
+);
+
+-- Spaced repetition cards per concept (SM-2)
+CREATE TABLE IF NOT EXISTS sr_cards (
+  id TEXT PRIMARY KEY,
+  topic TEXT NOT NULL,
+  course TEXT,
+  vault_path TEXT,                 -- source note
+  card_type TEXT DEFAULT 'recall', -- 'recall' | 'cloze' | 'explain'
+  front TEXT NOT NULL,             -- question / prompt
+  back TEXT NOT NULL,              -- answer / expected explanation points
+  ease_factor REAL DEFAULT 2.5,   -- SM-2 ease factor (min 1.3)
+  interval_days INTEGER DEFAULT 1,
+  repetitions INTEGER DEFAULT 0,
+  due_at TEXT NOT NULL,
+  last_reviewed TEXT,
+  last_quality INTEGER,            -- 0-5 SM-2 quality rating
+  mastery_state TEXT DEFAULT 'new' -- 'new' | 'learning' | 'reviewing' | 'mastered'
+);
+CREATE INDEX IF NOT EXISTS idx_sr_cards_due ON sr_cards(due_at);
+CREATE INDEX IF NOT EXISTS idx_sr_cards_course ON sr_cards(course);
+
+-- Review history for analytics (granular enough for future FSRS migration)
+CREATE TABLE IF NOT EXISTS sr_review_log (
+  id TEXT PRIMARY KEY,
+  card_id TEXT NOT NULL REFERENCES sr_cards(id),
+  quality INTEGER NOT NULL,        -- 0-5 SM-2 grade
+  response_time_ms INTEGER,        -- time to answer (retrieval fluency proxy)
+  ease_factor REAL NOT NULL,       -- EF after this review
+  interval_days INTEGER NOT NULL,  -- interval after this review
+  reviewed_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_sr_review_log_card ON sr_review_log(card_id);
+```
+
+### Mastery State Machine
+
+```
+new → learning → reviewing → mastered
+       ↑            │
+       └────────────┘  (lapse: quality < 3 resets to learning)
+```
+
+- **new**: Never reviewed. Initial state.
+- **learning**: Fewer than 3 consecutive correct recalls (quality >= 3)
+- **reviewing**: 3+ consecutive correct recalls with expanding intervals
+- **mastered**: interval >= 21 days AND ease_factor >= 2.3 AND 5+ consecutive correct recalls
+
+---
+
+## SM-2 Algorithm (`src/study/sm2.ts`)
+
+Pure function, ~50 lines. Export as standalone functions for testability (same pattern as RSVP engine).
+
+```typescript
+interface SM2Input {
+  quality: number;       // 0-5 (0=blackout, 5=perfect)
+  easeFactor: number;    // current EF, default 2.5
+  interval: number;      // current interval in days
+  repetitions: number;   // consecutive correct recalls
+}
+
+interface SM2Output {
+  easeFactor: number;    // updated EF (min 1.3)
+  interval: number;      // next interval in days
+  repetitions: number;   // updated repetition count
+}
+
+// Core formula:
+// If quality >= 3 (correct):
+//   rep 0: interval = 1
+//   rep 1: interval = 6
+//   rep 2+: interval = round(interval * EF)
+//   repetitions += 1
+// If quality < 3 (incorrect):
+//   repetitions = 0, interval = 1
+//
+// EF = EF + (0.1 - (5 - q) * (0.08 + (5 - q) * 0.02))
+// EF = max(EF, 1.3)
+```
+
+---
+
+## Study Engine (`src/study/engine.ts`)
+
+Core orchestrator. Exported standalone functions (not a class) following `src/db.ts` pattern.
+
+### Plan Generation
+
+```typescript
+generateStudyPlan(options: {
+  title: string;
+  course?: string;           // NULL for cross-course
+  strategy: 'exam-prep' | 'weekly-review';
+  focusTopics?: string[];    // optional topic filter
+  examDate?: string;         // ISO date — for exam-prep strategy
+  sessionLengthMin?: number; // default 30
+}): Promise<StudyPlan>
+```
+
+**Process:**
+1. Query knowledge map for topics in the course + their confidence scores
+2. Query RAG for vault content related to those topics
+3. Prioritize weak areas (low confidence) and unreviewed topics
+4. Apply isolated-to-interacting progression: simple sub-concepts before integration topics
+5. Generate SR cards (front/back) via Claude + RAG for each topic
+6. Assign card types based on confidence level:
+   - Confidence 1-2: `recall` (basic questions, read vault note first)
+   - Confidence 3: `recall` + `cloze` (deeper questions with "why" prompts)
+   - Confidence 4-5: `explain` (Feynman-style, interleaved with other topics)
+7. Schedule cards using the 10-20% rule relative to exam date or weekly cadence
+8. Store cards in `sr_cards`, link to plan via `study_plan_cards`
+
+### Session Queries
+
+```typescript
+getTodaySession(limit?: number): Promise<SRCard[]>
+```
+
+Returns due cards across all active plans, sorted by:
+1. Overdue cards first
+2. Low ease-factor cards (struggling concepts)
+3. Card type variety (don't cluster all recall together)
+
+### Completion Tracking
+
+```typescript
+completeCard(cardId: string, result: {
+  quality: number;       // 0-5
+  responseTimeMs?: number;
+}): Promise<SRCard>
+```
+
+1. Run SM-2 algorithm, update card (ease_factor, interval, repetitions, due_at)
+2. Update mastery_state based on state machine
+3. Log to sr_review_log
+4. Update knowledge map via StudentProfile.updateKnowledgeMap()
+5. Return updated card
+
+### Answer Evaluation
+
+```typescript
+evaluateAnswer(cardId: string, studentAnswer: string): Promise<Evaluation>
+```
+
+Uses RAG to retrieve vault context for the card's topic, then Claude evaluates:
+- Correctness (grounded in vault content)
+- Suggested quality rating (0-5)
+- Feedback with specific gaps
+- Vault note references
+
+This runs in the main process (has Claude access), not in the dashboard.
+
+---
+
+## Dashboard Modules
+
+### Navigation
+
+Add "Study" link to `dashboard/src/app/layout.tsx` nav bar, between "Vault" and "Read".
+
+### 1. Study Plan Page (`/study`)
+
+**Route:** `dashboard/src/app/study/page.tsx` — `'use client'`
+
+**Layout:**
+```
+┌─────────────────────────────────────┐
+│  Today's Session (N cards due)      │
+│  ┌───────┐ ┌───────┐ ┌───────┐     │
+│  │recall │ │explain│ │ cloze │     │
+│  │BI-2081│ │TIØ4258│ │BI-2081│     │
+│  │ due!  │ │ +2d   │ │ new   │     │
+│  └───────┘ └───────┘ └───────┘     │
+├─────────────────────────────────────┤
+│  Active Plans                       │
+│  ┌─────────────────────────────┐    │
+│  │ BI-2081 Exam Prep           │    │
+│  │ ████████░░ 72%  │  12 due   │    │
+│  └─────────────────────────────┘    │
+├─────────────────────────────────────┤
+│  + Generate New Plan                │
+│  Course: [dropdown]                 │
+│  Strategy: [exam-prep | weekly]     │
+│  Focus: [optional topics]           │
+│  Exam date: [date picker]           │
+│  [Generate]                         │
+├─────────────────────────────────────┤
+│  Progress                           │
+│  Mastery: ██████░░ 65%              │
+│  Streak: 5 days                     │
+│  Cards due this week: 23            │
+└─────────────────────────────────────┘
+```
+
+**Progress section metrics:**
+- *Mastery*: % of reviewed concepts in "reviewing" or "mastered" state
+- *Streak*: consecutive days with at least one completed review
+- *Review forecast*: cards due in the next 7 days
+
+### 2. Quiz Module (`/study/quiz`)
+
+**Route:** `dashboard/src/app/study/quiz/page.tsx` — `'use client'`
+
+**Query param:** `?card=<card_id>` or `?plan=<plan_id>` for a batch session.
+
+**Flow (brain-first, AI-second):**
+1. Show question (pre-generated, stored in `sr_cards.front`)
+2. Text area for student's answer — no hints, no multiple choice
+3. Student submits answer
+4. Dashboard posts answer to `/api/study/evaluate` which proxies to main process
+5. Show evaluation result:
+   - Correctness assessment with specific feedback
+   - The reference answer (from `sr_cards.back` + vault sources)
+   - Vault note links for further reading
+6. **Post-answer quality rating:** 0-5 (SM-2 scale), auto-suggested based on evaluation but student can override
+7. SR card updated, review logged
+8. Next card or session summary
+
+**Batch mode:** 5-10 cards per session. Summary at the end shows score and weak areas.
+
+### 3. RSVP Vault Integration (existing `/read`)
+
+**Changes to `dashboard/src/app/read/page.tsx`:**
+
+1. **Enable "From Vault" tab** — Currently disabled. Wire up:
+   - Search vault notes via `/api/vault?path=concepts/` (list) and search
+   - Select a note → load its markdown content (strip frontmatter)
+   - Feed content to the existing RSVP engine
+2. **Study item linking** — Cards with vault_path link to `/read?vault_path=...` for pre-study reading
+
+Post-reading comprehension checks are deferred — they couple two unrelated features (speed reading and quizzing). If you want to quiz after reading, navigate to `/study/quiz`.
+
+---
+
+## API Routes
+
+All under `dashboard/src/app/api/study/`. Follow existing patterns: `Response.json()`, try/catch, camelCase interfaces.
+
+MVP routes (5 total):
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/study/plans` | GET | List all study plans (with card counts + progress) |
+| `/api/study/plans` | POST | Trigger plan generation (posts to main process, returns plan ID) |
+| `/api/study/session` | GET | Today's due cards across all plans |
+| `/api/study/complete` | POST | Mark card complete with quality + response time |
+| `/api/study/stats` | GET | Progress metrics: mastery %, streak, forecast |
+
+Deferred routes (add when needed):
+- `GET /api/study/plans/[id]` — plan detail
+- `PATCH /api/study/plans/[id]` — update plan status
+- `GET /api/study/cards` — filtered card listing
+- `POST /api/study/evaluate` — proxy answer evaluation to main process
+
+### Dashboard DB Layer
+
+New file: `dashboard/src/lib/study-db.ts` — lazy singleton DB connection (same pattern as `ingestion-db.ts`). camelCase interfaces for API responses. Reads from the same `store/messages.db`.
+
+---
+
+## Agent Integration (Mr. Rogers)
+
+### IPC Task Contract
+
+The container agent communicates via JSON file drops in `data/ipc/{group_folder}/`. New task types:
+
+```typescript
+// Agent → Main: mark a card complete after in-chat quiz
+{ type: 'study_complete', cardId: string, quality: number, responseTimeMs?: number }
+
+// Agent → Main: request today's due cards (response written to result file)
+{ type: 'study_session', limit?: number }
+```
+
+These follow the existing IPC pattern in `src/ipc.ts` — the agent writes a JSON file, the IPC watcher processes it, and writes a response file if needed.
+
+### Scheduled Study Reminders
+
+Add a daily scheduled task in `groups/telegram_main/` that:
+1. Queries `sr_cards` for cards due today
+2. Sends a Telegram message with counts by course
+3. Includes a direct link to the dashboard `/study` page
+4. If user replies, Mr. Rogers can run quiz sessions directly in chat
+
+### In-Chat Study Sessions
+
+Mr. Rogers already has quiz and Q&A capabilities. Update `groups/telegram_main/CLAUDE.md` to:
+- After quiz sessions, write results back via IPC `study_complete` to update SR cards
+- When user asks "what should I study?", query due cards via IPC `study_session`
+- Support Feynman-style "explain this concept" exercises natively in chat (the conversational format is better suited for iterative explain-feedback than a dashboard form)
+- Use the brain-first principle: always ask the question, wait for answer, then evaluate
+
+### Feynman Technique — Agent-Native
+
+The Feynman technique (explain a concept simply, get feedback on gaps) is inherently conversational. Rather than building a separate dashboard module, Mr. Rogers handles this natively:
+1. Student says "let me explain [concept]" or agent suggests it for low-mastery topics
+2. Agent asks the student to explain
+3. Student explains
+4. Agent evaluates against vault content via RAG, identifies gaps
+5. Iterative refinement until the explanation is solid
+6. Agent writes quality rating back via IPC `study_complete`
+
+This leverages Mr. Rogers' existing Q&A infrastructure and the personalization effect (Mayer).
+
+---
+
+## Existing Code to Reuse
+
+| Module | What to Use |
+|--------|-------------|
+| `src/rag/rag-client.ts` | `query()` with hybrid mode for finding vault content to generate questions |
+| `src/profile/student-profile.ts` | `logStudySession()`, `updateKnowledgeMap()` for tracking |
+| `src/vault/vault-utility.ts` | `readNote()`, `listNotes()`, `searchNotes()` for vault access |
+| `src/db.ts` | Schema pattern, migration pattern (ALTER TABLE in try/catch), `_initTestDatabase()` |
+| `dashboard/src/lib/ingestion-db.ts` | Pattern for dashboard-side DB access (lazy singleton, camelCase interfaces) |
+| `dashboard/src/app/read/useRSVPEngine.ts` | Pure function export pattern for testable logic |
+
+---
+
+## Implementation Phases
+
+### Phase 1: Data Model + SM-2 Engine
+1. Add study types to `src/types.ts`
+2. Add study tables to `src/db.ts` schema (study_plans, study_plan_cards, sr_cards, sr_review_log)
+3. Add DB CRUD functions to `src/db.ts`
+4. Create `src/study/sm2.ts` — pure SM-2 algorithm
+5. Create `src/study/engine.ts` — plan generation, session queries, completion tracking, answer evaluation
+6. Create `src/study/index.ts` — public exports
+7. Write tests for SM-2, engine, and DB operations
+
+### Phase 2: Dashboard — Study Plan Page + Quiz
+8. Add "Study" nav link to `dashboard/src/app/layout.tsx`
+9. Create `dashboard/src/lib/study-db.ts` — dashboard DB layer
+10. Create 5 MVP API routes (plans GET/POST, session GET, complete POST, stats GET)
+11. Build study plan page (`/study`) with active plans, today's session, generate form, progress
+12. Build quiz module page (`/study/quiz`) with brain-first flow
+
+### Phase 3: RSVP Vault Integration
+13. Enable "From Vault" tab on `/read` — search and load vault notes
+14. Support `?vault_path=` deep linking from study cards
+
+### Phase 4: Agent Integration
+15. Add `study_complete` and `study_session` IPC task types to `src/ipc.ts`
+16. Add daily study reminder scheduled task
+17. Update Mr. Rogers' `CLAUDE.md` with study plan + Feynman instructions
+18. Wire quiz completions from Telegram back to SR tracking
+
+---
+
+## Key Design Decisions
+
+1. **SM-2, not FSRS.** SM-2 is simple, proven, and ~50 lines. The `sr_review_log` table stores granular data should FSRS ever become worthwhile, but we do not design around it.
+
+2. **Brain-first, AI-second.** Grounded in Kosmyna (2025) cognitive debt research. Every module requires the student to produce an answer before showing AI feedback. No passive flashcard flipping.
+
+3. **One card table, not two.** Plans reference cards via a join table (`study_plan_cards`). Cards are the canonical review unit. No dual-write between "items" and "cards."
+
+4. **Interleave by default, block for new material.** New concepts get focused study until first successful recall, then get mixed into interleaved review sessions.
+
+5. **Dashboard reads, main process writes.** The dashboard has no LLM access. Quiz questions are pre-generated during plan creation. Answer evaluation routes through the main process.
+
+6. **Feynman via Telegram, not dashboard.** The conversational format is better suited for iterative explain-feedback. Mr. Rogers already has the infrastructure.
+
+7. **Two strategies for MVP.** `exam-prep` (deadline-driven spacing) and `weekly-review` (rolling review). `deep-dive` and `project` are YAGNI.
+
+8. **Transfer tests, not just recall.** Following Mayer: meaningful learning = good retention AND good transfer. Quiz questions should include application/analysis questions, not just "what is X?" definitions.
+
+---
+
+## Deferred Features
+
+These are explicitly out of scope for the initial build but may be revisited:
+
+- **Pre-answer confidence tracking / calibration** — Adds friction per-answer. Needs 30+ samples per topic for meaningful correlation. Add once core flow is proven and engagement is consistent.
+- **Dashboard Feynman module** — Mr. Rogers handles this better via Telegram conversation.
+- **RSVP post-reading comprehension check** — Couples two unrelated features. Quiz after reading by navigating to `/study/quiz`.
+- **FSRS algorithm** — Review log data is stored for this, but do not design around it.
+- **`deep-dive` and `project` strategies** — No concrete use case yet.
+- **Cognitive efficiency E=P/R** — Requires population normalization (n=1 makes z-scores meaningless). SM-2 quality ratings capture difficulty progression adequately.
+
+---
+
+## Verification Checklist
+
+- [ ] `npm test` — SM-2 algorithm, engine plan generation, DB operations all pass
+- [ ] `npm run build` — TypeScript compiles without errors
+- [ ] `cd dashboard && npm run dev` — navigate to `/study`, generate a plan
+- [ ] Generate a plan → complete quiz cards → verify SR intervals update correctly
+- [ ] Mastery states transition correctly: new → learning → reviewing → mastered
+- [ ] RSVP: load a vault note via "From Vault" tab
+- [ ] Mr. Rogers: "what should I study?" returns due cards
+- [ ] Mr. Rogers: in-chat quiz results update SR cards via IPC
+- [ ] Daily reminder scheduled task fires and lists due cards
+
+---
+
+## Sources
+
+### From Vault
+- Kirschner (2002) — Cognitive Load Theory implications for instructional design
+- van Merrienboer & Sweller (2005) — CLT and complex learning, adaptive eLearning
+- Mayer (2002) — Cognitive Theory of Multimedia Learning, personalization effect
+- Kosmyna et al. (2025) — Cognitive debt from AI use, brain-first principle
+- Olusegun (2015) — Constructivism learning theory
+- Cowan (2014) — Working memory and education
+- Wang et al. (2024) — AI in education systematic review, ITS architecture
+- Rayner et al. (2016) — Speed reading evidence
+
+### External Research
+- Dunlosky et al. (2013) — Study technique utility meta-analysis ([SAGE](https://journals.sagepub.com/doi/abs/10.1177/1529100612453266))
+- Karpicke (2012) — Active retrieval practice, 400% retention improvement ([Purdue](https://learninglab.psych.purdue.edu/downloads/2012/2012_Karpicke_CDPS.pdf))
+- Wozniak (1987) — SM-2 algorithm ([SuperMemo](https://en.wikipedia.org/wiki/SuperMemo))
+- Cepeda et al. (2008) — Optimal spacing intervals, 10-20% rule ([UCSD](https://laplab.ucsd.edu/articles/Cepeda%20et%20al%202008_psychsci.pdf))
+- Ebersbach (2020) — Generating questions vs. testing vs. restudying
+- Firth (2021) — Systematic review of interleaving effects
+- Bjork & Bjork (2019) — Interleaving vs. blocking myths ([UCLA](https://bjorklab.psych.ucla.edu/wp-content/uploads/sites/13/2020/01/BjorkBjorkEducatinMythChapterPublishedFormSept2019.pdf))
+- LPITutor (2024) — LLM-based personalized ITS using RAG ([PMC](https://pmc.ncbi.nlm.nih.gov/articles/PMC12453719/))

--- a/docs/superpowers/specs/2026-04-12-multi-method-study-system-design.md
+++ b/docs/superpowers/specs/2026-04-12-multi-method-study-system-design.md
@@ -1,0 +1,1161 @@
+# Multi-Method Study System — Design Spec v2.1
+
+Personal, adaptive, multi-method study system for universityClaw. Goes beyond flashcard-based spaced repetition to implement a full learning toolkit grounded in cognitive science research. Concepts progress through Bloom's taxonomy levels with the system recommending appropriate study methods at each level.
+
+**Supersedes:** `2026-04-05-study-plan-system-design.md` (cards-only design). Preserves its architectural decisions (brain-first, dashboard-reads-main-writes) while expanding the pedagogical model, adding a dashboard chat interface for deep learning, and repositioning Telegram as a mobile companion.
+
+**Key evolution from original spec:** Study plans are co-created through collaborative dialogue (Knowles' learning contracts), not auto-generated. Concepts are organized by knowledge domain, not just course. The dashboard has a full chat interface for deep conversational methods. Telegram handles reminders, quick reviews, and podcast delivery.
+
+**v2.1 changes (2026-04-13 review):** Replaced BKT with weighted evidence mastery model. Replaced 8-stage method ladder with Bloom's-based progression (methods are tools, not stages). Clarified exam-prep as scheduling constraint. Dropped transfer_score. Made planning dialogue optional-depth. Added domain-batch concept approval. Session design: suggest strongly, enforce nothing. Added future considerations (backup, deletion handling, rate limiting).
+
+---
+
+## 1. Why Multi-Method? The Research Case
+
+### 1.1 The Limits of Cards Alone
+
+Spaced repetition flashcards are the most evidence-backed tool for long-term retention of factual knowledge (Dunlosky et al. 2013, "high utility"). But university learning demands more than recall:
+
+- **Karpicke & Blunt (2011, Science):** Retrieval practice outperforms elaborative study -- but only when retrieval targets the right cognitive level. Simple recall cards test recognition; complex understanding requires generation, explanation, and application.
+- **Matuschak (2020):** LLM-generated cards "reinforce the surface -- what is said, rather than what it means or why it matters." Cards are effective for declarative knowledge but fail for relational, procedural, and evaluative understanding.
+- **Nielsen (2018):** "What you really want is to feel every element and the connections between them in your bones." Cards build the skeleton; other methods build the muscle.
+
+For Simon's learning domains (knowledge management theory, digital transformation, information systems, cognitive psychology), the critical challenges are:
+- Understanding *why* Nonaka's SECI model differs from Wiig's lifecycle (comparative analysis)
+- Applying cognitive load theory to critique an instructional design (case-based reasoning)
+- Synthesizing across frameworks to argue a position in an exam (synthesis + writing)
+
+**Conclusion:** Cards are layer 1 of a multi-layer system. Each layer targets progressively higher Bloom's taxonomy levels with the study method best suited to that cognitive demand.
+
+### 1.2 The Study Method Toolkit — Evidence Base
+
+Each method is selected based on its research backing, the Bloom's levels it targets, and its practical implementability in an AI tutor. **Methods are tools, not stages** — any method can be used at any point, but the system recommends methods that match the concept's current Bloom's level.
+
+| Method | Bloom's | Key Research | Best For |
+|--------|---------|-------------|----------|
+| SR Cards | L1-L2 | Dunlosky 2013 ("high utility"), Cepeda 2008 (spacing), Wozniak 1987 (SM-2) | Foundational retention of facts and definitions |
+| Elaborative Interrogation | L2-L3 | Dunlosky 2013 ("moderate utility"), Pressley 1987 (2x recall improvement) | "Why" reasoning, activating prior knowledge schemas |
+| Self-Explanation / Feynman | L2-L4 | Chi 1994 (all high-explainers achieved correct mental model), Nestojko 2014 (teaching expectation improves memory) | Exposing gaps, integrative + error-correcting |
+| Concept Mapping | L2-L5 | Nesbit & Adesope 2006 (moderate-large effect), STEM meta-analysis 2025 (ES=0.630) | Mapping relationships between ideas |
+| Comparative Analysis | L4-L5 | Alfieri et al. 2013 (d=0.50, d=1.60 with principles after), Gentner 1983 (structure-mapping) | Deep structural comparison, framework discrimination |
+| Case-Based Learning | L3-L6 | Nkhoma 2016 (positive cascade: application -> higher-order thinking), Yadav 2024 (d=0.498 motivation) | Transferring theory to authentic situations |
+| Synthesis Exercises | L5-L6 | Research on argumentative synthesis (PMC 2022): explicit instruction on integrating conflicting sources required | Cross-topic integration, highest cognitive demand |
+| Socratic Dialogue | L4-L6 | UK RCT 2025 (5.5pp improvement on novel problems), ECAI 2024 (p<0.001 critical thinking improvement) | Probing assumptions, metacognitive fluency |
+
+**Bloom's level is the progression axis, not method type.** Concepts advance through Bloom's L1-L6 based on mastery evidence. The system recommends method combinations suited to the current level, but the student can use any method at any time. Karpicke & Blunt (2011) showed retrieval practice is effective at all cognitive levels — rigid method gates would prevent this.
+
+**Method recommendation guidelines (not gates):**
+- L1-L2 (Remember/Understand): Cards, elaboration, light Feynman
+- L3-L4 (Apply/Analyze): Feynman, concept mapping, comparison, case analysis
+- L5-L6 (Evaluate/Create): Synthesis, Socratic dialogue, case analysis, comparison
+
+The system suggests the best method mix for where you are, but never locks out a method.
+
+### 1.3 Foundational Design Principles
+
+These principles are carried forward from the original spec, grounded in research, and apply to every method -- not just cards.
+
+**Brain-first, AI-second (Kosmyna et al. 2025).**
+Habitual AI use causes cumulative cognitive debt -- 83.3% of LLM users failed to correctly quote from their own AI-assisted essay. Every method requires the student to produce output before receiving feedback. The AI scaffolds, questions, and evaluates -- it never leads with answers.
+
+**Desirable difficulties (Bjork 1994, 2011).**
+Conditions that feel harder during learning produce better long-term retention and transfer. The system optimizes for learning, which means: spacing (not massing), interleaving (not blocking review), generation (not recognition), and contextual variation (not repetition of identical prompts). The system communicates *why* it recommends certain activities ("interleaving these topics improves long-term retention") so the student can make informed decisions.
+
+**Suggest strongly, enforce nothing.**
+The system recommends session composition, method choices, and difficulty levels based on learning science. Mr. Rogers actively nudges and reminds. But the student has full control — they can change, skip, or ignore any recommendation. No flagging, no guilt mechanics, no paternalism. The system is a smart assistant, not a strict tutor.
+
+**Cognitive load management (Sweller 1988, Mayer 2002).**
+- New material: block presentation, one concept at a time (minimize intrinsic load)
+- Session length: 25-50 minutes (prevent working memory overload)
+- Prerequisite awareness: flag when a concept depends on others that aren't yet solid
+- Expertise reversal effect: reduce scaffolding as mastery grows (what helps novices hurts experts)
+- Personalization effect (Mayer): conversational style produces the largest multimedia learning effect (ES=1.55)
+- Minimize extraneous load: clear interfaces, smart defaults, no unnecessary steps — maximize cognitive effort on actual learning
+
+**Metacognition and self-regulated learning (Zimmerman 2002).**
+Three-phase cycle built into every session:
+1. Forethought: confidence ratings, goal setting
+2. Performance: self-monitoring, help-seeking
+3. Self-reflection: calibration feedback, adaptive reactions
+
+Tracking calibration (predicted vs. actual performance) builds metacognitive accuracy over time -- a skill that transfers beyond the study system.
+
+**Transfer over recall (Mayer 2002).**
+Rote learning produces retention without transfer. Meaningful learning produces both. The system prioritizes methods that develop transfer capability (application, analysis, synthesis) over methods that only develop recall. Cards are the floor, not the ceiling.
+
+**Mastery orientation over performance orientation (Dweck, Ames).**
+The system frames all learning as mastery-approach goals ("understand deeply, apply flexibly") rather than performance goals ("get 90% on the exam"). Mastery orientation produces deeper learning strategies, challenge-seeking, persistence after failure, and sustained interest beyond the course (Katz-Vago 2024). Exam-prep mode is a scheduling constraint (deadline + coverage), not a different learning philosophy — the mastery orientation applies regardless.
+
+---
+
+## 2. Architecture
+
+### 2.1 System Topology
+
+The architecture has four surfaces: the dashboard (UI + chat), the main process (engine + LLM), Telegram (mobile companion), and scheduled background tasks. Container agents (via NanoClaw's existing infrastructure) handle all LLM work, running through the Claude Max subscription via OneCLI -- no paid API calls.
+
+```
+Dashboard (Next.js, port 3100)
+  /study -------- Concept map, plans, analytics
+  /study/session - Multi-method study UI
+  /study/chat --- Deep learning dialogue (Feynman, Socratic, planning)
+  /study/plan --- Collaborative plan creation
+  /read --------- RSVP reader (vault deep-links)
+  /api/study/* -- SQLite reads + completion writes
+  Web channel --- SSE streaming for chat
+      |
+      | HTTP + SSE
+      v
+Main Process (src/study/)
+  engine.ts ----- Concept progression, session building
+  planner.ts ---- Collaborative plan dialogue
+  sm2.ts -------- Card-level scheduling
+  mastery.ts ---- Concept-level mastery (weighted evidence)
+  generator.ts -- Activity generation via Claude + RAG
+  audio.ts ------ Podcast/audio generation via Claude + TTS
+  Uses: RagClient, StudentProfile, VaultUtility, SQLite
+      |                    |
+      | IPC                | IPC
+      v                    v
+Study Agent             Mr. Rogers (Telegram)
+(Container)             - Daily reminders + nudges
+- Dashboard chat        - Quick card review
+- Feynman sessions      - Podcast delivery
+- Socratic dialogue     - Progress summaries
+- AI evaluation         - Light elaboration
+- Plan dialogue         - On-the-go study
+- Results -> IPC        - Concept discovery alerts
+                        - Results -> IPC
+```
+
+### 2.2 The Four Learning Surfaces
+
+The dashboard is the primary surface for deep, focused learning. Telegram is the mobile companion for lightweight interactions and content delivery. Each surface plays to its strengths.
+
+**Dashboard Chat (`/study/chat`)** -- Primary surface for deep learning:
+- Feynman technique (full multi-turn dialogue)
+- Socratic questioning (iterative, transcript-saving)
+- Case analysis discussion (multi-step reasoning)
+- Synthesis dialogue (cross-concept integration)
+- Collaborative plan creation
+- Future: live voice dialogue
+
+**Dashboard UI (`/study/session`, `/study`)** -- Primary surface for structured activities:
+- SR card review (quiz interface)
+- Concept mapping (visual builder)
+- Comparison matrices
+- Writing/synthesis labs
+- Progress analytics and mastery heatmaps
+- Pre/post session metacognitive prompts
+
+**Telegram (Mr. Rogers)** -- Mobile companion:
+- Daily reminders and session-ready notifications
+- Quick card review on the go
+- Light elaborative interrogation
+- Weekly/monthly progress summaries
+- Podcast/audio delivery (listen while traveling)
+- Concept discovery notifications ("3 new concepts from yesterday's upload")
+
+**Scheduled Tasks** -- Proactive background:
+- Morning session preparation (generate activities, build session)
+- Post-session activity generation (for escalated concepts)
+- Daily/weekly/monthly reminder triggers
+- Audio/podcast generation for upcoming review topics
+
+| Method | Dashboard Chat | Dashboard UI | Telegram | Scheduled |
+|--------|---------------|-------------|----------|-----------|
+| SR Card Review | -- | Full quiz interface | Quick review | -- |
+| Elaboration | "Why?" dialogue | Structured prompts | Light "why?" | -- |
+| Feynman | **Primary** | -- | -- | -- |
+| Concept Mapping | -- | **Primary** (visual) | -- | -- |
+| Comparison | Discussion mode | **Primary** (matrix) | -- | -- |
+| Case Analysis | **Primary** | Case workbench | -- | -- |
+| Synthesis | **Primary** | Writing lab | -- | -- |
+| Socratic | **Primary** | -- | -- | -- |
+| Plan Creation | **Primary** | Plan overview | -- | -- |
+| Daily Reminder | -- | -- | **Primary** | Trigger |
+| Podcasts | Generation UI | -- | **Delivery** | Generation |
+| Progress Reports | -- | Analytics page | Summaries | Trigger |
+| Voice Dialogue | **Future** | -- | -- | -- |
+
+### 2.3 Key Architectural Decisions
+
+**Decision 1: Dashboard reads, main process writes (carried forward).**
+The dashboard has no Anthropic API key. All LLM work -- activity generation, answer evaluation, Socratic dialogue on the web -- routes through the main process via container agents. Container agents run through the Claude Max subscription via OneCLI, so AI evaluation is essentially free in API cost terms.
+
+**Decision 2: Concepts are the central entity, organized by domain (new).**
+The original spec centered on cards and organized by course. This spec centers on concepts organized by **knowledge domain** and **subdomain**. A concept belongs to a domain ("Knowledge Management") and subdomain ("KM Models"), not necessarily to a course. Courses are just one way concepts get tagged -- personal interest, research fields, and cross-disciplinary themes are equally valid organizing structures.
+
+**Decision 3: SM-2 + weighted evidence mastery coexist at different levels (revised v2.1).**
+- SM-2 operates per-activity: "this specific elaboration prompt is due in 6 days"
+- Weighted evidence mastery operates per-concept: "the student has strong L1-L3 mastery but weak L4+ on Cognitive Load Theory"
+- SM-2 decides WHEN to show each activity
+- Mastery evidence decides WHICH TYPE of activity to recommend next and at what Bloom's level
+
+*Why weighted evidence and not BKT?* BKT was designed for estimating mastery across student populations. With a single learner, its four parameters (p_learn, p_guess, p_slip) never accumulate enough data per concept to converge meaningfully — the defaults from literature are population-derived constants. A weighted evidence model provides the same decision-making capability (stage gates, mastery %, identifying weak concepts) with transparent, interpretable scores. Each activity at a Bloom's level contributes weighted evidence scaled by quality, with exponential time decay. See Section 4.2.
+
+**Decision 4: Activities are schedulable units (new).**
+The original spec had only `sr_cards`. This spec introduces `learning_activities` -- a broader entity that includes cards, elaboration prompts, Feynman prompts, comparison tasks, case scenarios, synthesis exercises, and Socratic dialogue starters. All activity types share SM-2 scheduling fields. The session builder mixes activity types to create varied, cognitively demanding study sessions.
+
+**Decision 5: Brain-first applies to every method (carried forward, expanded).**
+Not just "show question before answer." For each method:
+- Cards: student answers before seeing reference
+- Elaboration: student explains "why" before seeing the source reasoning
+- Feynman: student explains the concept before AI identifies gaps
+- Concept mapping: student constructs the map before seeing the reference map
+- Comparison: student identifies differences before seeing the analysis
+- Case analysis: student proposes a solution before seeing the expert analysis
+- Synthesis: student writes the integration before seeing the model synthesis
+- Socratic dialogue: student reasons through questions before receiving guidance
+
+**Decision 6: AI evaluation from Bloom's L3+ via container agents (revised v2.1).**
+Since container agents run through the Claude Max subscription (no API cost), AI evaluation is used broadly:
+- L1-L2 activities (cards, basic elaboration): Self-rated only. Clear right/wrong answers. Self-rating builds metacognition.
+- L2-L3 activities (elaboration, Feynman): Self-rated + AI review. Student rates first (brain-first applies to evaluation too), then container agent evaluates against vault via RAG. Shows both ratings. This is where calibration training starts.
+- L4-L6 activities (cases, synthesis, Socratic): AI-rated (primary). The AI rating feeds SM-2 and mastery evidence. Complex free-text responses are genuinely hard to self-assess.
+
+**Container reuse:** During a study session, a single container agent stays alive across all activities — no per-activity spin-up. The dashboard chat is already a persistent container session via the web channel.
+
+**Decision 7: Domain-based synthesis, not course-based (new).**
+- **Within-subdomain synthesis (automatic):** Concepts in the same subdomain with strong L3+ mastery get synthesis activities automatically. Closely related ideas that should be integrated.
+- **Within-domain synthesis (automatic):** Concepts in the same domain but different subdomains with strong L3+ mastery get synthesis automatically.
+- **Cross-domain synthesis (proposed, not automatic):** When depth exists across multiple domains, the system suggests it in the weekly summary. Student confirms before generation. Avoids generating useless cross-domain connections while surfacing meaningful ones.
+
+**Decision 8: Batch activity generation, triggered post-session + morning (new).**
+Activities are generated in batches when concepts advance to new Bloom's levels. Two triggers:
+- **Post-session (primary):** After session completion, the engine checks which concepts advanced and immediately generates next-level activities via a container agent. By tomorrow, everything is ready.
+- **Morning scheduled task (safety net):** Catches anything missed, builds today's session composition, sends Telegram notification: "Your session is ready."
+- **Rate limit:** Maximum 10 concepts per generation cycle. Remaining queued for next cycle.
+The student never opens the dashboard to find "generating, please wait."
+
+**Decision 9: Study plans as collaborative learning contracts (new, optional depth).**
+Study plans are co-created through dialogue between the student and the AI (see Section 5). Grounded in Knowles' learning contracts (1975), backward design (Wiggins & McTighe), and self-determination theory (Deci & Ryan). The student drives; the AI structures.
+
+**The dialogue depth is optional.** The minimum path is: "I want to study X" → system creates a plan with the selected concepts and default scheduling. The student can optionally go deeper: set learning objectives, define desired outcomes, create implementation intentions, identify obstacles. All plan fields except domain and concepts are nullable — the engine uses sensible defaults for anything not provided. A 30-second exchange and a 10-minute deep planning session produce the same data structure.
+
+**Decision 10: Student-generated activities at key moments (new).**
+The act of writing prompts is itself a learning activity (Nielsen 2018, Matuschak 2020). The system prompts the student to write their own activities at moments where self-authoring is most valuable:
+- After a Feynman session where they struggled (captures personal gaps)
+- When they notice a connection the system hasn't made (captures insight)
+- During dashboard chat after an illuminating exchange (captures learning moments)
+- After reading a vault note (Nielsen's multi-pass Ankification)
+Student-authored activities are stored with `author = 'student'` and scheduled like any other.
+
+---
+
+## 3. Data Model
+
+### 3.1 New SQLite Tables
+
+```sql
+-- CONCEPTS -- the central learning entity
+-- Organized by knowledge domain/subdomain, not just course.
+-- Weighted evidence mastery updated after every activity.
+
+CREATE TABLE IF NOT EXISTS concepts (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,                    -- "Cognitive Load Theory"
+  domain TEXT,                            -- "Cognitive Psychology"
+  subdomain TEXT,                         -- "Learning & Memory"
+  course TEXT,                            -- "BI-2081" (optional tag, not primary organizer)
+  vault_note_path TEXT,                   -- "concepts/cognitive-load-theory.md"
+
+  -- Discovery and approval
+  status TEXT DEFAULT 'active',           -- 'pending' | 'active' | 'skipped' | 'archived'
+
+  -- Weighted evidence mastery (per Bloom's level)
+  -- Each field stores accumulated weighted evidence (0.0+)
+  -- Mastery at a level = evidence / threshold (capped at 1.0)
+  mastery_L1 REAL DEFAULT 0.0,           -- Remember
+  mastery_L2 REAL DEFAULT 0.0,           -- Understand
+  mastery_L3 REAL DEFAULT 0.0,           -- Apply
+  mastery_L4 REAL DEFAULT 0.0,           -- Analyze
+  mastery_L5 REAL DEFAULT 0.0,           -- Evaluate
+  mastery_L6 REAL DEFAULT 0.0,           -- Create
+  mastery_overall REAL DEFAULT 0.0,      -- weighted aggregate (L1=1, L2=1.5, ... L6=4)
+
+  -- Progression state
+  bloom_ceiling INTEGER DEFAULT 1,        -- highest Bloom's level with sufficient mastery
+
+  -- Metadata
+  created_at TEXT NOT NULL,
+  last_activity_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_concepts_domain ON concepts(domain);
+CREATE INDEX IF NOT EXISTS idx_concepts_status ON concepts(status);
+
+-- Prerequisite relationships between concepts.
+-- The system flags when a concept's prerequisites have weak mastery
+-- (CLT: isolated-to-interacting element progression, Sweller 1988)
+-- but does not hard-block — the student decides.
+CREATE TABLE IF NOT EXISTS concept_prerequisites (
+  concept_id TEXT NOT NULL REFERENCES concepts(id),
+  prerequisite_id TEXT NOT NULL REFERENCES concepts(id),
+  PRIMARY KEY (concept_id, prerequisite_id)
+);
+
+-- LEARNING ACTIVITIES -- schedulable study units
+-- Every activity type shares SM-2 scheduling fields so the
+-- session builder can interleave cards, elaboration, Feynman,
+-- comparisons, cases, and synthesis in a single session.
+
+CREATE TABLE IF NOT EXISTS learning_activities (
+  id TEXT PRIMARY KEY,
+  concept_id TEXT NOT NULL REFERENCES concepts(id),
+
+  -- Activity specification
+  activity_type TEXT NOT NULL,            -- see Activity Types (Section 3.2)
+  prompt TEXT NOT NULL,                   -- the question/task presented to student
+  reference_answer TEXT,                  -- expected answer or evaluation rubric
+  bloom_level INTEGER NOT NULL,           -- 1-6 (tagged per activity)
+  difficulty_estimate INTEGER DEFAULT 5,  -- 1-10, content-based initial estimate
+
+  -- For card_review activities specifically
+  card_type TEXT,                         -- 'cloze' | 'basic' | 'reversed' | NULL
+
+  -- Authorship
+  author TEXT DEFAULT 'system',           -- 'system' | 'student'
+
+  -- Source traceability (Wozniak Rules 18-19)
+  source_note_path TEXT,                  -- vault note this was generated from
+  source_chunk_hash TEXT,                 -- hash for staleness detection
+  generated_at TEXT NOT NULL,
+
+  -- SM-2 scheduling (per-activity)
+  ease_factor REAL DEFAULT 2.5,
+  interval_days INTEGER DEFAULT 1,
+  repetitions INTEGER DEFAULT 0,
+  due_at TEXT NOT NULL,
+  last_reviewed TEXT,
+  last_quality INTEGER,
+  mastery_state TEXT DEFAULT 'new'        -- 'new' | 'learning' | 'reviewing' | 'mastered'
+);
+CREATE INDEX IF NOT EXISTS idx_activities_due ON learning_activities(due_at);
+CREATE INDEX IF NOT EXISTS idx_activities_concept ON learning_activities(concept_id);
+CREATE INDEX IF NOT EXISTS idx_activities_type ON learning_activities(activity_type);
+
+-- ACTIVITY CONCEPTS -- join table for multi-concept activities
+-- Used by comparison, synthesis, and cross-domain activities.
+-- Replaces the previous related_concept_ids JSON field.
+CREATE TABLE IF NOT EXISTS activity_concepts (
+  activity_id TEXT NOT NULL REFERENCES learning_activities(id),
+  concept_id TEXT NOT NULL REFERENCES concepts(id),
+  role TEXT DEFAULT 'related',            -- 'primary' | 'related' | 'comparison_target'
+  PRIMARY KEY (activity_id, concept_id)
+);
+
+-- ACTIVITY LOG -- every interaction, every method
+-- Granular enough for future FSRS migration and mastery computation.
+-- Log everything; derive metrics later.
+
+CREATE TABLE IF NOT EXISTS activity_log (
+  id TEXT PRIMARY KEY,
+  activity_id TEXT NOT NULL REFERENCES learning_activities(id),
+  concept_id TEXT NOT NULL,               -- denormalized for fast concept queries
+  activity_type TEXT NOT NULL,            -- denormalized for analytics
+  bloom_level INTEGER NOT NULL,           -- denormalized for per-level analysis
+
+  -- Student response
+  quality INTEGER NOT NULL,               -- 0-5 (SM-2 scale)
+  response_text TEXT,                     -- student's actual answer (for AI eval)
+  response_time_ms INTEGER,              -- retrieval fluency proxy
+  confidence_rating INTEGER,             -- pre-answer self-assessment (1-5)
+
+  -- Evaluation
+  scaffolding_level INTEGER DEFAULT 0,   -- 0-5 (how much help was needed)
+  evaluation_method TEXT DEFAULT 'self_rated', -- 'self_rated' | 'ai_rated' | 'hybrid'
+  ai_quality INTEGER,                    -- AI's quality assessment (for hybrid)
+  ai_feedback TEXT,                       -- AI's specific feedback text
+
+  -- Method used (for analytics: which methods work best)
+  method_used TEXT,                       -- actual method type used in this interaction
+
+  -- Context
+  surface TEXT,                           -- 'dashboard_chat' | 'dashboard_ui' | 'telegram'
+  session_id TEXT REFERENCES study_sessions(id),
+  reviewed_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_log_concept ON activity_log(concept_id);
+CREATE INDEX IF NOT EXISTS idx_log_session ON activity_log(session_id);
+CREATE INDEX IF NOT EXISTS idx_log_bloom ON activity_log(bloom_level);
+
+-- STUDY SESSIONS -- groups activities into study sessions
+-- Enables Zimmerman's three-phase SRL cycle.
+
+CREATE TABLE IF NOT EXISTS study_sessions (
+  id TEXT PRIMARY KEY,
+  started_at TEXT NOT NULL,
+  ended_at TEXT,
+  session_type TEXT NOT NULL,             -- 'daily' | 'weekly' | 'monthly' | 'free'
+  plan_id TEXT REFERENCES study_plans(id),
+
+  -- Metacognition (Zimmerman 2002)
+  pre_confidence TEXT,                    -- JSON: { concept_id: rating(1-5) }
+  post_reflection TEXT,                   -- student's own words
+  calibration_score REAL,                 -- correlation(confidence, performance)
+
+  -- Session metrics
+  activities_completed INTEGER DEFAULT 0,
+  total_time_ms INTEGER,
+  surface TEXT                            -- 'dashboard' | 'telegram'
+);
+
+-- STUDY PLANS -- collaborative learning contracts
+-- Co-created through dialogue (Knowles 1975, Wiggins & McTighe backward design).
+-- All fields except domain and concepts are optional -- the engine
+-- uses sensible defaults for anything not provided.
+
+CREATE TABLE IF NOT EXISTS study_plans (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  domain TEXT,                            -- primary domain, or NULL for cross-domain
+  course TEXT,                            -- optional course tag
+  strategy TEXT NOT NULL DEFAULT 'open',  -- 'open' | 'exam-prep' | 'weekly-review' | 'exploration'
+
+  -- Learning contract (Knowles 1975) -- all optional
+  learning_objectives TEXT,               -- JSON array of Bloom's-tagged objectives
+  desired_outcomes TEXT,                  -- "what will I be able to do?" (backward design)
+
+  -- Commitment (Gollwitzer 1999, Oettingen WOOP) -- all optional
+  implementation_intention TEXT,          -- "if X, then Y" commitment
+  obstacle TEXT,                          -- identified barrier
+  study_schedule TEXT,                    -- "weekdays after dinner, 25 min"
+
+  -- Plan management
+  config TEXT,                            -- JSON: exam_date, session_length_min, etc.
+  checkpoint_interval_days INTEGER DEFAULT 14,
+  next_checkpoint_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  status TEXT DEFAULT 'active'            -- 'active' | 'completed' | 'archived'
+);
+
+-- Links plans to concepts
+CREATE TABLE IF NOT EXISTS study_plan_concepts (
+  plan_id TEXT NOT NULL REFERENCES study_plans(id),
+  concept_id TEXT NOT NULL REFERENCES concepts(id),
+  target_bloom INTEGER DEFAULT 6,         -- target Bloom's level for this plan
+  sort_order INTEGER DEFAULT 0,
+  PRIMARY KEY (plan_id, concept_id)
+);
+```
+
+**Transaction requirement:** All multi-table writes (activity completion updating activity_log + learning_activities + concepts + study_sessions) MUST be wrapped in a SQLite transaction to prevent inconsistent state on partial failure.
+
+### 3.2 Activity Types
+
+```
+activity_type values:
+
+  card_review     -- Traditional SR card (cloze, basic Q&A, reversed)
+                    Bloom's L1-L2. Recommended at low mastery.
+
+  elaboration     -- "Why does this make sense?" prompt
+                    Bloom's L2-L3.
+                    Student explains causal reasoning.
+
+  self_explain    -- Feynman technique prompt ("Explain X as if teaching someone")
+                    Bloom's L2-L4.
+                    Student produces full explanation, AI identifies gaps.
+
+  concept_map     -- "List key concepts and their relationships"
+                    Bloom's L2-L5.
+                    Visual on dashboard, text-based fallback.
+
+  comparison      -- "Compare X and Y along dimensions [a, b, c]"
+                    Bloom's L4-L5.
+                    Uses activity_concepts join table (2+ concepts).
+
+  case_analysis   -- Real-world scenario requiring theory application
+                    Bloom's L3-L6.
+                    Multi-step: identify problem -> select framework -> analyze -> recommend.
+
+  synthesis       -- "Integrate concepts A, B, C to address question Q"
+                    Bloom's L5-L6.
+                    Uses activity_concepts join table (2-3 concepts).
+
+  socratic        -- Dialogue starter with guided question sequence
+                    Bloom's L4-L6.
+                    Primary surface: dashboard chat.
+```
+
+### 3.3 Activity Quality Rules
+
+Every auto-generated activity must pass these checks before entering the schedule. Grounded in Wozniak's 20 Rules, Matuschak's 5 Attributes, and card design research.
+
+**Wozniak's Minimum Information Principle:** Each activity tests ONE concept. If the reference answer exceeds ~15 words (for card_review type), split the activity.
+
+**Matuschak's Five Attributes:**
+1. **Focused** -- one concept per prompt
+2. **Precise** -- produces a consistent answer over time
+3. **Consistent** -- correct answer doesn't shift with context
+4. **Tractable** -- answerable with effort (not impossible)
+5. **Effortful** -- requires genuine retrieval (not trivially inferable)
+
+**Anti-patterns to reject:**
+- Yes/no questions (50% guessable, no retrieval effort)
+- "List all X" prompts (sets are extremely hard to memorize -- break into individuals)
+- Copy-paste from source text (encourages pattern-matching, not understanding)
+- Orphan activities (single activity per concept -- always generate 2+ from different angles)
+- Answer keywords in the question (enables pattern matching without recall)
+- Answers longer than 15 words for card_review (split the card)
+
+**Source traceability (Wozniak Rules 18-19):**
+Every activity stores `source_note_path` and `source_chunk_hash`. This enables:
+- Clicking through to the vault note during review
+- Staleness detection when vault content changes
+- Verification of AI-generated content against the source
+
+---
+
+## 4. Algorithms
+
+### 4.1 SM-2 -- Per-Activity Scheduling
+
+Carried forward from original spec. Pure function, ~50 lines.
+
+```typescript
+// If quality >= 3 (correct):
+//   rep 0: interval = 1
+//   rep 1: interval = 6
+//   rep 2+: interval = round(interval * EF)
+//   repetitions += 1
+// If quality < 3 (incorrect):
+//   repetitions = 0, interval = 1
+//
+// EF = EF + (0.1 - (5 - q) * (0.08 + (5 - q) * 0.02))
+// EF = max(EF, 1.3)
+```
+
+SM-2 is chosen over FSRS for simplicity. The activity_log schema stores all fields needed for future FSRS migration (quality, response_time_ms, ease_factor, interval_days per review).
+
+### 4.2 Weighted Evidence Mastery -- Per-Concept, Per-Bloom's Level
+
+Replaces BKT. Estimates mastery at each Bloom's level for each concept, updated after every activity. Transparent, interpretable, and doesn't require population data to converge.
+
+```typescript
+// Bloom's level weights -- higher levels contribute more evidence
+const BLOOM_WEIGHTS = { 1: 1.0, 2: 1.5, 3: 2.0, 4: 2.5, 5: 3.0, 6: 4.0 };
+
+// Mastery threshold -- evidence needed to consider a level "mastered"
+const MASTERY_THRESHOLD = 10.0;
+
+// Time decay -- recent evidence weighted more than old
+const DECAY_HALF_LIFE_DAYS = 30;
+
+function updateMastery(concept, activityLog) {
+  // For each Bloom's level, compute weighted evidence
+  for (let level = 1; level <= 6; level++) {
+    const activities = activityLog.filter(a => a.bloom_level === level);
+    let evidence = 0;
+
+    for (const activity of activities) {
+      const qualityWeight = activity.quality / 5.0;  // 0.0-1.0
+      const daysSince = daysBetween(activity.reviewed_at, now);
+      const timeDecay = Math.pow(0.5, daysSince / DECAY_HALF_LIFE_DAYS);
+
+      evidence += qualityWeight * timeDecay;
+    }
+
+    concept[`mastery_L${level}`] = evidence;
+  }
+
+  // Overall mastery: weighted sum across levels
+  concept.mastery_overall = sum(
+    levels.map(l => Math.min(concept[`mastery_L${l}`] / MASTERY_THRESHOLD, 1.0) * BLOOM_WEIGHTS[l])
+  ) / sum(Object.values(BLOOM_WEIGHTS));
+
+  // Bloom ceiling: highest level with sufficient mastery
+  concept.bloom_ceiling = highestLevel where
+    concept[`mastery_L${level}`] / MASTERY_THRESHOLD >= 0.7;
+}
+```
+
+**What this gives you:**
+- Per-concept, per-Bloom's-level mastery visibility ("strong recall but weak application")
+- Transparent scoring — you can see exactly why a concept shows 72% mastery
+- Time decay means unused knowledge fades, driving spaced review
+- bloom_ceiling drives activity recommendations (push the student to the next level)
+- All raw data logged in activity_log for future metric derivation
+
+### 4.3 Concept Progression Engine
+
+The core logic that determines which activities to recommend for a concept. **Bloom's level is the progression axis; methods are recommended, not gated.**
+
+```
+For each active concept, compute bloom_ceiling from mastery evidence.
+
+LEVEL RECOMMENDATIONS:
+
+  Bloom's L1-L2 (Remember/Understand) — bloom_ceiling < 3
+    Recommended activities: 3-5 SR cards, 2 elaboration prompts
+    Evaluation: Self-rated
+    Advancement: mastery_L1 and mastery_L2 reach threshold
+    Rationale: Cepeda 2008 -- foundational facts retained before
+    deeper methods build on them.
+
+  Bloom's L3-L4 (Apply/Analyze) — bloom_ceiling 3-4
+    Recommended activities: Feynman prompts, concept map tasks,
+    comparison tasks, initial case analysis
+    Evaluation: Self-rated + AI review (container agent via RAG)
+    Advancement: mastery_L3 and mastery_L4 reach threshold
+    Prerequisite awareness: flag if prerequisites have weak L1-L2
+    Rationale: Chi 1994, Alfieri 2013 -- explanation and comparison
+    build structural understanding.
+
+  Bloom's L5-L6 (Evaluate/Create) — bloom_ceiling 5-6
+    Recommended activities: Synthesis prompts, Socratic dialogue
+    starters, complex case analysis, cross-concept comparison
+    Evaluation: AI-rated (primary) -- complex free-text too hard
+    to self-assess
+    No further advancement -- maintain with spaced reviews.
+    Rationale: Synthesis requires integration across mastered concepts.
+
+SYNTHESIS RULES:
+  Within-subdomain: Automatic when 2+ concepts have bloom_ceiling >= 4
+  Within-domain: Automatic when concepts across subdomains have bloom_ceiling >= 4
+  Cross-domain: Proposed in weekly summary, requires student confirmation
+
+DE-ESCALATION GUIDANCE:
+  If quality consistently < 3 and mastery evidence at a level is declining,
+  the system recommends returning to lower-level activities for that concept.
+  "Your recent case analyses on CLT suggest the foundational understanding
+  could use reinforcement — want to do some elaboration exercises?"
+
+ANY METHOD, ANY TIME:
+  The student can always request any method for any concept via dashboard
+  chat or free study mode. The system logs and updates mastery regardless
+  of whether the activity was system-recommended.
+```
+
+### 4.4 Adaptive Scaffolding
+
+Within each activity, scaffolding adapts based on the student's rolling performance (Vygotsky's ZPD, Wood et al. 1976).
+
+```
+Target success rate: 70-85% (the ZPD sweet spot)
+  > 90% -> reduce scaffolding, recommend higher Bloom's level
+  < 50% -> increase scaffolding, recommend simpler method
+  70-85% -> maintain current level (in the zone)
+
+Scaffolding levels (available for all activity types):
+  Level 0: Activity prompt only (no hints)
+  Level 1: Contextual hint ("Think about concept X")
+  Level 2: Structural hint ("The answer involves three components...")
+  Level 3: Partial solution ("The first step is...")
+  Level 4: Worked example with similar problem
+  Level 5: Full explanation + answer (last resort)
+```
+
+### 4.5 Session Builder
+
+Builds a daily study session mixing methods, topics, and Bloom's levels. **The session is a recommendation — the student has full control to adjust.**
+
+```
+buildDailySession(student):
+  1. Pull all activities with due_at <= now, sorted by:
+     a. Overdue first
+     b. Low ease_factor (struggling activities)
+     c. Activity type variety
+
+  2. Compose session in three blocks:
+
+     NEW MATERIAL BLOCK (~30%, BLOCKED by topic)
+       L1-L2 activities for recently added concepts.
+       Grouped by topic to minimize extraneous cognitive load.
+       Rationale: Hwang 2025 -- interleaving new material creates
+       "undesirable difficulty." Block first, interleave later.
+
+     REVIEW BLOCK (~50%, INTERLEAVED)
+       Mix activity types across concepts and domains.
+       Never 2 consecutive activities on same concept.
+       Vary activity_type: card -> elaboration -> comparison -> card.
+       Rationale: Cepeda 2006 -- interleaved review outperforms blocked.
+
+     STRETCH BLOCK (~20%, highest available Bloom's)
+       One higher-order activity (synthesis, case, or Socratic starter).
+       Only if student has concepts at bloom_ceiling 4+.
+       Rationale: Bjork 1994 -- desirable difficulties.
+
+  3. Bookend with metacognition (Zimmerman 2002):
+     PRE-SESSION: Confidence ratings, session goal
+     POST-SESSION: Calibration feedback, reflection prompt
+
+  4. Constraints:
+     Target: 25-30 min OR 15-25 activities.
+     Recommend not exceeding 50 min.
+     At least 1 activity from each active domain when possible.
+
+  5. Student adjustments:
+     - Swap activities for similar Bloom's level alternatives
+     - Request domain focus ("I want to focus on KM today")
+     - Skip any activity or block
+     - Switch to free study mode at any time
+     System explains reasoning: "The stretch block targets L5-L6
+     where your evidence is still building — recommended but optional."
+```
+
+### 4.6 Activity Generation Timing
+
+```
+Post-session generation (primary trigger):
+  Student completes session
+    -> Engine checks for Bloom's level advancements
+    -> For each advanced concept: generate next-level activities
+       via container agent (Claude + RAG)
+    -> Activities stored with due_at based on SM-2 intervals
+    -> Happens immediately in background
+    -> Rate limit: max 10 concepts per cycle, queue remainder
+
+Morning scheduled task (safety net, e.g. 06:00):
+  -> Check for concepts missing activities at recommended level
+  -> Generate if needed (respecting rate limit)
+  -> Build today's session composition
+  -> Send Telegram: "Good morning! 15 activities ready (~25 min)"
+```
+
+### 4.7 Weekly and Monthly Sessions
+
+**Weekly session (triggered by scheduled task):**
+- Cross-topic synthesis questions
+- Higher Bloom's level assessments for concepts at bloom_ceiling 4+
+- Concept map reconstruction from memory
+- Weekly progress summary via Telegram
+- Cross-domain synthesis suggestions (if applicable)
+- Rationale: Bruner's spiral curriculum (1960)
+
+**Monthly session (triggered by scheduled task):**
+- Comprehensive mastery check across all active domains
+- Identify decaying concepts (mastery evidence declining)
+- Study plan checkpoint and adaptation dialogue
+- Growth trajectory: Bloom's distribution over time, method effectiveness
+- Rationale: Harden 1999
+
+---
+
+## 5. Collaborative Study Plan Creation
+
+Study plans are not auto-generated. They are co-created through dialogue grounded in learning science. **The dialogue depth is optional — the minimum path is "I want to study X."**
+
+### 5.1 Planning Dialogue (Flexible Depth)
+
+The planning conversation adapts to what the student wants. The minimum is selecting concepts; the maximum is a full learning contract.
+
+**Quick path (30 seconds):**
+- "I want to study Knowledge Management models"
+- System: "You have 8 concepts in KM Models, 3 untouched. Add all to a plan with default scheduling?"
+- "Yes" → Plan created, activities generated.
+
+**Standard path (5 minutes):**
+- Concept selection + "Want to set a target date or just add to rotation?"
+- If deadline: allocate time, set checkpoint
+- "Any specific goals? Or should I push toward full Bloom's coverage?"
+
+**Deep path (10+ minutes, optional):**
+Uses the full framework when the student wants it:
+
+1. **Discover (Needs Analysis + Backward Design):** "What do you want to learn and why?" → "When you're done, what will you be able to *do*?" (Wiggins & McTighe)
+2. **Define (Goal-Setting + Bloom's):** Translate intent into Bloom's-tagged objectives (Locke & Latham). Offer choices for autonomy (Deci & Ryan SDT).
+3. **Design (Sequencing + Scheduling):** Map objectives to concepts, prerequisites, timeline. Build in spaced practice. Set checkpoints every 2-3 weeks.
+4. **Commit (WOOP + Implementation Intentions):** "When and where will you study?" → "What's most likely to get in the way?" (Gollwitzer 1999, Oettingen WOOP). Record in plan.
+5. **Adapt (SRL Cycle):** At each checkpoint: reflect, compare against plan, propose adjustments (Zimmerman self-reflection).
+
+The system asks "Want to go deeper?" at natural break points rather than forcing all 5 phases.
+
+### 5.2 Where Planning Happens
+
+The planning dialogue happens primarily on the **dashboard chat** (`/study/plan`). This is a focused conversation where the student sits down with the AI to co-create their learning path. The dashboard `/study` page shows the plan overview, progress, and upcoming checkpoints.
+
+### 5.3 Concept Discovery and Approval
+
+When new documents are ingested (upload or Zotero), new vault notes may represent concepts worth studying. The system auto-discovers these and supports batch approval:
+
+```
+Document uploaded / Zotero sync
+  -> Chef Brockett generates vault notes
+  -> Study engine detects new vault notes in concepts/
+  -> Creates concept entries with status = 'pending'
+  -> Pre-populates: title, domain/subdomain (from frontmatter),
+     vault_note_path, suggested prerequisites (from wikilinks)
+  -> Dashboard shows: "3 new concepts ready for review"
+  -> Telegram morning message includes: "3 new concepts
+     from yesterday's upload -- check dashboard to add them"
+
+Student reviews on dashboard:
+  -> Quick actions: [Add to study] [Skip] [Edit domain]
+  -> Domain-batch action: [Approve all in "Knowledge Management"]
+  -> "Add to study" -> status = 'active', generate L1-L2 activities
+  -> "Skip" -> status = 'skipped' (stays in vault, not in study system)
+
+Important: The study system's priorities are:
+  1. Spaced revision of existing material (the core daily loop)
+  2. New material from collaborative planning (student-directed)
+  3. Auto-discovered concepts from ingestion (supplementary pool)
+Auto-discovered concepts feed a pool of *available* concepts.
+They don't enter active study unless pulled in during planning
+or approved via domain batch.
+```
+
+---
+
+## 6. Activity Generation
+
+### 6.1 Generation Pipeline
+
+When a concept advances to a new Bloom's level, a container agent generates appropriate activities.
+
+```
+Concept advances to new Bloom's level
+  -> Query RAG for the concept's vault content (hybrid mode)
+  -> Build generation prompt with:
+     - Source content from vault
+     - Bloom's level + recommended method instructions
+     - Quality checklist (Wozniak + Matuschak rules)
+     - Student's current knowledge map context
+     - For comparison/synthesis: related concepts' content
+  -> Container agent generates activities as structured JSON
+  -> Quality filter (automated): reject anti-patterns
+  -> Assign SM-2 initial parameters
+  -> Store in learning_activities table
+  -> Multi-concept activities: create activity_concepts entries
+```
+
+### 6.2 Bloom's-Level Generation Guidelines
+
+**L1-L2 (Remember/Understand):** 3-5 cards per concept + 2 elaboration prompts
+**L3-L4 (Apply/Analyze):** Feynman prompts, concept map tasks, comparison tasks, case starters
+**L5-L6 (Evaluate/Create):** Synthesis prompts, Socratic dialogue starters, complex case scenarios
+
+The generator can produce any activity type at any level — these are guidelines for the default generation prompt, not constraints.
+
+### 6.3 LLM Prompting Strategy
+
+Based on Matuschak's research on LLM card generation and Gossmann's benchmarks:
+- **Analyze first, generate second:** LLM identifies key concepts and relationships before generating activities.
+- **Specify card type explicitly:** Don't just say "make flashcards."
+- **Supply the Bloom's level:** "Generate a Bloom's L3 (Apply) question."
+- **Include quality criteria in the prompt:** Reference the Wozniak/Matuschak checklist.
+- **Request multiple angles:** Different activities per concept.
+- **Use structured JSON output:** Consistent parsing and metadata.
+- **Avoid shallow pattern matching:** "Ensure question uses different vocabulary than answer."
+
+### 6.4 Student-Generated Activities
+
+Prompted at key moments where self-authoring is most valuable:
+- After a Feynman session where the student struggled (captures personal gaps)
+- When the student notices a connection the system hasn't made
+- During dashboard chat after an illuminating exchange
+- After reading a vault note (Nielsen's multi-pass Ankification)
+
+Student-authored activities stored with `author = 'student'`, scheduled by SM-2 like any other. The dashboard chat agent helps refine self-authored activities against quality rules.
+
+---
+
+## 7. Dashboard Modules
+
+### 7.1 Navigation
+
+Add "Study" link to `dashboard/src/app/layout.tsx` nav bar, between "Vault" and "Read".
+
+### 7.2 Study Overview (`/study`)
+
+Shows: today's session (activity counts by type, estimated time, start button), concept progress (per concept: Bloom's ceiling, mastery bars per level), active plans (progress, upcoming checkpoints), pending concepts (from auto-discovery with domain-batch approval), and 7-day analytics (retention, calibration, Bloom's distribution, streak).
+
+### 7.3 Dashboard Chat (`/study/chat`)
+
+A proper conversational interface connected to a study-focused container agent via the existing web channel (HTTP + SSE). Supports:
+- Multi-turn Feynman technique dialogues
+- Socratic questioning sessions
+- Case analysis discussions
+- Synthesis conversations
+- Collaborative plan creation/revision
+- Session transcripts saved and linked to concepts
+
+Extends the existing web channel (`src/channels/web.ts`) which already supports SSE streaming and session management. The key extension: persistent study conversations rather than one-off draft reviews.
+
+### 7.4 Study Session (`/study/session`)
+
+Handles all activity types with activity-type-specific UI:
+- `card_review`: Question -> text input -> submit -> reference answer + quality rating
+- `elaboration`: "Why?" prompt -> text input -> submit -> source reasoning + AI feedback
+- `self_explain`: "Explain X" -> large text area -> submit -> AI gap analysis
+- `concept_map`: Concept list -> relationship builder -> reference map
+- `comparison`: Comparison matrix -> fill cells -> submit -> expert analysis
+- `case_analysis`: Scenario -> multi-step response -> expert comparison
+- `synthesis`: Integration prompt -> essay area -> AI feedback
+- `socratic`: Redirects to dashboard chat for dialogue
+
+Pre-session: Confidence ratings (Zimmerman forethought). Post-session: Calibration feedback, reflection prompt, session summary.
+
+### 7.5 Concept Detail Page (`/study/concepts/[id]`)
+
+Per-concept view: Bloom's level mastery breakdown (6-level bar chart), activity history, method effectiveness for this concept, related concepts, vault source link, "Generate more activities" button.
+
+### 7.6 API Routes
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/api/study/plans` | GET | List plans with concept counts + progress |
+| `/api/study/plans` | POST | Create plan from dialogue results |
+| `/api/study/concepts` | GET | List concepts with mastery, Bloom's ceiling, due counts |
+| `/api/study/concepts/pending` | GET | List pending concepts for approval |
+| `/api/study/concepts/approve` | POST | Approve concept(s) — single or domain batch |
+| `/api/study/session` | GET | Build today's session (mixed activities) |
+| `/api/study/session` | POST | Create session record (pre-confidence) |
+| `/api/study/complete` | POST | Complete activity (quality, response, time) |
+| `/api/study/evaluate` | POST | Proxy answer to container agent for AI evaluation |
+| `/api/study/stats` | GET | Analytics: retention, calibration, Bloom's dist |
+| `/api/study/session/[id]/reflect` | POST | Save post-session reflection |
+
+---
+
+## 8. Audio & Podcast Generation
+
+### 8.1 Purpose
+
+Audio content serves as a **priming layer** -- passive exposure that activates concepts in working memory before the next active study session. Research on pre-training (Mayer 2002) supports this: exposure to key concepts before the main lesson reduces intrinsic cognitive load during the learning activity.
+
+Audio does NOT replace active study. It supplements it for mobile/traveling contexts.
+
+### 8.2 Implementation
+
+```
+Generation trigger:
+  - On demand: student requests "generate podcast for [topic/plan]"
+  - Scheduled: before weekly review, generate audio summaries
+    of concepts due for review
+
+Pipeline:
+  1. Select concepts (from plan, or due this week)
+  2. Claude generates a conversational script/summary from vault content
+  3. TTS converts to audio (Mistral API, already configured)
+  4. Send to Telegram via existing sendVoice() channel method
+  5. Store audio path in metadata for re-listening
+
+Content types:
+  - Concept summary (5-10 min): overview of a topic and its key relationships
+  - Review primer (3-5 min): quick recap of concepts due today
+  - Weekly digest (10-15 min): synthesis of the week's learning themes
+```
+
+### 8.3 Delivery
+
+Primary delivery via Telegram -- the student listens on their phone while traveling. Dashboard can also host an audio player for desktop listening. Audio files linked to concepts so the student can jump to active study after listening.
+
+---
+
+## 9. Agent Integration (Mr. Rogers / Study Agent)
+
+### 9.1 Two Agent Roles
+
+**Study Agent (container, dashboard chat):** Handles deep conversational methods. Spun up when the student opens `/study/chat` and stays alive for the session. Has access to vault via RAG, student profile, and study system state via IPC. Handles: Feynman, Socratic, case discussion, plan dialogue, AI evaluation.
+
+**Mr. Rogers (container, Telegram):** Mobile companion. Handles: daily reminders and nudges, quick card review, light elaboration, progress summaries, podcast delivery, concept discovery alerts. Already exists; needs study system IPC integration.
+
+### 9.2 IPC Task Contract
+
+```typescript
+// Complete an activity (from either agent)
+{ type: 'study_complete', activityId, quality, responseTimeMs?,
+  responseText?, surface: 'dashboard_chat' | 'telegram' }
+
+// Request today's due activities
+{ type: 'study_session', limit?, preferredTypes? }
+
+// Request concept status
+{ type: 'study_concept_status', conceptId?, domain? }
+
+// Trigger activity generation for advanced concepts
+{ type: 'study_generate', conceptId, bloomLevel }
+```
+
+### 9.3 Scheduled Tasks
+
+**Daily (morning, cron):**
+- Run activity generation for any gaps (safety net, respecting rate limit)
+- Build today's session composition
+- Send via Telegram: "Your session is ready -- 15 activities, ~25 min"
+- Nudge if yesterday's session was skipped (encouraging, not guilt-inducing)
+
+**Weekly (Sunday evening, cron):**
+- Progress summary: retention rate, concepts advanced, Bloom's distribution
+- Cross-domain synthesis suggestions (if applicable)
+- Plan checkpoint reminder (if due)
+
+**Monthly (1st of month, cron):**
+- Comprehensive mastery review
+- Decay detection (mastery evidence declining)
+- Growth trajectory snapshot
+- Plan adaptation recommendation
+
+---
+
+## 10. Learning Analytics
+
+### 10.1 Key Metrics
+
+| Metric | Computation | What It Tells You |
+|--------|------------|-------------------|
+| Retention rate | correct_reviews / total_reviews | Overall recall effectiveness |
+| Calibration score | pearson(confidence, actual_quality) | Metacognitive accuracy |
+| Per-level mastery | mastery_L1 through mastery_L6 per concept | Understanding depth at each Bloom's level |
+| Time to level | avg days to reach each Bloom's ceiling | Learning velocity |
+| Decay rate | regression slope of quality between reviews | Concept-specific forgetting |
+| Scaffolding dependency | avg scaffolding_level per concept | Concepts needing more support |
+| Method effectiveness | avg quality after each method type | What works for this student |
+| Bloom's distribution | % of activities at each level | Depth of engagement |
+
+### 10.2 Understanding vs. Memorization Detection
+
+The per-level mastery breakdown directly shows this. If a concept has strong mastery_L1 and mastery_L2 but weak mastery_L4+, the student is memorizing without developing understanding. The system recommends more explanation, comparison, and application activities.
+
+All raw data (quality scores, Bloom's levels, methods, response times, confidence ratings, timestamps) is logged in activity_log. Future metrics can be derived retroactively from this data without schema changes.
+
+---
+
+## 11. Implementation Phases
+
+### Phase 1: Core Engine + Cards (MVP)
+- [ ] Add all tables to `src/db.ts` (with transaction helpers)
+- [ ] Implement SM-2 in `src/study/sm2.ts` (pure functions)
+- [ ] Implement weighted evidence mastery in `src/study/mastery.ts` (pure functions)
+- [ ] Build concept progression engine in `src/study/engine.ts` (L1-L3 recommendations)
+- [ ] Build activity generator in `src/study/generator.ts` (cards + elaboration)
+- [ ] Build session builder (new material block + review block)
+- [ ] Write comprehensive tests
+- [ ] Create dashboard `/study` page with concept list, Bloom's mastery bars, due counts
+- [ ] Create dashboard `/study/session` page (card_review + elaboration)
+- [ ] Wire core API routes (including domain-batch concept approval)
+- [ ] Add daily reminder scheduled task (Telegram)
+- [ ] Add concept discovery queue (pending concepts from ingestion)
+
+### Phase 2: Deep Methods + Dashboard Chat
+- [ ] Add L4-L6 activity generation for all types
+- [ ] Build dashboard chat interface (`/study/chat`) extending web channel
+- [ ] Implement Feynman and Socratic dialogue in study agent
+- [ ] Build comparison matrix and concept map UI
+- [ ] Expand session builder with stretch block
+- [ ] Wire AI evaluation for L3+ (container agents, session-persistent)
+- [ ] Add weekly scheduled task
+
+### Phase 3: Planning + Metacognition
+- [ ] Build collaborative planning dialogue (`/study/plan`)
+- [ ] Implement flexible-depth planning framework in `src/study/planner.ts`
+- [ ] Add pre/post session confidence tracking and calibration
+- [ ] Build analytics dashboard
+- [ ] Implement scaffolding hint system (5 levels)
+- [ ] Add plan checkpoints and adaptation dialogue
+- [ ] Add monthly scheduled task
+- [ ] Concept detail page
+
+### Phase 4: Audio + Mobile + Refinement
+- [ ] Audio/podcast generation pipeline (`src/study/audio.ts`)
+- [ ] Telegram podcast delivery
+- [ ] Wire Mr. Rogers IPC for study system
+- [ ] Student-generated activity prompting in dashboard chat
+- [ ] Post-session activity generation (automatic, rate-limited)
+- [ ] Prerequisite awareness flags for L4+ activities
+- [ ] Staleness detection (source_chunk_hash)
+- [ ] Vault note deletion handling (archive linked concepts)
+- [ ] RSVP vault integration (deep-link from activities)
+- [ ] FSRS migration evaluation
+
+---
+
+## 12. Future Considerations
+
+These are noted for later implementation, not designed in detail now:
+
+- **Data backup:** Periodic SQLite backup (cron job). Critical once learning history accumulates. Address during Mac Mini deployment.
+- **Vault note deletion:** When a vault note is deleted, mark linked concepts as `archived` rather than deleting — learning history remains valuable. The ingestion pipeline already watches the vault.
+- **Offline/degraded mode:** Dashboard could work read-only without the main process (show due cards, self-rate, queue completions). Low priority — launchd auto-start handles the common case.
+- **Export:** Anki-compatible export of SR cards for portability. CSV export of learning history.
+
+---
+
+## 13. Vault Knowledge Gaps
+
+RAG searches revealed the vault lacks content on core learning science:
+
+**Missing (high priority):**
+- Spaced repetition algorithms and research (Ebbinghaus, Cepeda, Wozniak)
+- Active recall / testing effect (Roediger & Karpicke 2006, Karpicke 2012)
+- Bloom's Taxonomy revised (Anderson & Krathwohl 2001)
+- Mastery learning (Bloom 1968)
+- Zone of Proximal Development (Vygotsky 1978)
+- Interleaving and distributed practice (Cepeda 2006)
+- Self-regulated learning (Zimmerman 2002)
+- Bruner's spiral curriculum (1960)
+
+**Already in vault (leverage these):**
+- Cognitive Load Theory (Sweller, well-covered)
+- Working memory and concept formation (Cowan 2014)
+- Knowledge construction and comprehension
+- Formative assessment and feedback loops
+- Learning analytics and adaptive learning
+
+---
+
+## 14. Sources
+
+### Learning Science Foundations
+- Dunlosky, J. et al. (2013). Improving students' learning with effective techniques. *Psychological Science in the Public Interest*, 14(1), 4-58
+- Karpicke, J.D. & Blunt, J.R. (2011). Retrieval practice produces more learning than elaborative studying. *Science*, 331(6018), 772-775
+- Karpicke, J.D. (2012). Retrieval-based learning. *Current Directions in Psychological Science*, 21(3), 157-163
+- Bjork, R.A. (1994). Memory and metamemory considerations in training. *Metacognition*
+- Bjork, E.L. & Bjork, R.A. (2011). Making things hard on yourself, but in a good way. *Psychology and the Real World*
+- Kosmyna, N. et al. (2025). Your brain on ChatGPT: Cognitive debt from AI use. *Nature*
+- Sweller, J. (1988). Cognitive load during problem solving. *Cognitive Science*, 12(2), 257-285
+- Mayer, R.E. (2002). Cognitive Theory of Multimedia Learning. *Cambridge Handbook of Multimedia Learning*
+- Zimmerman, B.J. (2002). Becoming a self-regulated learner. *Theory Into Practice*, 41(2), 64-70
+- Bloom, B.S. (1968). Learning for mastery. *Evaluation Comment*, 1(2), 1-12
+- Cepeda, N.J. et al. (2008). Spacing effects in learning. *Psychological Science*, 19(11), 1095-1102
+
+### Method-Specific Research
+- Pressley, M. et al. (1987). Elaborative interrogation facilitates acquisition of confusing facts. *Journal of Educational Psychology*
+- Chi, M.T.H. et al. (1994). Eliciting self-explanations improves understanding. *Cognitive Science*, 18(3), 439-477
+- Nestojko, J.F. et al. (2014). Expecting to teach enhances learning. *Memory & Cognition*, 42, 1038-1048
+- Novak, J.D. & Gowin, D.B. (1984). *Learning How to Learn*. Cambridge University Press
+- Nesbit, J.C. & Adesope, O.O. (2006). Learning with concept and knowledge maps. *Review of Educational Research*
+- Alfieri, L. et al. (2013). Learning through case comparisons. *Educational Psychologist*, 48(2), 87-113
+- Gentner, D. (1983). Structure-mapping: A theoretical framework for analogy. *Cognitive Science*, 7(2), 155-170
+- Nkhoma, M. et al. (2016). Unpacking the revised Bloom's taxonomy in CBL. *Education + Training*
+- Hwang, H. (2025). Undesirable difficulty of interleaved practice. *Language Learning*
+- Wood, D., Bruner, J.S. & Ross, G. (1976). The role of tutoring in problem solving. *JCPP*, 17(2), 89-100
+- Vygotsky, L.S. (1978). *Mind in Society*. Harvard University Press
+- Bruner, J.S. (1960). *The Process of Education*. Harvard University Press
+
+### Study Plan Design
+- Knowles, M. (1975). *Self-Directed Learning: A Guide for Learners and Teachers*
+- Wiggins, G. & McTighe, J. (2005). *Understanding by Design* (2nd ed.). ASCD
+- Locke, E.A. & Latham, G.P. (2002). Building a practically useful theory of goal setting. *American Psychologist*, 57(9), 705-717
+- Gollwitzer, P.M. (1999). Implementation intentions: Strong effects of simple plans. *American Psychologist*, 54(7), 493-503
+- Oettingen, G. (2012). Future thought and behaviour change. *European Review of Social Psychology*, 23(1), 1-63
+- Deci, E.L. & Ryan, R.M. (2000). Self-determination theory. *Contemporary Educational Psychology*, 25(1), 54-67
+- Dweck, C.S. (1986). Motivational processes affecting learning. *American Psychologist*, 41(10), 1040-1048
+
+### Card Design
+- Wozniak, P. (1999). 20 Rules of Formulating Knowledge (supermemo.com)
+- Matuschak, A. (2020). How to write good prompts (andymatuschak.org/prompts)
+- Nielsen, M. (2018). Augmenting long-term memory (augmentingcognition.com)
+
+### AI Tutoring
+- UK RCT 2025 -- AI Socratic tutors in classrooms (arXiv: 2512.23633)
+- ECAI 2024 -- Socratic chatbot for critical thinking (arXiv: 2409.05511)
+- Gossmann, A. -- Comparing LLMs for flashcard generation (alexejgossmann.com)
+
+### Algorithms
+- Wozniak, P. (1987). SM-2 algorithm (SuperMemo)
+
+---
+
+## 15. Open Questions — All Resolved
+
+1. **Activity generation timing** — Batch per Bloom's level advancement. Post-session generation (primary) + morning safety net. Rate limited to 10 concepts per cycle.
+2. **Cross-domain synthesis** — Graduated: within-domain automatic (bloom_ceiling 4+), cross-domain proposed and confirmed by student.
+3. **AI evaluation threshold** — Self-rated for L1-L2; self-rated + AI review for L2-L3; AI-rated for L4-L6. Container agents via Claude Max subscription (no API cost). Single container reused per session.
+4. **Dashboard vs. Telegram** — Dashboard chat is primary for deep work (Feynman, Socratic, cases, planning). Telegram is mobile companion (reminders, quick review, podcasts). Mr. Rogers nudges actively but doesn't restrict.
+5. **Student-generated activities** — Prompted at key moments (post-struggle, post-insight, post-reading). Not always available, but actively suggested when valuable.
+6. **Session flexibility** — AI-recommended with full student control. System builds session, shows reasoning, suggests strongly. Student can adjust anything — swap activities, skip blocks, switch to free study. No enforcement, no guilt mechanics. Balances autonomy (Deci & Ryan SDT) with desirable difficulties (Bjork) through transparent communication.
+7. **Concept approval** — Domain-batch approval supported. Auto-discovered concepts enter a pool; they don't enter active study without student action. System priorities: revision > planned new material > discovered concepts.
+8. **Planning depth** — Optional. Minimum: select concepts + defaults. Maximum: full 5-phase learning contract. Engine handles missing fields with sensible defaults.

--- a/src/study/generator.ts
+++ b/src/study/generator.ts
@@ -111,7 +111,6 @@ export async function generateActivities(
     singleTurn: true,
     chatJid: 'internal:study-generator',
     isMain: false,
-    ipcNamespace: 'study-generator',
   };
 
   // 7. Fire and forget — IPC handler processes the output asynchronously


### PR DESCRIPTION
## Summary

Turns the concept detail page into a practice hub and wires up the "Generate more" button that previously just `alert()`-ed.

- **Practice button** launches a study session scoped to a single concept. Concept-focused sessions pull *all* activities for the concept (not just due), since the user is explicitly choosing to practice this now — their intent overrides the SRS queue.
- **Generate more button** now actually triggers activity generation via a new `/api/study/generate` endpoint that calls `requestGeneration`. Includes user-visible status feedback.
- **Activity list redesign**: shows the prompt text itself plus color-coded type/state badges, due indicator, and card type — much more useful than the old type-only table.
- Minor: `getConceptDetail` now exposes `prompt` and `cardType`; drops unused `ipcNamespace` from generator config.

Also includes a second commit adding the sprint plans, specs, and tutoring research notes that were sitting untracked in the repo — documents that shaped S0–S6 design decisions and should live in version control.

## Test plan

- [ ] Navigate to `/study/concepts/[id]` — activity list shows prompts and badges
- [ ] Click **Practice** — session loads with all activities for that concept
- [ ] Click **Generate more** at low Bloom level — status message appears; new activities show up within a minute
- [ ] `/study/session?planId=X` still works unchanged
- [ ] `/study/session` (no params) still uses due-activity queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)