### PR TITLE
feat(speech): migrate TTS/STT from Mistral to Google Gemini

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,8 @@ VAULT_DIR=./vault
 UPLOAD_DIR=./upload
 DASHBOARD_PORT=3100
 
-# --- Mistral API (TTS + STT) ---
-MISTRAL_API_KEY=
+# --- Gemini API (TTS + STT) ---
+GEMINI_API_KEY=
 
 # --- LightRAG ---
 LIGHTRAG_PORT=9621

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ Key env vars (set in `.env` or shell). All have sensible defaults:
 | `MAX_CONCURRENT_CONTAINERS` | `5` | Parallel container limit |
 | `EXTRACTION_TIMEOUT` | `600000` (10min) | Docling per-document timeout |
 | `DASHBOARD_PORT` | `3100` | Dashboard web UI port |
-| `MISTRAL_API_KEY` | — | Mistral API key (TTS + STT) |
+| `GEMINI_API_KEY` | — | Gemini API key (TTS + STT) |
 | `LIGHTRAG_LLM_BINDING` | `openai` | LightRAG LLM provider |
 | `LIGHTRAG_LLM_MODEL` | `gpt-4o-mini` | LightRAG LLM model |
 | `LIGHTRAG_EMBED_BINDING` | `openai` | LightRAG embedding provider |

--- a/container/agent-runner/src/gemini-tts-request.test.ts
+++ b/container/agent-runner/src/gemini-tts-request.test.ts
@@ -44,4 +44,19 @@ describe('buildGeminiTtsRequest', () => {
       body.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName,
     ).toBe('Charon');
   });
+
+  it('produces the exact Gemini v1beta REST body shape', () => {
+    const body = buildGeminiTtsRequest({ text: 'hi', voiceName: 'Kore' });
+    expect(body).toEqual({
+      contents: [{ parts: [{ text: 'hi' }] }],
+      generationConfig: {
+        responseModalities: ['AUDIO'],
+        speechConfig: {
+          voiceConfig: {
+            prebuiltVoiceConfig: { voiceName: 'Kore' },
+          },
+        },
+      },
+    });
+  });
 });

--- a/container/agent-runner/src/gemini-tts-request.test.ts
+++ b/container/agent-runner/src/gemini-tts-request.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { buildGeminiTtsRequest } from './gemini-tts-request.js';
+
+describe('buildGeminiTtsRequest', () => {
+  it('sends text unchanged when stylePrompt is omitted', () => {
+    const body = buildGeminiTtsRequest({
+      text: 'Hello world',
+      voiceName: 'Kore',
+    });
+    expect(body.contents[0].parts[0].text).toBe('Hello world');
+  });
+
+  it('sends text unchanged when stylePrompt is an empty string', () => {
+    const body = buildGeminiTtsRequest({
+      text: 'Hello world',
+      stylePrompt: '',
+      voiceName: 'Kore',
+    });
+    expect(body.contents[0].parts[0].text).toBe('Hello world');
+  });
+
+  it('sends text unchanged when stylePrompt is whitespace only', () => {
+    const body = buildGeminiTtsRequest({
+      text: 'Hello world',
+      stylePrompt: '   \t  ',
+      voiceName: 'Kore',
+    });
+    expect(body.contents[0].parts[0].text).toBe('Hello world');
+  });
+
+  it('prepends a trimmed stylePrompt with a colon separator', () => {
+    const body = buildGeminiTtsRequest({
+      text: 'Hello world',
+      stylePrompt: '  Say warmly and slowly  ',
+      voiceName: 'Kore',
+    });
+    expect(body.contents[0].parts[0].text).toBe('Say warmly and slowly: Hello world');
+  });
+
+  it('requests AUDIO modality with the specified prebuilt voice', () => {
+    const body = buildGeminiTtsRequest({ text: 'hi', voiceName: 'Charon' });
+    expect(body.generationConfig.responseModalities).toEqual(['AUDIO']);
+    expect(
+      body.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName,
+    ).toBe('Charon');
+  });
+});

--- a/container/agent-runner/src/gemini-tts-request.ts
+++ b/container/agent-runner/src/gemini-tts-request.ts
@@ -1,0 +1,48 @@
+/**
+ * Body builder for the Gemini generateContent TTS endpoint.
+ *
+ * Shapes the v1beta REST request body in camelCase, optionally prepending a
+ * trimmed style prompt as "{stylePrompt}: {text}". Empty or whitespace-only
+ * style prompts are treated as absent so callers don't need to pre-filter.
+ */
+
+export interface GeminiTtsRequestBody {
+  contents: Array<{
+    parts: Array<{ text: string }>;
+  }>;
+  generationConfig: {
+    responseModalities: ['AUDIO'];
+    speechConfig: {
+      voiceConfig: {
+        prebuiltVoiceConfig: {
+          voiceName: string;
+        };
+      };
+    };
+  };
+}
+
+export function buildGeminiTtsRequest(args: {
+  text: string;
+  stylePrompt?: string;
+  voiceName: string;
+}): GeminiTtsRequestBody {
+  const { text, stylePrompt, voiceName } = args;
+
+  const trimmedStyle = stylePrompt?.trim();
+  const prompt = trimmedStyle ? `${trimmedStyle}: ${text}` : text;
+
+  return {
+    contents: [{ parts: [{ text: prompt }] }],
+    generationConfig: {
+      responseModalities: ['AUDIO'],
+      speechConfig: {
+        voiceConfig: {
+          prebuiltVoiceConfig: {
+            voiceName,
+          },
+        },
+      },
+    },
+  };
+}

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -376,7 +376,7 @@ server.tool(
   {
     text: z
       .string()
-      .max(50000)
+      .max(TTS_MAX_TEXT_LENGTH)
       .describe(
         'Text to synthesize. You can embed Gemini audio tags like [warmly], [slowly], [whispering], [excitedly] inline to color specific moments within the speech.',
       ),

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -10,6 +10,8 @@ import { z } from 'zod';
 import fs from 'fs';
 import path from 'path';
 import { CronExpressionParser } from 'cron-parser';
+import { pcmToWav } from './pcm-to-wav.js';
+import { buildGeminiTtsRequest } from './gemini-tts-request.js';
 
 const IPC_DIR = '/workspace/ipc';
 const MESSAGES_DIR = path.join(IPC_DIR, 'messages');
@@ -339,94 +341,126 @@ Use available_groups.json to find the JID for a group. The folder name must be c
 
 const AUDIO_DIR = '/workspace/group/audio';
 const TTS_MAX_TEXT_LENGTH = 50000;
-const MISTRAL_TTS_URL = 'https://api.mistral.ai/v1/audio/speech';
-// Default voice: "Paul - Neutral" (en_us, male, casual)
-const MISTRAL_DEFAULT_VOICE_ID = 'c69964a6-ab8b-4f8a-9465-ec0925096ec8';
+
+// Voice is a single prebuilt. To try another, change this constant.
+// Kore is a balanced multilingual default. Other good starting points:
+// "Charon", "Puck", "Zephyr", "Aoede". Full list: 30 prebuilts in Gemini TTS docs.
+const GEMINI_TTS_VOICE = 'Kore';
+
+// TTS model is currently a preview. If it is deprecated or promoted to GA,
+// swap this constant — it is the only coupling point to the preview name.
+const GEMINI_TTS_MODEL = 'gemini-3.1-flash-tts-preview';
+const GEMINI_TTS_URL = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_TTS_MODEL}:generateContent`;
+
+interface GeminiTtsResponse {
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{
+        text?: string;
+        inlineData?: {
+          data?: string;
+          mimeType?: string;
+        };
+      }>;
+    };
+    finishReason?: string;
+  }>;
+  promptFeedback?: {
+    blockReason?: string;
+  };
+}
 
 server.tool(
   'synthesize_speech',
   'Convert text to speech audio. Returns a file path to the generated WAV audio. Call send_voice with the returned path to deliver it as a Telegram voice message. Everything is pre-configured — just call this tool.',
   {
-    text: z.string().max(50000).describe('Text to synthesize (max 50000 characters). Mistral handles long text via server-side interleaving.'),
+    text: z
+      .string()
+      .max(50000)
+      .describe(
+        'Text to synthesize. You can embed Gemini audio tags like [warmly], [slowly], [whispering], [excitedly] inline to color specific moments within the speech.',
+      ),
+    style_prompt: z
+      .string()
+      .optional()
+      .describe(
+        'Natural-language whole-utterance style directive, e.g. "Say warmly and slowly" or "Speak with calm encouragement". Prepended to the text before synthesis. Use style_prompt for whole-utterance tone; use [inline tags] inside text for moment-specific expression.',
+      ),
   },
   async (args) => {
+    const errorResult = (text: string) => ({
+      isError: true,
+      content: [{ type: 'text' as const, text }],
+    });
+
     if (!args.text || args.text.trim().length === 0) {
-      return {
-        content: [{ type: 'text' as const, text: 'Error: text cannot be empty.' }],
-        isError: true,
-      };
+      return errorResult('Error: text cannot be empty.');
     }
     if (args.text.length > TTS_MAX_TEXT_LENGTH) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Error: text too long (${args.text.length} chars, max ${TTS_MAX_TEXT_LENGTH}).`,
-          },
-        ],
-        isError: true,
-      };
+      return errorResult(
+        `Error: text too long (${args.text.length} chars, max ${TTS_MAX_TEXT_LENGTH}).`,
+      );
     }
 
-    const apiKey = process.env.MISTRAL_API_KEY;
+    const apiKey = process.env.GEMINI_API_KEY;
     if (!apiKey) {
-      return {
-        content: [
-          { type: 'text' as const, text: 'Error: MISTRAL_API_KEY is not set in the container environment.' },
-        ],
-        isError: true,
-      };
+      return errorResult('Error: GEMINI_API_KEY is not set in the container environment.');
     }
 
     try {
-      const response = await fetch(MISTRAL_TTS_URL, {
+      const response = await fetch(GEMINI_TTS_URL, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
+          'x-goog-api-key': apiKey,
         },
-        body: JSON.stringify({
-          model: 'voxtral-mini-tts-2603',
-          input: args.text,
-          voice_id: MISTRAL_DEFAULT_VOICE_ID,
-          response_format: 'wav',
-        }),
+        body: JSON.stringify(
+          buildGeminiTtsRequest({
+            text: args.text,
+            stylePrompt: args.style_prompt,
+            voiceName: GEMINI_TTS_VOICE,
+          }),
+        ),
         signal: AbortSignal.timeout(300_000),
       });
 
       if (!response.ok) {
         const errText = await response.text().catch(() => 'unknown error');
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: `Error: TTS service returned ${response.status}: ${errText}`,
-            },
-          ],
-          isError: true,
-        };
+        return errorResult(`Error: TTS service returned ${response.status}: ${errText}`);
       }
 
-      // Mistral returns JSON with base64-encoded audio_data
-      const responseJson = await response.json() as { audio_data?: string };
-      if (!responseJson.audio_data) {
-        return {
-          content: [
-            { type: 'text' as const, text: 'Error: TTS response missing audio_data field.' },
-          ],
-          isError: true,
-        };
+      const responseJson = (await response.json()) as GeminiTtsResponse;
+      const candidate = responseJson.candidates?.[0];
+      const part = candidate?.content?.parts?.[0];
+      const audioB64 = part?.inlineData?.data;
+
+      if (!audioB64) {
+        // Modality mismatch: model returned text instead of audio.
+        if (part?.text) {
+          return errorResult(
+            `Error: TTS model returned text instead of audio (modality negotiation failed). Model said: ${part.text}`,
+          );
+        }
+        // Generic missing-audio: include diagnostics so callers can debug safety
+        // filter or modality negotiation failures.
+        const finishReason = candidate?.finishReason;
+        const blockReason = responseJson.promptFeedback?.blockReason;
+        return errorResult(
+          `Error: TTS response missing inlineData.data. finishReason=${finishReason ?? 'unknown'} blockReason=${blockReason ?? 'none'}`,
+        );
       }
-      const audioBuffer = Buffer.from(responseJson.audio_data, 'base64');
+
+      const pcm = Buffer.from(audioB64, 'base64');
+      const wavBuffer = pcmToWav(pcm);
 
       fs.mkdirSync(AUDIO_DIR, { recursive: true });
       const random = Math.random().toString(36).slice(2, 6);
       const filename = `tts-${Date.now()}-${random}.wav`;
       const filepath = path.join(AUDIO_DIR, filename);
-      fs.writeFileSync(filepath, audioBuffer);
+      fs.writeFileSync(filepath, wavBuffer);
 
-      // Estimate duration from WAV size (24kHz, 16-bit mono = 48000 bytes/sec, minus 44-byte header)
-      const durationSeconds = Math.max(0, Math.round((audioBuffer.length - 44) / 48000));
+      // Estimate duration from WAV size (24kHz mono × 2 bytes/sample = 48000 bytes/sec, minus 44-byte header)
+      const durationSeconds = Math.max(0, Math.round((wavBuffer.length - 44) / 48000));
 
       return {
         content: [
@@ -442,10 +476,8 @@ server.tool(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       return {
-        content: [
-          { type: 'text' as const, text: `Error: TTS request failed: ${message}` },
-        ],
         isError: true,
+        content: [{ type: 'text' as const, text: `Error: TTS request failed: ${message}` }],
       };
     }
   },

--- a/container/agent-runner/src/pcm-to-wav.test.ts
+++ b/container/agent-runner/src/pcm-to-wav.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { pcmToWav } from './pcm-to-wav.js';
+
+describe('pcmToWav', () => {
+  it('prepends a 44-byte RIFF/WAVE header to the PCM buffer', () => {
+    const pcm = Buffer.alloc(100, 0xAB);
+    const wav = pcmToWav(pcm);
+    expect(wav.length).toBe(100 + 44);
+    expect(wav.slice(0, 4).toString('ascii')).toBe('RIFF');
+    expect(wav.slice(8, 12).toString('ascii')).toBe('WAVE');
+    expect(wav.slice(12, 16).toString('ascii')).toBe('fmt ');
+    expect(wav.slice(36, 40).toString('ascii')).toBe('data');
+    expect(wav.slice(44).equals(pcm)).toBe(true);
+  });
+
+  it('encodes fmt chunk for 24kHz mono 16-bit little-endian PCM', () => {
+    const pcm = Buffer.alloc(10);
+    const wav = pcmToWav(pcm);
+    expect(wav.readUInt32LE(16)).toBe(16);
+    expect(wav.readUInt16LE(20)).toBe(1);
+    expect(wav.readUInt16LE(22)).toBe(1);
+    expect(wav.readUInt32LE(24)).toBe(24000);
+    expect(wav.readUInt32LE(28)).toBe(48000);
+    expect(wav.readUInt16LE(32)).toBe(2);
+    expect(wav.readUInt16LE(34)).toBe(16);
+  });
+
+  it('writes the RIFF and data chunk sizes correctly', () => {
+    const pcm = Buffer.alloc(1000);
+    const wav = pcmToWav(pcm);
+    expect(wav.readUInt32LE(4)).toBe(1000 + 36);
+    expect(wav.readUInt32LE(40)).toBe(1000);
+  });
+
+  it('handles an empty PCM buffer', () => {
+    const wav = pcmToWav(Buffer.alloc(0));
+    expect(wav.length).toBe(44);
+    expect(wav.readUInt32LE(4)).toBe(36);
+    expect(wav.readUInt32LE(40)).toBe(0);
+  });
+});

--- a/container/agent-runner/src/pcm-to-wav.ts
+++ b/container/agent-runner/src/pcm-to-wav.ts
@@ -1,0 +1,35 @@
+// Gemini TTS returns raw 24kHz mono 16-bit little-endian PCM, but the host
+// ffmpeg WAV→OGG pipeline expects a WAV file on disk. This helper prepends
+// the standard 44-byte RIFF/WAVE header so the downstream pipeline works
+// unchanged.
+
+export function pcmToWav(pcm: Buffer): Buffer {
+  const sampleRate = 24000;
+  const numChannels = 1;
+  const bitsPerSample = 16;
+  const byteRate = sampleRate * numChannels * (bitsPerSample / 8);
+  const blockAlign = numChannels * (bitsPerSample / 8);
+
+  const header = Buffer.alloc(44);
+
+  // RIFF chunk descriptor
+  header.write('RIFF', 0, 'ascii');
+  header.writeUInt32LE(pcm.length + 36, 4);
+  header.write('WAVE', 8, 'ascii');
+
+  // fmt sub-chunk
+  header.write('fmt ', 12, 'ascii');
+  header.writeUInt32LE(16, 16); // fmt chunk size (PCM)
+  header.writeUInt16LE(1, 20); // audio format (PCM = 1)
+  header.writeUInt16LE(numChannels, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(byteRate, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(bitsPerSample, 34);
+
+  // data sub-chunk
+  header.write('data', 36, 'ascii');
+  header.writeUInt32LE(pcm.length, 40);
+
+  return Buffer.concat([header, pcm]);
+}

--- a/container/agent-runner/src/pcm-to-wav.ts
+++ b/container/agent-runner/src/pcm-to-wav.ts
@@ -1,14 +1,16 @@
-// Gemini TTS returns raw 24kHz mono 16-bit little-endian PCM, but the host
-// ffmpeg WAV→OGG pipeline expects a WAV file on disk. This helper prepends
-// the standard 44-byte RIFF/WAVE header so the downstream pipeline works
-// unchanged.
+/**
+ * Gemini TTS returns raw 24kHz mono 16-bit little-endian PCM, but the host
+ * ffmpeg WAV→OGG pipeline expects a WAV file on disk. This helper prepends
+ * the standard 44-byte RIFF/WAVE header so the downstream pipeline works
+ * unchanged.
+ */
 
 export function pcmToWav(pcm: Buffer): Buffer {
-  const sampleRate = 24000;
-  const numChannels = 1;
-  const bitsPerSample = 16;
-  const byteRate = sampleRate * numChannels * (bitsPerSample / 8);
-  const blockAlign = numChannels * (bitsPerSample / 8);
+  const SAMPLE_RATE = 24000;
+  const CHANNELS = 1;
+  const BITS_PER_SAMPLE = 16;
+  const BYTE_RATE = SAMPLE_RATE * CHANNELS * (BITS_PER_SAMPLE / 8);
+  const BLOCK_ALIGN = CHANNELS * (BITS_PER_SAMPLE / 8);
 
   const header = Buffer.alloc(44);
 
@@ -21,11 +23,11 @@ export function pcmToWav(pcm: Buffer): Buffer {
   header.write('fmt ', 12, 'ascii');
   header.writeUInt32LE(16, 16); // fmt chunk size (PCM)
   header.writeUInt16LE(1, 20); // audio format (PCM = 1)
-  header.writeUInt16LE(numChannels, 22);
-  header.writeUInt32LE(sampleRate, 24);
-  header.writeUInt32LE(byteRate, 28);
-  header.writeUInt16LE(blockAlign, 32);
-  header.writeUInt16LE(bitsPerSample, 34);
+  header.writeUInt16LE(CHANNELS, 22);
+  header.writeUInt32LE(SAMPLE_RATE, 24);
+  header.writeUInt32LE(BYTE_RATE, 28);
+  header.writeUInt16LE(BLOCK_ALIGN, 32);
+  header.writeUInt16LE(BITS_PER_SAMPLE, 34);
 
   // data sub-chunk
   header.write('data', 36, 'ascii');

--- a/container/agent-runner/tsconfig.json
+++ b/container/agent-runner/tsconfig.json
@@ -11,5 +11,5 @@
     "declaration": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,302 @@
+# universityClaw Architecture
+
+Four diagrams, zooming in: **system context → running services → NanoClaw internals → end-to-end flows**.
+
+All diagrams are [Mermaid](https://mermaid.js.org/) and render natively on GitHub. Edit the source below to keep them in sync with the code.
+
+Quick map of where things live:
+
+| Concern | Code |
+|---|---|
+| Orchestrator + startup | [src/index.ts](../src/index.ts) |
+| Channel registry + implementations | [src/channels/](../src/channels/) |
+| Outbound formatting + routing | [src/router.ts](../src/router.ts) |
+| Agent container spawn | [src/container-runner.ts](../src/container-runner.ts) |
+| Host ↔ container IPC | [src/ipc.ts](../src/ipc.ts), `data/ipc/` |
+| Cron-style tasks | [src/task-scheduler.ts](../src/task-scheduler.ts) |
+| Document ingestion | [src/ingestion/](../src/ingestion/) |
+| RAG indexing + client | [src/rag/](../src/rag/) |
+| SQLite schema (Drizzle) | [src/db/schema/](../src/db/schema/) |
+| Web UI | [dashboard/](../dashboard/) |
+
+---
+
+## 1. System context
+
+Who uses universityClaw, and what external systems does it depend on?
+
+```mermaid
+flowchart LR
+    simon([Simon])
+
+    tg["Telegram<br/>Bot API"]
+    claude["Claude API"]
+    gemini["Gemini API<br/>(TTS / STT)"]
+    zotero["Zotero<br/>library"]
+
+    subgraph uc["universityClaw (local host)"]
+        core["NanoClaw core<br/><sub>channels · agent runner ·<br/>ingestion · RAG indexer</sub>"]
+        dash["Dashboard<br/><sub>Next.js UI</sub>"]
+        vault[("Obsidian vault<br/><sub>concepts, sources, profile</sub>")]
+    end
+
+    simon <-->|"chat: 'Mr. Rogers …'"| tg
+    tg <-->|gramjs| core
+
+    simon <-->|browser| dash
+    simon -->|"drop PDFs → upload/"| core
+    simon <-->|edit notes| vault
+
+    core <-->|"auto-ingest"| zotero
+    core -->|"prompts (via local OneCLI gateway)"| claude
+    core -->|"audio synthesis + transcription"| gemini
+
+    core <--> vault
+    dash <--> vault
+```
+
+**Notes**
+
+- OneCLI is a **local** credential gateway (`:10254`), not an external service — it proxies to Claude (and others) while keeping secrets off the container.
+- Telegram is the only remote channel wired up in `src/channels/` today (`web.ts` is served by the dashboard). WhatsApp/Slack/Discord/Gmail exist as optional skill branches.
+
+---
+
+## 2. Running services
+
+Four long-lived processes run on the host. Each has a different lifecycle and port.
+
+```mermaid
+flowchart TB
+    simon([Simon])
+    tg["Telegram"]
+    claudeapi[["Claude API"]]
+
+    subgraph host["Host machine"]
+        direction TB
+
+        subgraph procs["Node / Python processes"]
+            core["NanoClaw<br/><sub>tsx src/index.ts</sub>"]
+            rag["LightRAG<br/><sub>:9621 · python venv</sub>"]
+            dash["Dashboard<br/><sub>:3100 · next dev</sub>"]
+        end
+
+        subgraph docker["Docker"]
+            onecli["OneCLI gateway<br/><sub>:10254<br/>onecli-app-1 + postgres</sub>"]
+            agents["Agent containers<br/><sub>spawned per request/task</sub>"]
+        end
+
+        subgraph fs["Filesystem"]
+            db[("SQLite<br/>store/messages.db")]
+            vault[("vault/<br/><sub>concepts · sources ·<br/>drafts · profile</sub>")]
+            upload[("upload/")]
+            ipc[("data/ipc/")]
+        end
+    end
+
+    simon -->|":3100"| dash
+    simon -->|drop files| upload
+    tg <--> core
+
+    core --> db
+    core -->|watches| upload
+    core <-->|watches & writes| vault
+    core -->|polls| ipc
+    core -->|index / query| rag
+    core -->|spawns| agents
+
+    agents -->|"r/w group folder,<br/>read vault"| fs
+    agents -->|writes output JSON| ipc
+    agents -->|tool calls + LLM| onecli
+    onecli -->|proxies| claudeapi
+
+    dash --> db
+    dash --> vault
+    dash -->|"/api/…"| core
+    dash -->|"retrieval"| rag
+```
+
+**Lifecycle at a glance**
+
+| Service | How it's started | Port |
+|---|---|---|
+| OneCLI | `docker restart onecli-app-1 onecli-postgres-1` | 10254 |
+| LightRAG | `.venv/bin/python3 -m lightrag.api.lightrag_server …` | 9621 |
+| Dashboard | `cd dashboard && npm run dev` | 3100 |
+| NanoClaw | `npm run dev` | — |
+| Agent containers | spawned by NanoClaw on demand | — (IPC via files) |
+
+See [CLAUDE.md](../CLAUDE.md#start-everything) for the copy-pasteable startup sequence.
+
+---
+
+## 3. NanoClaw internals
+
+Components inside the NanoClaw Node process — what `src/index.ts` boots and how they wire up.
+
+```mermaid
+flowchart TB
+    subgraph ch["Channels · src/channels/"]
+        reg["registry.ts<br/><sub>registerChannel /<br/>findChannel</sub>"]
+        tg["telegram.ts"]
+        web["web.ts"]
+    end
+
+    subgraph inbound["Inbound path"]
+        ml["message loop<br/><sub>polls DB ~1s</sub>"]
+        gq["GroupQueue<br/><sub>serialize per group</sub>"]
+    end
+
+    subgraph run["Agent execution"]
+        cr["container-runner.ts<br/><sub>runContainerAgent()</sub>"]
+        crt["container-runtime.ts<br/><sub>docker / apple-container<br/>abstraction</sub>"]
+    end
+
+    subgraph outbound["Outbound path"]
+        ipcw["ipc.ts<br/><sub>watches data/ipc/</sub>"]
+        router["router.ts<br/><sub>formatOutbound /<br/>routeOutbound</sub>"]
+    end
+
+    subgraph bg["Background loops"]
+        ts["task-scheduler.ts<br/><sub>cron / interval</sub>"]
+        ing["ingestion/pipeline.ts<br/><sub>upload → vault</sub>"]
+        idx["rag/indexer.ts<br/><sub>vault → LightRAG</sub>"]
+        rc["remote-control.ts"]
+    end
+
+    db[("SQLite<br/>(Drizzle schemas)")]
+    main(["index.ts · main()"])
+
+    main --> ch
+    main --> inbound
+    main --> run
+    main --> outbound
+    main --> bg
+
+    tg -.onMessage.-> db
+    web -.onMessage.-> db
+
+    ml --> db
+    ml --> gq
+    gq --> cr
+    cr --> crt
+
+    cr -. spawns agent .-> ipcw
+    ipcw --> db
+
+    gq --> router
+    router --> tg
+    router --> web
+
+    ts --> cr
+    ing --> cr
+    idx --> db
+```
+
+**Key design points**
+
+- **Channel self-registration.** Each channel calls `registerChannel()` at import time; `src/channels/index.ts` is a barrel that triggers those imports.
+- **DB is the message bus.** Channels `storeMessage()` on receipt; the message loop polls `getNewMessages()` since `lastTimestamp`. This makes crash recovery trivial — no in-memory queue to lose.
+- **GroupQueue serializes per chat.** Two messages in the same group can never run concurrently, so there's no interleaving of responses.
+- **IPC is filesystem-based.** Agents write JSON into `data/ipc/{group}/output/`; the host watches the directory, applies each file to the DB, and deletes it. No shared memory, no sockets.
+
+---
+
+## 4. End-to-end flows
+
+### 4a. Chat message → response
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Simon
+    participant T as Telegram
+    participant C as telegram.ts
+    participant D as SQLite
+    participant ML as messageLoop
+    participant Q as GroupQueue
+    participant CR as container-runner
+    participant A as Agent container
+    participant I as IPC watcher
+    participant R as router
+
+    U->>T: "Mr. Rogers, what's my next concept?"
+    T->>C: update event (gramjs)
+    C->>D: storeMessage(jid, sender, text, ts)
+
+    loop every ~1s
+        ML->>D: getNewMessages(since)
+    end
+    ML->>Q: enqueue(jid, prompt)
+    Q->>CR: runContainerAgent(group, prompt)
+    CR->>A: docker run (mounts: vault, group, ipc, .claude)
+
+    par Agent work
+        A->>A: read vault, call tools via OneCLI
+        A-->>I: write data/ipc/{group}/output/*.json
+        I->>D: persist concepts, activities, tasks
+    and Response stream
+        A-->>CR: stdout markers
+    end
+
+    CR-->>Q: {status, result}
+    Q->>R: routeOutbound(jid, text)
+    R->>C: channel.sendMessage(jid, text)
+    C->>T: send
+    T->>U: reply
+```
+
+### 4b. Document ingestion (`upload/` → vault → RAG)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as Simon
+    participant UP as upload/
+    participant FW as file-watcher
+    participant P as pipeline<br/>(drainer)
+    participant D as SQLite<br/>(ingestion_jobs)
+    participant EX as extractor
+    participant DL as docling-extract.py
+    participant AP as agent-processor
+    participant A as Review agent<br/>(container)
+    participant V as vault/drafts
+    participant PR as promoter
+    participant VS as vault/sources<br/>+ concepts
+    participant IDX as rag-indexer
+    participant LR as LightRAG :9621
+
+    U->>UP: drop paper.pdf
+    FW->>P: new file event
+    P->>D: createIngestionJob (status=pending)
+
+    P->>EX: extract(jobId)
+    EX->>DL: spawn python3 docling-extract.py
+    DL-->>EX: content.md + figures + metadata
+    P->>D: status=extracted
+
+    P->>AP: process(jobId)
+    AP->>A: runContainerAgent(review_agent, prompt)
+    A->>V: write draft .md files
+    A-->>AP: sentinel file signals done
+    P->>D: status=generated
+
+    P->>PR: promote(jobId)
+    PR->>VS: move drafts → sources/ + concepts/
+    P->>D: status=completed
+
+    VS-->>IDX: chokidar file change
+    IDX->>LR: POST (index document)
+    IDX->>D: update tracked_docs
+```
+
+---
+
+## How to update this doc
+
+- When you add a new **channel**, update §1 (if it's remote) and §3 (channels subgraph).
+- When you add a new **long-running service**, update §2.
+- When you change **message flow** or **ingestion stages**, update the matching sequence in §4.
+- When a file in the "Quick map" table moves or splits, update the table.
+
+Diagrams should match the code. If you find a drift, fix the diagram in the same PR as the code change.

--- a/docs/speech.md
+++ b/docs/speech.md
@@ -114,7 +114,7 @@ No local binaries, model files, or resident services are needed.
 - TTS (`gemini-3.1-flash-tts-preview`): $1 / M text-input tokens, $20 / M audio-output tokens. Batch mode is half price.
 - STT (`gemini-2.5-flash-lite`): priced at the lite model's audio-input rates.
 
-_Prices as documented at https://ai.google.dev/pricing — see the live page for current rates._
+_Prices per https://ai.google.dev/pricing as of 2026-04-19 — check the live page for current rates._
 
 ## Limitations
 

--- a/docs/speech.md
+++ b/docs/speech.md
@@ -1,117 +1,132 @@
 # Speech: Cloud TTS & STT
 
-Two-way audio for uniClaw via Telegram. Both text-to-speech and speech-to-text use Mistral's cloud APIs — no local models or dependencies.
+Two-way audio for uniClaw via Telegram. Inbound voice notes (STT) and outbound voice replies (TTS) both use Google Gemini cloud APIs.
 
 ## How It Works
 
 ### Inbound: Voice Message → Text (STT)
 
-When a user sends a voice message on Telegram:
+Voice transcription happens on the host, inside the Telegram message handler in `src/channels/telegram.ts`, before the agent container is invoked.
 
 ```
-Telegram voice msg (.oga)
-  → grammY downloads to /tmp/ via @grammyjs/files plugin
-  → POST multipart to https://api.mistral.ai/v1/audio/transcriptions
-  → Mistral returns transcription text
-  → text delivered to agent as "[Voice]: {transcribed text}"
-  → temp file cleaned up
+Telegram voice note (.oga)
+  → grammY downloads to /tmp/ via @grammyjs/files
+  → base64-encode file bytes
+  → POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent
+     headers: x-goog-api-key: $GEMINI_API_KEY
+     body: { contents: [{ parts: [
+              { inlineData: { mimeType: "audio/ogg", data: <base64> } },
+              { text: "Generate a transcript of this speech." }
+           ] }] }
+  → response.candidates[0].content.parts[0].text (trimmed)
+  → delivered to agent as "[Voice]: {text}"
+  → temp file unlinked
 ```
 
-All of this happens on the host in `src/channels/telegram.ts`, before the message reaches the agent container. If transcription fails for any reason, the agent receives `[Voice message (transcription failed)]` instead.
+No language hint is sent — Gemini auto-detects Norwegian, English, and others from the audio itself. The `[Voice]:` prefix signals to the agent that the message originated from audio rather than typed text. If any step fails, the agent receives the literal placeholder `[Voice message (transcription failed)]` instead.
 
-The `[Voice]:` prefix tells the agent the message originated from audio, not typed text.
+The STT model is exposed as a single constant (`GEMINI_STT_MODEL`) at the top of `src/channels/telegram.ts`. If `gemini-2.5-flash-lite` ever returns 400 on audio input, swap it to `gemini-2.5-flash` (documented multimodal, ~3-5x the cost).
 
 ### Outbound: Agent → Voice Message (TTS)
 
-When the agent wants to speak:
+TTS happens inside the agent container. The agent calls an MCP tool; the container produces a WAV file; the host converts it to OGG Opus and sends it as a Telegram voice bubble.
 
 ```
-Agent calls synthesize_speech MCP tool (text)
-  → HTTPS POST to https://api.mistral.ai/v1/audio/speech
-  → Container reads MISTRAL_API_KEY from env and sends Bearer auth
-  → Mistral returns WAV audio
-  → WAV saved to /workspace/group/audio/
-  → Agent calls send_voice MCP tool (file path)
-  → IPC JSON written to /workspace/ipc/messages/
-  → Host picks up IPC, resolves container path → host path
-  → ffmpeg converts WAV → OGG Opus (Telegram requires this for voice bubbles)
-  → grammY sends OGG as voice message via Telegram Bot API
-  → WAV and OGG cleaned up after upload completes
+Agent calls synthesize_speech({ text, style_prompt? })
+  → container composes prompt: `${style_prompt.trim()}: ${text}` when
+    style_prompt is a non-empty, non-whitespace string; otherwise just text
+  → POST https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:generateContent
+     headers: x-goog-api-key: $GEMINI_API_KEY
+     body: { contents: [{ parts: [{ text: prompt }] }],
+             generationConfig: {
+               responseModalities: ["AUDIO"],
+               speechConfig: { voiceConfig: { prebuiltVoiceConfig: { voiceName: "Kore" } } }
+             } }
+  → response.candidates[0].content.parts[0].inlineData.data
+     (base64 raw PCM: 24 kHz mono 16-bit little-endian — NOT a WAV)
+  → pcmToWav() prepends a 44-byte RIFF/WAVE header
+  → write to /workspace/group/audio/tts-{timestamp}-{rand}.wav
+  → return { path, duration_seconds }
+Agent then calls send_voice({ file_path })
+  → IPC JSON queued at /workspace/ipc/messages/
+  → host picks up IPC, resolves container path → host path
+  → host ffmpeg converts WAV → OGG Opus
+  → grammY sends OGG as Telegram voice bubble
+  → intermediate files cleaned up
 ```
 
-TTS is on-demand only — the agent uses it when asked, not on every response.
+TTS is on-demand: the agent invokes it when asked, not on every response.
 
 ## Architecture Decisions
 
-### Why a cloud API for TTS?
+### Why STT runs on the host (not in container)
 
-Previously, TTS used a local mlx-audio server running Voxtral on Apple Silicon (~3GB RAM, manual startup). Switching to Mistral's cloud API eliminates the operational burden — no resident process, no local model files, no platform dependency.
+STT happens in the Telegram message handler before the agent is even invoked. The container never needs audio access — text arrives as `[Voice]: ...` in the prompt, so the agent treats voice and text uniformly.
 
-### Why STT runs on the host (not in container)?
+### Why wrap PCM as WAV in the container
 
-STT happens in the Telegram message handler before the agent is even invoked. The container doesn't need audio access — text arrives as `[Voice]: ...` in the prompt.
-
-### Why WAV as the intermediate format for TTS?
-
-Mistral's TTS API outputs WAV. Telegram requires OGG Opus for voice bubbles (with waveform display and speed controls). So ffmpeg converts WAV→OGG on the host side before sending.
-
-STT does NOT need format conversion — the .oga file from Telegram is sent directly to Mistral's transcription API.
+Gemini's TTS response is raw 24 kHz s16le mono PCM, not a container format. The container prepends a 44-byte RIFF/WAVE header (via the pure helper `pcmToWav`) so the existing host IPC contract and ffmpeg invocation do not change — they still receive a `.wav` file path and convert it to OGG Opus exactly as before. The intermediate `.wav` files also remain playable in isolation, which helps debugging.
 
 ## Configuration
 
-| Variable | Location | Purpose |
-|----------|----------|---------|
-| `MISTRAL_API_KEY` | `.env` (host) | STT authentication (Telegram channel) and TTS (passed into containers as env var) |
+| Variable         | Location      | Purpose                                                                       |
+| ---------------- | ------------- | ----------------------------------------------------------------------------- |
+| `GEMINI_API_KEY` | `.env` (host) | STT authentication (Telegram channel) and TTS (passed into containers as env var) |
 
-No local binaries, model files, or resident services needed.
+No local binaries, model files, or resident services are needed.
 
 ## Components
 
 ### Host Dependencies
 
-| Component | Install | Purpose |
-|-----------|---------|---------|
-| ffmpeg | `brew install ffmpeg` | WAV→OGG Opus conversion for TTS delivery |
-| @grammyjs/files | npm dependency | Downloading Telegram voice messages |
+| Component        | Install              | Purpose                                       |
+| ---------------- | -------------------- | --------------------------------------------- |
+| `ffmpeg`         | `brew install ffmpeg`| WAV → OGG Opus conversion for TTS delivery    |
+| `@grammyjs/files`| npm dependency       | Downloading Telegram voice messages           |
 
 ### Files
 
-| File | Role |
-|------|------|
-| `src/channels/telegram.ts` | STT: downloads voice, POSTs to Mistral, delivers text |
-| `src/ipc.ts` | TTS delivery: picks up voice IPC, converts WAV→OGG, sends via channel |
-| `src/index.ts` | Wires `sendVoice` into IPC deps |
-| `src/types.ts` | Optional `sendVoice` on Channel interface |
-| `container/agent-runner/src/ipc-mcp-stdio.ts` | MCP tools: `synthesize_speech` and `send_voice` |
+| File                                              | Role                                                                                            |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `src/channels/telegram.ts`                        | STT: downloads voice, POSTs to Gemini, delivers text                                            |
+| `src/ipc.ts`                                      | TTS delivery: picks up voice IPC, converts WAV→OGG, sends via channel                           |
+| `src/index.ts`                                    | Wires `sendVoice` into IPC deps                                                                 |
+| `src/types.ts`                                    | Optional `sendVoice` on Channel interface                                                       |
+| `container/agent-runner/src/ipc-mcp-stdio.ts`     | MCP tools: `synthesize_speech` and `send_voice`                                                 |
+| `container/agent-runner/src/pcm-to-wav.ts`        | Pure helper: prepends 44-byte RIFF/WAVE header to Gemini's raw PCM                              |
+| `container/agent-runner/src/gemini-tts-request.ts`| Pure helper: builds the Gemini `generateContent` request body, handles `style_prompt` empty/whitespace semantics |
 
 ## Error Handling
 
-- **TTS API error:** MCP tool returns error text; agent responds in text instead
-- **TTS timeout (60s):** Catches `AbortSignal.timeout` and returns error
-- **Text too long (>5000 chars):** Rejected with clear error before API call
-- **STT API error:** Agent receives `[Voice message (transcription failed)]`
-- **STT timeout (60s):** Same fallback text
-- **MISTRAL_API_KEY missing:** STT skipped with warning log; TTS returns explicit error from MCP tool
-- **ffmpeg failure (TTS delivery):** Logged, voice message not sent
-- **Invalid container path in IPC:** Rejected if not under `/workspace/group/` or contains `..`
+| Condition                                                                   | Behavior                                                                                                                 |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `GEMINI_API_KEY` missing (STT)                                              | Log warning, skip transcription, agent receives `[Voice message (transcription failed)]`                                 |
+| `GEMINI_API_KEY` missing (TTS)                                              | MCP tool returns error with `isError: true`; agent falls back to text                                                    |
+| Gemini STT non-2xx / timeout (60s)                                          | Log error with status + body; agent receives `[Voice message (transcription failed)]`                                    |
+| Gemini TTS non-2xx / timeout (300s)                                         | MCP tool returns error with body; agent falls back to text                                                               |
+| TTS response missing `inlineData.data`                                      | MCP tool returns error including `finishReason` and `promptFeedback.blockReason` so safety blocks and modality failures are diagnosable |
+| TTS response returns `text` instead of audio (modality negotiation failure) | MCP tool returns a distinct error including the returned text, logged for debugging                                      |
+| Empty / oversized text (>50000 chars)                                       | Rejected in-tool before API call                                                                                         |
+| ffmpeg / IPC path validation                                                | Unchanged — WAV output preserves the invariant                                                                           |
 
 ## Cost
 
-| Service | Rate | Typical Usage |
-|---------|------|--------------|
-| TTS (Voxtral) | $0.016/1k chars | ~$0.01 per voice response |
-| STT (Voxtral Transcribe) | $0.003/min | ~$0.001 per voice message |
+- TTS (`gemini-3.1-flash-tts-preview`): $1 / M text-input tokens, $20 / M audio-output tokens. Batch mode is half price.
+- STT (`gemini-2.5-flash-lite`): priced at the lite model's audio-input rates.
+
+_Prices as documented at https://ai.google.dev/pricing — see the live page for current rates._
 
 ## Limitations
 
-- **Only Telegram** has voice support. The `sendVoice` method on the Channel interface is optional — other channels silently skip voice delivery.
+- **Only Telegram** has voice support. `sendVoice` is optional on the Channel interface; other channels silently skip voice delivery.
 - **No streaming TTS.** Audio is fully generated before sending.
-- **No voice cloning (yet).** Using default Mistral voice. Can add a `voice_id` parameter later by cloning from a reference audio sample.
-- **No Norwegian TTS.** Mistral supports 9 languages (en, fr, de, es, nl, pt, it, hi, ar) but not Norwegian. Norwegian voice messages are transcribed correctly (STT works for 13 languages including Norwegian-adjacent detection).
+- **No mid-conversation voice swap.** The voice is compile-time hardcoded (`Kore`) via `GEMINI_TTS_VOICE` in `container/agent-runner/src/ipc-mcp-stdio.ts`. Changing it requires editing the constant and rebuilding the container.
+- **No voice cloning.** Only Gemini's prebuilt voices are supported.
 
 ## Security
 
-- Container `send_voice` tool restricts file paths to `/workspace/group/audio/` directory
-- Host IPC handler validates container paths (prefix check + no `..` traversal)
-- Voice IPC uses the same authorization model as text: main group can send anywhere, others only to their own chat
-- MISTRAL_API_KEY is passed into containers as an env var by the host (read from `process.env` or `.env`). The container sends it directly in the Authorization header to the Mistral API
+- The container's `send_voice` tool restricts file paths to `/workspace/group/audio/`.
+- The host IPC handler validates container paths (prefix check + no `..` traversal).
+- Voice IPC uses the same authorization model as text: the main group can send anywhere; other groups only to their own chat.
+- `GEMINI_API_KEY` is passed into containers as an env var by the host (read from `process.env` or `.env`). The container sends it directly in the `x-goog-api-key` header to the Gemini API.
+- Key injection bypasses the OneCLI gateway intentionally — this matches the direct env-injection pattern used for provider keys that are not routed through the proxy.

--- a/docs/superpowers/plans/2026-04-18-gemini-tts-stt-migration-plan.md
+++ b/docs/superpowers/plans/2026-04-18-gemini-tts-stt-migration-plan.md
@@ -1,0 +1,1171 @@
+# Gemini TTS/STT Migration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Mistral with Google Gemini across both audio paths (host-side STT, container-side TTS) with zero changes to the downstream ffmpeg/IPC pipeline; enable Norwegian TTS; add an optional `style_prompt` parameter to the `synthesize_speech` MCP tool.
+
+**Architecture:** Host-side STT in `src/channels/telegram.ts` swaps Mistral multipart POST for Gemini `generateContent` on `gemini-2.5-flash-lite`. Container-side `synthesize_speech` in `container/agent-runner/src/ipc-mcp-stdio.ts` swaps Mistral endpoint for Gemini `gemini-3.1-flash-tts-preview` TTS, wraps base64 PCM as 44-byte WAV, and gains a `style_prompt` param. Voice is hardcoded to `Kore`. Env var is standardized to `GEMINI_API_KEY`.
+
+**Tech Stack:** TypeScript (ES modules, strict), Node 22, native `fetch`, Vitest, Zod (MCP tool schemas), `@modelcontextprotocol/sdk`. No new runtime dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-gemini-tts-stt-migration-design.md`
+
+---
+
+## Essential Reading (coordinator only — do not duplicate to subagents)
+
+- **Spec:** `docs/superpowers/specs/2026-04-18-gemini-tts-stt-migration-design.md` — the source of truth. Each task below is self-contained; subagents should not need to open the spec, but the coordinator should re-read it before final review.
+- **Current Mistral STT:** `src/channels/telegram.ts` voice-message handler (search for `MISTRAL` / `voxtral-mini-latest` / `api.mistral.ai`).
+- **Current Mistral TTS:** `container/agent-runner/src/ipc-mcp-stdio.ts` — the `synthesize_speech` tool handler and surrounding constants (`MISTRAL_TTS_URL`, `MISTRAL_DEFAULT_VOICE_ID`, `AUDIO_DIR`, `TTS_MAX_TEXT_LENGTH`).
+- **Env plumbing:** `src/container-runner.ts` — the `MISTRAL_API_KEY` injection block (a small `process.env.X || readEnvFile(['X']).X` pattern that pushes `-e X=...` into the container `args` array).
+- **Review feedback applied to spec:** STT model has a documented fallback (`gemini-2.5-flash`) behind a single constant; `style_prompt` empty/whitespace semantics specified; `finishReason` / `promptFeedback` logging required; `google_api_key` → `GEMINI_API_KEY` rename is a first-class rollout step.
+
+## Conventions (apply to every code task)
+
+- **TDD, strictly:** Write the failing test → run it and see the failure → write the minimal code → see it pass → commit.
+- **Commit per task.** Small commits. Subject line format: `feat(tts): ...` / `feat(stt): ...` / `chore(env): ...` / `docs(speech): ...` matching this repo's recent history (check `git log --oneline -20`).
+- **Never skip hooks.** Husky + prettier run on commit; let them. If prettier reformats staged files, re-stage and retry — do not `--no-verify`.
+- **Never amend or force-push.** New commit per fix.
+- **ES module imports:** include `.js` extension on relative imports (the repo uses `"module": "NodeNext"` and compiled output runs as ESM). Example: `import { pcmToWav } from './pcm-to-wav.js';`.
+- **Do not add new runtime dependencies.** All code in this plan uses built-ins or the Vitest/Zod already installed.
+- **Do not touch files outside the `Files` list of your task.** If the spec says a change is needed elsewhere, it's covered by a later task.
+- **Spec deviations:** if an instruction conflicts with the spec, stop and surface the conflict in a commit message or a comment — do not silently deviate.
+
+## Parallel-Execution Guide
+
+Tasks 1, 2, and 4 can run in parallel (different files, no shared edits). All others are sequential per the dependency arrows:
+
+```
+Task 0 (vitest bootstrap) ──┬─> Task 1 (pcm-to-wav)    ─┐
+                            ├─> Task 2 (request body)  ─┤
+                            │                           ├─> Task 3 (synthesize_speech rewrite)
+                            └─> Task 4 (telegram STT)  ─┘                              │
+                                                                                       │
+                                        Task 5 (container-runner env) ─────────────────┘
+                                                  │
+                                                  v
+                              Tasks 6–10 (docs, in parallel with each other)
+                                                  │
+                                                  v
+                                            Task 11 (smoke + PR gate)
+```
+
+**Ownership (parallel safety):**
+- Task 1 owns: `container/agent-runner/src/pcm-to-wav.ts`, `container/agent-runner/src/pcm-to-wav.test.ts`. Must not touch `ipc-mcp-stdio.ts`.
+- Task 2 owns: `container/agent-runner/src/gemini-tts-request.ts`, `container/agent-runner/src/gemini-tts-request.test.ts`. Must not touch `ipc-mcp-stdio.ts`.
+- Task 4 owns: `src/channels/telegram.ts`, `src/channels/telegram.test.ts`. Must not touch any container/ path.
+
+---
+
+## Task 0: Bootstrap Vitest coverage for `container/agent-runner`
+
+**Why this exists first:** The spec calls for two new unit test files under `container/agent-runner/src/`, but the host's `vitest.config.ts` does not currently glob that directory. Without this bootstrap, Tasks 1 and 2 cannot observe their tests running. Also, `container/agent-runner/tsconfig.json` currently compiles everything in `src/**/*` — we must exclude `*.test.ts` so test files do not ship into the container image.
+
+**Files:**
+- Modify: `vitest.config.ts`
+- Modify: `container/agent-runner/tsconfig.json`
+
+- [ ] **Step 1: Read the current vitest config**
+
+Run: `cat vitest.config.ts`
+
+Expected output:
+```ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts', 'setup/**/*.test.ts', 'dashboard/src/**/*.test.ts'],
+  },
+});
+```
+
+- [ ] **Step 2: Add the container-runner test glob**
+
+Edit `vitest.config.ts` — add `'container/agent-runner/src/**/*.test.ts'` to the `include` array. Final state:
+
+```ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [
+      'src/**/*.test.ts',
+      'setup/**/*.test.ts',
+      'dashboard/src/**/*.test.ts',
+      'container/agent-runner/src/**/*.test.ts',
+    ],
+  },
+});
+```
+
+- [ ] **Step 3: Exclude test files from the agent-runner TypeScript build**
+
+Edit `container/agent-runner/tsconfig.json` — add `"src/**/*.test.ts"` to the `exclude` array:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}
+```
+
+- [ ] **Step 4: Verify Vitest still runs cleanly**
+
+Run: `npm test`
+Expected: All existing tests pass. Vitest reports no new test files (they don't exist yet).
+
+- [ ] **Step 5: Verify the agent-runner build is unaffected**
+
+Run: `cd container/agent-runner && npx tsc --noEmit`
+Expected: Exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vitest.config.ts container/agent-runner/tsconfig.json
+git commit -m "chore(test): wire container/agent-runner into vitest
+
+Add container/agent-runner/src/**/*.test.ts to vitest include and
+exclude test files from the agent-runner tsc build so tests are
+runnable but do not ship into the container image."
+```
+
+---
+
+## Task 1: `pcmToWav` helper — TDD
+
+**Why:** Gemini TTS returns raw base64 PCM (24kHz mono 16-bit little-endian). The host ffmpeg pipeline expects a WAV on disk (that's the invariant the spec preserves). A pure function `pcmToWav(pcm: Buffer): Buffer` prepends a standard 44-byte RIFF/WAVE header. Isolating it as a file makes it trivially unit-testable and keeps `ipc-mcp-stdio.ts` readable.
+
+**Files:**
+- Create: `container/agent-runner/src/pcm-to-wav.ts`
+- Create: `container/agent-runner/src/pcm-to-wav.test.ts`
+
+**Header layout (from spec, do not deviate):**
+
+| Offset | Bytes | Value | Notes |
+|---|---|---|---|
+| 0 | 4 | `"RIFF"` | ASCII |
+| 4 | 4 | `pcm.length + 36` | little-endian u32 (file size minus 8) |
+| 8 | 4 | `"WAVE"` | ASCII |
+| 12 | 4 | `"fmt "` | note the trailing space |
+| 16 | 4 | `16` | fmt chunk size (PCM) |
+| 20 | 2 | `1` | PCM format |
+| 22 | 2 | `1` | mono |
+| 24 | 4 | `24000` | sample rate |
+| 28 | 4 | `48000` | byte rate = 24000 × 1 × 2 |
+| 32 | 2 | `2` | block align |
+| 34 | 2 | `16` | bits per sample |
+| 36 | 4 | `"data"` | ASCII |
+| 40 | 4 | `pcm.length` | little-endian u32 |
+
+All numeric fields little-endian. All `writeUIntLE` / `writeUInt32LE` / `writeUInt16LE` — these are Node `Buffer` built-ins, no deps.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `container/agent-runner/src/pcm-to-wav.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { pcmToWav } from './pcm-to-wav.js';
+
+describe('pcmToWav', () => {
+  it('prepends a 44-byte RIFF/WAVE header to the PCM buffer', () => {
+    const pcm = Buffer.alloc(100, 0xAB);
+    const wav = pcmToWav(pcm);
+    expect(wav.length).toBe(100 + 44);
+    // Header ASCII markers
+    expect(wav.slice(0, 4).toString('ascii')).toBe('RIFF');
+    expect(wav.slice(8, 12).toString('ascii')).toBe('WAVE');
+    expect(wav.slice(12, 16).toString('ascii')).toBe('fmt ');
+    expect(wav.slice(36, 40).toString('ascii')).toBe('data');
+    // PCM body is appended verbatim
+    expect(wav.slice(44).equals(pcm)).toBe(true);
+  });
+
+  it('encodes fmt chunk for 24kHz mono 16-bit little-endian PCM', () => {
+    const pcm = Buffer.alloc(10);
+    const wav = pcmToWav(pcm);
+    expect(wav.readUInt32LE(16)).toBe(16);   // fmt chunk size
+    expect(wav.readUInt16LE(20)).toBe(1);    // PCM format
+    expect(wav.readUInt16LE(22)).toBe(1);    // mono
+    expect(wav.readUInt32LE(24)).toBe(24000); // sample rate
+    expect(wav.readUInt32LE(28)).toBe(48000); // byte rate
+    expect(wav.readUInt16LE(32)).toBe(2);    // block align
+    expect(wav.readUInt16LE(34)).toBe(16);   // bits per sample
+  });
+
+  it('writes the RIFF and data chunk sizes correctly', () => {
+    const pcm = Buffer.alloc(1000);
+    const wav = pcmToWav(pcm);
+    expect(wav.readUInt32LE(4)).toBe(1000 + 36); // RIFF size = total - 8
+    expect(wav.readUInt32LE(40)).toBe(1000);     // data chunk size
+  });
+
+  it('handles an empty PCM buffer', () => {
+    const wav = pcmToWav(Buffer.alloc(0));
+    expect(wav.length).toBe(44);
+    expect(wav.readUInt32LE(4)).toBe(36);
+    expect(wav.readUInt32LE(40)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `npx vitest run container/agent-runner/src/pcm-to-wav.test.ts`
+Expected: Failure — module `./pcm-to-wav.js` not found (the import target does not exist yet).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `container/agent-runner/src/pcm-to-wav.ts`:
+
+```ts
+/**
+ * Wrap raw PCM (24kHz, mono, 16-bit little-endian) in a 44-byte RIFF/WAVE
+ * header so the host ffmpeg pipeline can read it as a standard WAV.
+ *
+ * The audio format is fixed — Gemini TTS returns PCM at exactly these
+ * parameters, so there are no knobs here.
+ */
+export function pcmToWav(pcm: Buffer): Buffer {
+  const SAMPLE_RATE = 24000;
+  const CHANNELS = 1;
+  const BITS_PER_SAMPLE = 16;
+  const BYTE_RATE = SAMPLE_RATE * CHANNELS * (BITS_PER_SAMPLE / 8);
+  const BLOCK_ALIGN = CHANNELS * (BITS_PER_SAMPLE / 8);
+
+  const header = Buffer.alloc(44);
+  header.write('RIFF', 0, 'ascii');
+  header.writeUInt32LE(pcm.length + 36, 4);
+  header.write('WAVE', 8, 'ascii');
+  header.write('fmt ', 12, 'ascii');
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(CHANNELS, 22);
+  header.writeUInt32LE(SAMPLE_RATE, 24);
+  header.writeUInt32LE(BYTE_RATE, 28);
+  header.writeUInt16LE(BLOCK_ALIGN, 32);
+  header.writeUInt16LE(BITS_PER_SAMPLE, 34);
+  header.write('data', 36, 'ascii');
+  header.writeUInt32LE(pcm.length, 40);
+
+  return Buffer.concat([header, pcm]);
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `npx vitest run container/agent-runner/src/pcm-to-wav.test.ts`
+Expected: All four tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add container/agent-runner/src/pcm-to-wav.ts container/agent-runner/src/pcm-to-wav.test.ts
+git commit -m "feat(tts): add pcmToWav helper for Gemini PCM → WAV wrap
+
+Gemini TTS returns raw 24kHz mono 16-bit PCM. Wrap it in a 44-byte
+RIFF/WAVE header so the existing host ffmpeg WAV→OGG pipeline can
+consume it unchanged."
+```
+
+---
+
+## Task 2: `buildGeminiTtsRequest` helper — TDD
+
+**Why:** The request body builder is the only piece of the TTS tool with real decision logic (whether to prepend `style_prompt`, how to shape `speechConfig`). Extracting it keeps the MCP handler thin and lets us pin the Gemini request shape with unit tests so future refactors can't silently drift from the documented API.
+
+**Files:**
+- Create: `container/agent-runner/src/gemini-tts-request.ts`
+- Create: `container/agent-runner/src/gemini-tts-request.test.ts`
+
+**Contract (from spec):**
+
+```ts
+function buildGeminiTtsRequest(args: {
+  text: string;
+  stylePrompt?: string;
+  voiceName: string;
+}): GeminiTtsRequestBody;
+```
+
+The `stylePrompt` is treated as absent when `undefined`, empty, or whitespace-only. Otherwise it's trimmed and prepended as `"{stylePrompt}: {text}"`. The `voiceName` is passed through from the caller so this helper stays pure.
+
+**Body shape (Gemini v1beta REST, camelCase):**
+
+```json
+{
+  "contents": [{ "parts": [{ "text": "<prompt>" }] }],
+  "generationConfig": {
+    "responseModalities": ["AUDIO"],
+    "speechConfig": {
+      "voiceConfig": {
+        "prebuiltVoiceConfig": {
+          "voiceName": "Kore"
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `container/agent-runner/src/gemini-tts-request.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildGeminiTtsRequest } from './gemini-tts-request.js';
+
+describe('buildGeminiTtsRequest', () => {
+  it('sends text unchanged when stylePrompt is omitted', () => {
+    const body = buildGeminiTtsRequest({
+      text: 'Hello world',
+      voiceName: 'Kore',
+    });
+    expect(body.contents[0].parts[0].text).toBe('Hello world');
+  });
+
+  it('sends text unchanged when stylePrompt is an empty string', () => {
+    const body = buildGeminiTtsRequest({
+      text: 'Hello world',
+      stylePrompt: '',
+      voiceName: 'Kore',
+    });
+    expect(body.contents[0].parts[0].text).toBe('Hello world');
+  });
+
+  it('sends text unchanged when stylePrompt is whitespace only', () => {
+    const body = buildGeminiTtsRequest({
+      text: 'Hello world',
+      stylePrompt: '   \t  ',
+      voiceName: 'Kore',
+    });
+    expect(body.contents[0].parts[0].text).toBe('Hello world');
+  });
+
+  it('prepends a trimmed stylePrompt with a colon separator', () => {
+    const body = buildGeminiTtsRequest({
+      text: 'Hello world',
+      stylePrompt: '  Say warmly and slowly  ',
+      voiceName: 'Kore',
+    });
+    expect(body.contents[0].parts[0].text).toBe('Say warmly and slowly: Hello world');
+  });
+
+  it('requests AUDIO modality with the specified prebuilt voice', () => {
+    const body = buildGeminiTtsRequest({ text: 'hi', voiceName: 'Charon' });
+    expect(body.generationConfig.responseModalities).toEqual(['AUDIO']);
+    expect(
+      body.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName,
+    ).toBe('Charon');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `npx vitest run container/agent-runner/src/gemini-tts-request.test.ts`
+Expected: Failure — module `./gemini-tts-request.js` not found.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `container/agent-runner/src/gemini-tts-request.ts`:
+
+```ts
+export interface GeminiTtsRequestBody {
+  contents: Array<{ parts: Array<{ text: string }> }>;
+  generationConfig: {
+    responseModalities: ['AUDIO'];
+    speechConfig: {
+      voiceConfig: {
+        prebuiltVoiceConfig: { voiceName: string };
+      };
+    };
+  };
+}
+
+export function buildGeminiTtsRequest(args: {
+  text: string;
+  stylePrompt?: string;
+  voiceName: string;
+}): GeminiTtsRequestBody {
+  const style = args.stylePrompt?.trim();
+  const prompt = style ? `${style}: ${args.text}` : args.text;
+
+  return {
+    contents: [{ parts: [{ text: prompt }] }],
+    generationConfig: {
+      responseModalities: ['AUDIO'],
+      speechConfig: {
+        voiceConfig: {
+          prebuiltVoiceConfig: { voiceName: args.voiceName },
+        },
+      },
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `npx vitest run container/agent-runner/src/gemini-tts-request.test.ts`
+Expected: All five tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add container/agent-runner/src/gemini-tts-request.ts container/agent-runner/src/gemini-tts-request.test.ts
+git commit -m "feat(tts): add buildGeminiTtsRequest body builder
+
+Pure helper that shapes the Gemini generateContent body. Handles
+style_prompt empty/whitespace semantics (treated as absent) and
+trims+prepends when present."
+```
+
+---
+
+## Task 3: Rewrite `synthesize_speech` tool to use Gemini
+
+**Why:** This is the functional core of the migration on the TTS side. The tool's external contract (`{ path, duration_seconds }`) and file location (`/workspace/group/audio/`) are preserved so the host-side IPC and ffmpeg pipeline don't notice. A new optional `style_prompt` param is added; the voice and model are named constants.
+
+**Files:**
+- Modify: `container/agent-runner/src/ipc-mcp-stdio.ts`
+
+**Depends on:** Task 1 (pcmToWav) and Task 2 (buildGeminiTtsRequest).
+
+**What to replace:** The whole block starting with the constants just above the `synthesize_speech` tool declaration and ending at the closing `);` of the tool definition. Specifically:
+
+- Delete: `const MISTRAL_TTS_URL = ...`
+- Delete: `const MISTRAL_DEFAULT_VOICE_ID = ...`
+- Keep: `const AUDIO_DIR = '/workspace/group/audio';`
+- Keep: `const TTS_MAX_TEXT_LENGTH = 50000;`
+- Add: the new Gemini constants (see Step 2 below).
+- Add: imports for the two helpers.
+- Replace: the entire `server.tool('synthesize_speech', ...)` call.
+
+**What to leave alone:** The `send_voice` tool (directly after `synthesize_speech`) is unchanged. All other tools (`send_message`, `schedule_task`, `list_tasks`, etc.) are unchanged.
+
+- [ ] **Step 1: Add helper imports at the top of the file**
+
+Near the other imports in `container/agent-runner/src/ipc-mcp-stdio.ts` (after the existing `import { CronExpressionParser } from 'cron-parser';` line), add:
+
+```ts
+import { pcmToWav } from './pcm-to-wav.js';
+import { buildGeminiTtsRequest } from './gemini-tts-request.js';
+```
+
+- [ ] **Step 2: Replace the Mistral constants with Gemini constants**
+
+Find the block near `AUDIO_DIR` and `TTS_MAX_TEXT_LENGTH`. Replace the two `MISTRAL_*` constants with:
+
+```ts
+const AUDIO_DIR = '/workspace/group/audio';
+const TTS_MAX_TEXT_LENGTH = 50000;
+
+// Voice is a single prebuilt. To try another, change this constant.
+// Kore is a balanced multilingual default. Other good starting points:
+// "Charon", "Puck", "Zephyr", "Aoede". Full list: 30 prebuilts in Gemini TTS docs.
+const GEMINI_TTS_VOICE = 'Kore';
+
+// TTS model is currently a preview. If it is deprecated or promoted to GA,
+// swap this constant — it is the only coupling point to the preview name.
+const GEMINI_TTS_MODEL = 'gemini-3.1-flash-tts-preview';
+const GEMINI_TTS_URL = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_TTS_MODEL}:generateContent`;
+```
+
+- [ ] **Step 3: Replace the `synthesize_speech` tool handler**
+
+Replace the entire `server.tool('synthesize_speech', ...)` block with the Gemini-backed version. The new handler adds `style_prompt`, uses the two helpers, wraps PCM as WAV, and adds Gemini-specific error branches (`finishReason` / `promptFeedback` logging, modality-mismatch text-instead-of-audio).
+
+```ts
+server.tool(
+  'synthesize_speech',
+  'Convert text to speech audio. Returns a file path to the generated WAV audio. Call send_voice with the returned path to deliver it as a Telegram voice message. Everything is pre-configured — just call this tool.',
+  {
+    text: z
+      .string()
+      .max(50000)
+      .describe(
+        'Text to synthesize. You can embed Gemini audio tags like [warmly], [slowly], [whispering], [excitedly] inline to color specific moments within the speech.',
+      ),
+    style_prompt: z
+      .string()
+      .optional()
+      .describe(
+        'Natural-language whole-utterance style directive, e.g. "Say warmly and slowly" or "Speak with calm encouragement". Prepended to the text before synthesis. Use style_prompt for whole-utterance tone; use [inline tags] inside text for moment-specific expression.',
+      ),
+  },
+  async (args) => {
+    if (!args.text || args.text.trim().length === 0) {
+      return {
+        content: [{ type: 'text' as const, text: 'Error: text cannot be empty.' }],
+        isError: true,
+      };
+    }
+    if (args.text.length > TTS_MAX_TEXT_LENGTH) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error: text too long (${args.text.length} chars, max ${TTS_MAX_TEXT_LENGTH}).`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      return {
+        content: [
+          { type: 'text' as const, text: 'Error: GEMINI_API_KEY is not set in the container environment.' },
+        ],
+        isError: true,
+      };
+    }
+
+    try {
+      const body = buildGeminiTtsRequest({
+        text: args.text,
+        stylePrompt: args.style_prompt,
+        voiceName: GEMINI_TTS_VOICE,
+      });
+
+      const response = await fetch(GEMINI_TTS_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': apiKey,
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(300_000),
+      });
+
+      if (!response.ok) {
+        const errText = await response.text().catch(() => 'unknown error');
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error: TTS service returned ${response.status}: ${errText}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const responseJson = (await response.json()) as {
+        candidates?: Array<{
+          content?: { parts?: Array<{ text?: string; inlineData?: { data?: string } }> };
+          finishReason?: string;
+        }>;
+        promptFeedback?: { blockReason?: string };
+      };
+
+      const part = responseJson.candidates?.[0]?.content?.parts?.[0];
+      const audioB64 = part?.inlineData?.data;
+
+      if (!audioB64) {
+        // Distinguish "model returned text instead of audio" from "missing entirely"
+        if (part?.text) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Error: TTS model returned text instead of audio (modality negotiation failed). Model said: ${part.text}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        const finishReason = responseJson.candidates?.[0]?.finishReason;
+        const blockReason = responseJson.promptFeedback?.blockReason;
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error: TTS response missing inlineData.data. finishReason=${finishReason ?? 'unknown'} blockReason=${blockReason ?? 'none'}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const pcm = Buffer.from(audioB64, 'base64');
+      const wavBuffer = pcmToWav(pcm);
+
+      fs.mkdirSync(AUDIO_DIR, { recursive: true });
+      const random = Math.random().toString(36).slice(2, 6);
+      const filename = `tts-${Date.now()}-${random}.wav`;
+      const filepath = path.join(AUDIO_DIR, filename);
+      fs.writeFileSync(filepath, wavBuffer);
+
+      // 24kHz × 1 channel × 2 bytes/sample = 48000 bytes/sec
+      const durationSeconds = Math.max(0, Math.round((wavBuffer.length - 44) / 48000));
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              path: filepath,
+              duration_seconds: durationSeconds,
+            }),
+          },
+        ],
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        content: [
+          { type: 'text' as const, text: `Error: TTS request failed: ${message}` },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+```
+
+- [ ] **Step 4: Confirm no `MISTRAL` string remains in this file**
+
+Run: `grep -n -i mistral container/agent-runner/src/ipc-mcp-stdio.ts`
+Expected: No output.
+
+- [ ] **Step 5: Type-check the container-agent-runner package**
+
+Run: `cd container/agent-runner && npx tsc --noEmit`
+Expected: Exits 0 with no errors.
+
+- [ ] **Step 6: Run the full test suite**
+
+Run: `npm test`
+Expected: All tests pass (Tasks 1 and 2 tests, plus all pre-existing tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add container/agent-runner/src/ipc-mcp-stdio.ts
+git commit -m "feat(tts): migrate synthesize_speech to Gemini
+
+Swap Mistral voxtral-mini-tts for Gemini gemini-3.1-flash-tts-preview.
+Add optional style_prompt MCP param. Voice is hardcoded to Kore as a
+single constant. PCM response is wrapped as 44-byte WAV so the host
+ffmpeg WAV→OGG pipeline is untouched. Adds finishReason/promptFeedback
+logging and a distinct error for text-instead-of-audio modality
+failures."
+```
+
+---
+
+## Task 4: Rewrite STT handler in `src/channels/telegram.ts`
+
+**Why:** Host-side voice transcription runs before the agent is invoked. This task swaps the Mistral multipart `FormData` POST for a Gemini inline-base64 JSON POST. The function shape (download → transcribe → deliver `[Voice]: ...`) is preserved. No change to how the bot is wired up or how messages are delivered.
+
+**Files:**
+- Modify: `src/channels/telegram.ts`
+
+**Scope of the change (symbols, not line numbers):**
+- Constructor: rename param `mistralApiKey` → `geminiApiKey`.
+- Private field: rename `this.mistralApiKey` → `this.geminiApiKey`.
+- Voice handler (`this.bot.on('message:voice', ...)`): replace the Mistral multipart POST block with a Gemini inline-base64 JSON POST.
+- `registerChannel` callback at the bottom of the file: read `GEMINI_API_KEY` instead of `MISTRAL_API_KEY`; update the warning log message.
+
+**What to leave alone:** the markdown send helper, the pool bot code, all non-voice handlers, `sendMessage`, `sendVoice`, `setTyping`, etc.
+
+**STT model constant:** add a single module-level constant near the top of the voice handler (or as a file-level `const` at the top of the file) so the model is a one-line swap if `lite` rejects audio input during smoke testing:
+
+```ts
+// STT model. Swap to 'gemini-2.5-flash' if 'lite' returns 400 on audio input.
+const GEMINI_STT_MODEL = 'gemini-2.5-flash-lite';
+```
+
+- [ ] **Step 1: Rename the constructor parameter and field**
+
+In the class `TelegramChannel`:
+- Change constructor signature: `mistralApiKey: string = ''` → `geminiApiKey: string = ''`.
+- Change field declaration: `private mistralApiKey: string;` → `private geminiApiKey: string;`.
+- Change assignment: `this.mistralApiKey = mistralApiKey;` → `this.geminiApiKey = geminiApiKey;`.
+
+- [ ] **Step 2: Add the STT model constant**
+
+Near the top of the file (below the imports, above the exports), add:
+
+```ts
+// STT model. Swap to 'gemini-2.5-flash' if 'lite' returns 400 on audio input.
+const GEMINI_STT_MODEL = 'gemini-2.5-flash-lite';
+```
+
+- [ ] **Step 3: Replace the STT body inside the `message:voice` handler**
+
+The current Mistral block is the `try { const audioData = fs.readFileSync(...); const formData = new FormData(); ... fetch('https://api.mistral.ai/v1/audio/transcriptions', ...) ...}` block. Replace it with a Gemini inline-base64 equivalent.
+
+Inside the outer `try { ... const file = await ctx.getFile(); ... await file.download(localPath); try { ... } finally { fs.unlink(localPath, () => {}); } }` structure, the inner try/finally block should look like this after the change:
+
+```ts
+try {
+  if (!this.geminiApiKey) {
+    logger.warn('Skipping transcription — no GEMINI_API_KEY');
+  } else {
+    const audioData = fs.readFileSync(localPath);
+    const base64Audio = audioData.toString('base64');
+
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_STT_MODEL}:generateContent`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': this.geminiApiKey,
+        },
+        body: JSON.stringify({
+          contents: [
+            {
+              parts: [
+                { inlineData: { mimeType: 'audio/ogg', data: base64Audio } },
+                { text: 'Generate a transcript of this speech.' },
+              ],
+            },
+          ],
+        }),
+        signal: AbortSignal.timeout(60_000),
+      },
+    );
+
+    if (response.ok) {
+      const result = (await response.json()) as {
+        candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+      };
+      const text = result.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+      if (text) {
+        transcribedText = `[Voice]: ${text}`;
+      }
+    } else {
+      const errText = await response.text().catch(() => '');
+      logger.error(
+        { status: response.status, body: errText },
+        'Gemini STT request failed',
+      );
+    }
+  }
+} finally {
+  fs.unlink(localPath, () => {});
+}
+```
+
+The surrounding `transcribedText` variable, outer try/catch, `storeNonText(ctx, transcribedText)` call, and error-log structure all stay as-is.
+
+- [ ] **Step 4: Update the `registerChannel` callback at the bottom of the file**
+
+Replace the Mistral-key reading with Gemini-key reading. The final state of the callback:
+
+```ts
+registerChannel('telegram', (opts: ChannelOpts) => {
+  const envVars = readEnvFile(['TELEGRAM_BOT_TOKEN', 'GEMINI_API_KEY']);
+  const token =
+    process.env.TELEGRAM_BOT_TOKEN || envVars.TELEGRAM_BOT_TOKEN || '';
+  if (!token) {
+    logger.warn('Telegram: TELEGRAM_BOT_TOKEN not set');
+    return null;
+  }
+  const geminiApiKey =
+    process.env.GEMINI_API_KEY || envVars.GEMINI_API_KEY || '';
+  if (!geminiApiKey) {
+    logger.warn(
+      'Telegram: GEMINI_API_KEY not set — voice transcription disabled',
+    );
+  }
+  return new TelegramChannel(token, opts, geminiApiKey);
+});
+```
+
+- [ ] **Step 5: Confirm no `MISTRAL` / `mistral` string remains in this file**
+
+Run: `grep -n -i mistral src/channels/telegram.ts`
+Expected: No output.
+
+- [ ] **Step 6: Type-check the host package**
+
+Run: `npx tsc --noEmit`
+Expected: Exits 0.
+
+- [ ] **Step 7: Run the existing Telegram tests**
+
+Run: `npx vitest run src/channels/telegram.test.ts`
+Expected: Existing tests still pass. (We are not adding new tests here — STT is externally validated by the manual smoke checklist in Task 11.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/channels/telegram.ts
+git commit -m "feat(stt): migrate Telegram voice transcription to Gemini
+
+Swap Mistral voxtral transcription for Gemini gemini-2.5-flash-lite
+via generateContent with inlineData audio/ogg. Rename the constructor
+param and private field from mistralApiKey to geminiApiKey. Add a
+single STT model constant so pivoting to gemini-2.5-flash is a
+one-line change."
+```
+
+---
+
+## Task 5: Update container env injection in `src/container-runner.ts`
+
+**Why:** Containers currently receive `MISTRAL_API_KEY`. This task swaps the injection for `GEMINI_API_KEY`. The pattern (`process.env.X || readEnvFile(['X']).X`) stays identical; only the variable name changes.
+
+**Files:**
+- Modify: `src/container-runner.ts`
+
+- [ ] **Step 1: Replace the Mistral injection block**
+
+Find the block that reads `MISTRAL_API_KEY` and pushes it into the container `args` (look for the comment `// Mistral API key for TTS (synthesize_speech tool in container)` — it is between the `LIGHTRAG_URL` injection and the OneCLI `applyContainerConfig` call).
+
+Replace the entire block — comment included — with:
+
+```ts
+// Gemini API key for STT (on host) and TTS (synthesize_speech tool in container).
+// This bypasses the OneCLI gateway intentionally — it matches the direct env
+// injection pattern the previous Mistral key used.
+const geminiKey =
+  process.env.GEMINI_API_KEY ||
+  readEnvFile(['GEMINI_API_KEY']).GEMINI_API_KEY;
+if (geminiKey) {
+  args.push('-e', `GEMINI_API_KEY=${geminiKey}`);
+}
+```
+
+- [ ] **Step 2: Confirm no `MISTRAL` string remains in this file**
+
+Run: `grep -n -i mistral src/container-runner.ts`
+Expected: No output.
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: Exits 0.
+
+- [ ] **Step 4: Run the container-runner tests**
+
+Run: `npx vitest run src/container-runner.test.ts`
+Expected: Existing tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/container-runner.ts
+git commit -m "chore(env): inject GEMINI_API_KEY into agent containers
+
+Replace the MISTRAL_API_KEY env-injection block with an equivalent
+GEMINI_API_KEY block. Pattern and surrounding comments unchanged;
+OneCLI bypass is intentional and matches the prior Mistral behavior."
+```
+
+---
+
+## Task 6: Update `.env.example`
+
+**Files:**
+- Modify: `.env.example`
+
+- [ ] **Step 1: Read the current file**
+
+Run: `cat .env.example`
+
+Look for the `# --- Mistral API (TTS + STT) ---` block followed by `MISTRAL_API_KEY=`.
+
+- [ ] **Step 2: Replace the Mistral block with a Gemini block**
+
+Final state of that block:
+
+```
+# --- Gemini API (TTS + STT) ---
+GEMINI_API_KEY=
+```
+
+- [ ] **Step 3: Confirm no `MISTRAL` string remains**
+
+Run: `grep -n -i mistral .env.example`
+Expected: No output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .env.example
+git commit -m "chore(env): rename MISTRAL_API_KEY to GEMINI_API_KEY in example"
+```
+
+---
+
+## Task 7: Update `CLAUDE.md` env var table
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Locate the env-var row**
+
+In the "Environment Variables" table under "Services & Dependencies", find the row for `MISTRAL_API_KEY`. Current state:
+
+```
+| `MISTRAL_API_KEY` | — | Mistral API key (TTS + STT) |
+```
+
+- [ ] **Step 2: Replace with Gemini row**
+
+Final state:
+
+```
+| `GEMINI_API_KEY` | — | Gemini API key (TTS + STT) |
+```
+
+- [ ] **Step 3: Confirm no `MISTRAL` string remains**
+
+Run: `grep -n -i mistral CLAUDE.md`
+Expected: No output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md env-var table for Gemini migration"
+```
+
+---
+
+## Task 8: Update `docs/ARCHITECTURE.md` mermaid diagram
+
+**Files:**
+- Modify: `docs/ARCHITECTURE.md`
+
+- [ ] **Step 1: Locate the mermaid node**
+
+Find the line `mistral["Mistral API<br/>(TTS / STT)"]` in the mermaid block.
+
+- [ ] **Step 2: Rename the node and update the edge label**
+
+Change the node declaration:
+
+```
+gemini["Gemini API<br/>(TTS / STT)"]
+```
+
+Find the edge `core -->|"audio synthesis"| mistral` and update it to:
+
+```
+core -->|"audio synthesis + transcription"| gemini
+```
+
+Do a final scan to ensure the `mistral` id is fully replaced by `gemini` everywhere in the diagram (node declaration AND edges). There should be no remaining references to the old node id.
+
+- [ ] **Step 3: Confirm no `mistral` / `Mistral` string remains**
+
+Run: `grep -n -i mistral docs/ARCHITECTURE.md`
+Expected: No output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/ARCHITECTURE.md
+git commit -m "docs(arch): replace Mistral node with Gemini in architecture diagram"
+```
+
+---
+
+## Task 9: Rewrite `docs/speech.md`
+
+**Why:** `docs/speech.md` is the document someone reads when they want to understand the speech pipeline. It's Mistral-specific today and has pre-existing staleness (says "5000 chars" instead of 50000, "60s" timeout instead of 300s). Full rewrite.
+
+**Files:**
+- Modify: `docs/speech.md`
+
+**Rewrite scope:** The entire file. Keep the high-level sections ("How It Works", "Architecture Decisions", "Configuration", "Components", "Error Handling", "Cost", "Limitations", "Security") but rewrite each section for Gemini. Key changes:
+
+- **Intro sentence:** describe both paths as using Gemini.
+- **STT flow:** update the endpoint, auth header, model name, request shape (inline base64 JSON, not multipart).
+- **TTS flow:** update the endpoint, auth header, model name, describe PCM → WAV wrap in container.
+- **Architecture Decisions:** remove "Why a cloud API for TTS" (obsolete historical decision). Keep "Why STT runs on the host (not in container)" (still applies). Add a short section: "Why wrap PCM as WAV in the container" — preserves the existing host ffmpeg pipeline contract.
+- **Configuration table:** replace `MISTRAL_API_KEY` row with `GEMINI_API_KEY` row.
+- **Error Handling:** update all timeouts (TTS timeout is 300s, not 60s — previously stale), update text-length limit (50000, not 5000 — previously stale), add Gemini-specific rows: `finishReason` / `promptFeedback` logging, modality-mismatch error.
+- **Cost:** Gemini rates. Per spec: TTS $1/M text input tokens, $20/M audio output tokens; STT = input-text priced at `gemini-2.5-flash-lite` rates (look up the current price from Google Cloud pricing when rewriting). If current pricing can't be confirmed cheaply, write the rate card with a footnote citing the Gemini pricing page as the source.
+- **Limitations:** remove "No Norwegian TTS" (now supported). Add "No mid-conversation voice swap" and "No streaming TTS".
+- **Components:** Unchanged except for the security note about the API key.
+- **Security:** Update references from `MISTRAL_API_KEY` to `GEMINI_API_KEY`; note the same direct-env pattern.
+
+- [ ] **Step 1: Rewrite the file end-to-end**
+
+Replace the full contents of `docs/speech.md` with a Gemini-focused version that covers the sections above. Do not retain any sentence that mentions Mistral, Voxtral, or the old limits (5000 chars, 60s TTS timeout).
+
+- [ ] **Step 2: Confirm no stale strings remain**
+
+Run each:
+```
+grep -n -i mistral docs/speech.md
+grep -n -i voxtral docs/speech.md
+grep -n '5000 chars' docs/speech.md
+grep -n '60s' docs/speech.md
+```
+Expected: All return empty.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/speech.md
+git commit -m "docs(speech): rewrite for Gemini TTS/STT
+
+Replace Mistral-centric documentation with Gemini. Corrects two
+pre-existing stale values along the way (TTS char limit 50000, not
+5000; TTS timeout 300s, not 60s). Removes 'No Norwegian TTS'
+limitation; Gemini supports nb and nn."
+```
+
+---
+
+## Task 10: Repo-wide Mistral sweep
+
+**Why:** Catch anything the preceding tasks missed. Historical plan/spec docs are explicitly left alone per the migration spec's "Docs left alone" section, but any active-path code or config reference to Mistral is a bug.
+
+**Files:** None to modify in this task (it's a verification task). If this task finds a stray reference, open a new task to fix it; do not silently patch.
+
+- [ ] **Step 1: Search for any `MISTRAL` / `mistral` reference outside the historical plans**
+
+Run:
+```
+grep -rn -i mistral . \
+  --include='*.ts' --include='*.tsx' --include='*.js' --include='*.json' \
+  --include='*.md' --include='*.sh' --include='.env.example' \
+  | grep -v docs/superpowers/plans/ \
+  | grep -v docs/superpowers/specs/2026-04-12- \
+  | grep -v docs/superpowers/specs/2026-04-18-gemini- \
+  | grep -v node_modules
+```
+Expected: Empty. Any hit that is NOT in `node_modules` or the excluded historical paths is a bug that needs a fix.
+
+- [ ] **Step 2: If anything surfaces, file it as a follow-up**
+
+If the grep returns non-empty output, leave a note at the bottom of this plan file under a new "Follow-ups" section describing the stray reference, and do not proceed to Task 11 until it is resolved.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `npm test`
+Expected: All tests pass.
+
+- [ ] **Step 4: Typecheck host + container**
+
+Run: `npx tsc --noEmit && cd container/agent-runner && npx tsc --noEmit && cd ../..`
+Expected: Both exit 0.
+
+- [ ] **Step 5: Commit (only if this task uncovered and fixed something; otherwise skip)**
+
+This is a verification task. If nothing changed, no commit is needed.
+
+---
+
+## Task 11: Pre-merge gate — build, container rebuild, manual smoke, PR
+
+**Why:** Audio paths cannot be fully unit-tested. This task gates the PR on the seven-step manual smoke checklist from the spec plus a clean build of the container image.
+
+**Files:** None.
+
+**Prerequisite:** The `.env` file must already have `GEMINI_API_KEY` set (renamed from the prior lowercase `google_api_key`; `MISTRAL_API_KEY` deleted). If not, STOP and surface to the user before continuing — the agent must not rename env vars in the user's `.env` without explicit confirmation.
+
+- [ ] **Step 1: Confirm the user has migrated `.env`**
+
+Ask the user: "Before I run the smoke checklist, please confirm your local `.env` has `GEMINI_API_KEY=...` (same value that was in `google_api_key`) and that `MISTRAL_API_KEY` is deleted."
+
+Do not proceed until confirmed.
+
+- [ ] **Step 2: Clean build**
+
+Run: `npm run build`
+Expected: Exits 0.
+
+- [ ] **Step 3: Run tests**
+
+Run: `npm test`
+Expected: All tests pass.
+
+- [ ] **Step 4: Rebuild the container**
+
+Per `CLAUDE.md`: the builder cache is aggressive. If the container's Gemini-backed `ipc-mcp-stdio.ts` doesn't behave as expected after a normal rebuild, prune the builder and retry.
+
+Run: `./container/build.sh`
+Expected: Build succeeds. Note the image tag.
+
+- [ ] **Step 5: Restart NanoClaw**
+
+Per `CLAUDE.md` on macOS:
+```
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+```
+Or, if running via `npm run dev`: stop and re-run `npm run dev`.
+
+- [ ] **Step 6: Manual smoke checklist (from spec)**
+
+Run each check and tick it off only after observing the expected behavior:
+
+- [ ] Send a short English voice note to Telegram → agent receives `[Voice]: ...` with correct transcript.
+- [ ] Send a Norwegian voice note → transcript is Norwegian with accented characters (æ, ø, å) rendered correctly as UTF-8.
+- [ ] Ask agent to speak → receive a Telegram voice bubble that plays, has a waveform, and sounds like the Kore voice.
+- [ ] Ask agent to speak Norwegian → plays Norwegian audio.
+- [ ] Ask agent to speak using `style_prompt: "Say warmly and slowly"` → tone is noticeably warmer and slower.
+- [ ] Ask agent to speak with inline `[whispering]` / `[slowly]` tags → tags honored at the tagged position.
+- [ ] Temporarily unset `GEMINI_API_KEY` and restart; send a voice note → `[Voice message (transcription failed)]`. Ask agent to speak → text-only fallback with sensible error message. Restore `GEMINI_API_KEY` and restart.
+
+If Step 1 of the smoke checklist (English STT) fails with a 400 response, swap the STT model: in `src/channels/telegram.ts` change `const GEMINI_STT_MODEL = 'gemini-2.5-flash-lite';` to `'gemini-2.5-flash';`, rebuild, and re-run. Commit as `chore(stt): pivot to gemini-2.5-flash — lite rejects audio`.
+
+- [ ] **Step 7: Push branch and open PR**
+
+Run: `git push -u origin feat/gemini-tts-stt-migration`
+Run: `gh pr create --base main --title "feat(speech): migrate TTS/STT from Mistral to Google Gemini" --body "$(cat <<'EOF'
+## Summary
+- Replaces Mistral with Google Gemini across both audio paths (host-side STT, container-side TTS).
+- Enables Norwegian TTS (Gemini supports nb/nn; Mistral did not).
+- Adds optional `style_prompt` param to the `synthesize_speech` MCP tool for whole-utterance tone control. Inline `[tags]` remain available inside `text` for moment-level expression.
+- Hardcodes TTS voice to `Kore` (easy one-constant swap in `ipc-mcp-stdio.ts`). STT model is `gemini-2.5-flash-lite` with a documented fallback to `gemini-2.5-flash` (also one-constant swap).
+- Standardizes env var to `GEMINI_API_KEY`. `MISTRAL_API_KEY` and the prior lowercase `google_api_key` are removed.
+- Host ffmpeg WAV→OGG pipeline is untouched — container wraps Gemini's base64 PCM as WAV to preserve the existing IPC contract.
+
+## Test plan
+- [x] `npm run build`
+- [x] `npm test` (new unit tests for `pcmToWav` and `buildGeminiTtsRequest`; all prior tests pass)
+- [x] `./container/build.sh`
+- [x] English STT smoke
+- [x] Norwegian STT smoke (æ/ø/å render)
+- [x] English TTS smoke (Kore voice, waveform in Telegram)
+- [x] Norwegian TTS smoke
+- [x] `style_prompt` smoke (warmer/slower)
+- [x] Inline audio tags smoke
+- [x] Missing `GEMINI_API_KEY` graceful-fallback smoke
+
+## Docs
+- Spec: \`docs/superpowers/specs/2026-04-18-gemini-tts-stt-migration-design.md\`
+- Plan: \`docs/superpowers/plans/2026-04-18-gemini-tts-stt-migration-plan.md\`
+- Rewrote \`docs/speech.md\`, updated \`docs/ARCHITECTURE.md\`, \`CLAUDE.md\`, \`.env.example\`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"`
+
+Target repo: `SimonKvalheim/universityClaw` (never upstream `qwibitai/nanoclaw`).
+
+- [ ] **Step 8: Done**
+
+PR URL printed. Hand back to user for review/merge.
+
+---
+
+## Follow-ups
+
+(Empty. Populate if Task 10 uncovers stray references.)

--- a/docs/superpowers/plans/2026-04-18-gemini-tts-stt-migration-plan.md
+++ b/docs/superpowers/plans/2026-04-18-gemini-tts-stt-migration-plan.md
@@ -486,159 +486,63 @@ const GEMINI_TTS_MODEL = 'gemini-3.1-flash-tts-preview';
 const GEMINI_TTS_URL = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_TTS_MODEL}:generateContent`;
 ```
 
-- [ ] **Step 3: Replace the `synthesize_speech` tool handler**
+- [ ] **Step 3: Replace the `synthesize_speech` tool handler — load-bearing bits verbatim, composition up to you**
 
-Replace the entire `server.tool('synthesize_speech', ...)` block with the Gemini-backed version. The new handler adds `style_prompt`, uses the two helpers, wraps PCM as WAV, and adds Gemini-specific error branches (`finishReason` / `promptFeedback` logging, modality-mismatch text-instead-of-audio).
+Replace the entire `server.tool('synthesize_speech', ...)` call. Two parts are load-bearing and MUST be exactly as shown (wire format + tool contract): the Zod schema and the `fetch` invocation. Everything else is composition — write it however reads cleanly; the invariants you must preserve are listed after the verbatim blocks.
+
+**Verbatim — Zod schema** (wire-level; MCP clients depend on these strings and keys):
 
 ```ts
-server.tool(
-  'synthesize_speech',
-  'Convert text to speech audio. Returns a file path to the generated WAV audio. Call send_voice with the returned path to deliver it as a Telegram voice message. Everything is pre-configured — just call this tool.',
-  {
-    text: z
-      .string()
-      .max(50000)
-      .describe(
-        'Text to synthesize. You can embed Gemini audio tags like [warmly], [slowly], [whispering], [excitedly] inline to color specific moments within the speech.',
-      ),
-    style_prompt: z
-      .string()
-      .optional()
-      .describe(
-        'Natural-language whole-utterance style directive, e.g. "Say warmly and slowly" or "Speak with calm encouragement". Prepended to the text before synthesis. Use style_prompt for whole-utterance tone; use [inline tags] inside text for moment-specific expression.',
-      ),
-  },
-  async (args) => {
-    if (!args.text || args.text.trim().length === 0) {
-      return {
-        content: [{ type: 'text' as const, text: 'Error: text cannot be empty.' }],
-        isError: true,
-      };
-    }
-    if (args.text.length > TTS_MAX_TEXT_LENGTH) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Error: text too long (${args.text.length} chars, max ${TTS_MAX_TEXT_LENGTH}).`,
-          },
-        ],
-        isError: true,
-      };
-    }
-
-    const apiKey = process.env.GEMINI_API_KEY;
-    if (!apiKey) {
-      return {
-        content: [
-          { type: 'text' as const, text: 'Error: GEMINI_API_KEY is not set in the container environment.' },
-        ],
-        isError: true,
-      };
-    }
-
-    try {
-      const body = buildGeminiTtsRequest({
-        text: args.text,
-        stylePrompt: args.style_prompt,
-        voiceName: GEMINI_TTS_VOICE,
-      });
-
-      const response = await fetch(GEMINI_TTS_URL, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-goog-api-key': apiKey,
-        },
-        body: JSON.stringify(body),
-        signal: AbortSignal.timeout(300_000),
-      });
-
-      if (!response.ok) {
-        const errText = await response.text().catch(() => 'unknown error');
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: `Error: TTS service returned ${response.status}: ${errText}`,
-            },
-          ],
-          isError: true,
-        };
-      }
-
-      const responseJson = (await response.json()) as {
-        candidates?: Array<{
-          content?: { parts?: Array<{ text?: string; inlineData?: { data?: string } }> };
-          finishReason?: string;
-        }>;
-        promptFeedback?: { blockReason?: string };
-      };
-
-      const part = responseJson.candidates?.[0]?.content?.parts?.[0];
-      const audioB64 = part?.inlineData?.data;
-
-      if (!audioB64) {
-        // Distinguish "model returned text instead of audio" from "missing entirely"
-        if (part?.text) {
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text: `Error: TTS model returned text instead of audio (modality negotiation failed). Model said: ${part.text}`,
-              },
-            ],
-            isError: true,
-          };
-        }
-        const finishReason = responseJson.candidates?.[0]?.finishReason;
-        const blockReason = responseJson.promptFeedback?.blockReason;
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: `Error: TTS response missing inlineData.data. finishReason=${finishReason ?? 'unknown'} blockReason=${blockReason ?? 'none'}`,
-            },
-          ],
-          isError: true,
-        };
-      }
-
-      const pcm = Buffer.from(audioB64, 'base64');
-      const wavBuffer = pcmToWav(pcm);
-
-      fs.mkdirSync(AUDIO_DIR, { recursive: true });
-      const random = Math.random().toString(36).slice(2, 6);
-      const filename = `tts-${Date.now()}-${random}.wav`;
-      const filepath = path.join(AUDIO_DIR, filename);
-      fs.writeFileSync(filepath, wavBuffer);
-
-      // 24kHz × 1 channel × 2 bytes/sample = 48000 bytes/sec
-      const durationSeconds = Math.max(0, Math.round((wavBuffer.length - 44) / 48000));
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({
-              path: filepath,
-              duration_seconds: durationSeconds,
-            }),
-          },
-        ],
-      };
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      return {
-        content: [
-          { type: 'text' as const, text: `Error: TTS request failed: ${message}` },
-        ],
-        isError: true,
-      };
-    }
-  },
-);
+{
+  text: z
+    .string()
+    .max(50000)
+    .describe(
+      'Text to synthesize. You can embed Gemini audio tags like [warmly], [slowly], [whispering], [excitedly] inline to color specific moments within the speech.',
+    ),
+  style_prompt: z
+    .string()
+    .optional()
+    .describe(
+      'Natural-language whole-utterance style directive, e.g. "Say warmly and slowly" or "Speak with calm encouragement". Prepended to the text before synthesis. Use style_prompt for whole-utterance tone; use [inline tags] inside text for moment-specific expression.',
+    ),
+}
 ```
+
+The tool description string (second arg to `server.tool`) stays as today: `'Convert text to speech audio. Returns a file path to the generated WAV audio. Call send_voice with the returned path to deliver it as a Telegram voice message. Everything is pre-configured — just call this tool.'`
+
+**Verbatim — the Gemini fetch** (wire format; a typo here fails silently with a 400):
+
+```ts
+const response = await fetch(GEMINI_TTS_URL, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'x-goog-api-key': apiKey,
+  },
+  body: JSON.stringify(
+    buildGeminiTtsRequest({
+      text: args.text,
+      stylePrompt: args.style_prompt,
+      voiceName: GEMINI_TTS_VOICE,
+    }),
+  ),
+  signal: AbortSignal.timeout(300_000),
+});
+```
+
+**Invariants you must preserve** (compose the rest however reads best — extract helpers, unify error shapes, rename locals; you own the handler's structure):
+
+- **Input validation** (pre-fetch): empty/whitespace-only `text` → error `"Error: text cannot be empty."`. `text.length > TTS_MAX_TEXT_LENGTH` → error `"Error: text too long (${len} chars, max ${TTS_MAX_TEXT_LENGTH})."`. Missing `process.env.GEMINI_API_KEY` → error `"Error: GEMINI_API_KEY is not set in the container environment."`. All three return `{ isError: true, content: [...] }` — match the shape used by the current tool.
+- **HTTP failure**: `!response.ok` → error `"Error: TTS service returned ${status}: ${body}"` where body is `await response.text()` with a defensive catch.
+- **Response extraction**: the audio is at `candidates[0].content.parts[0].inlineData.data` (base64). Anything else that's there on the part is not audio.
+- **Modality-mismatch branch** (REQUIRED, do not omit): if `parts[0]` contains a `text` field instead of `inlineData`, return a DISTINCT error message that includes the model's returned text — do not collapse this into the generic "missing inlineData" path. Rationale: this is the single most informative diagnostic when the preview model's modality negotiation breaks.
+- **Missing-audio branch with diagnostics** (REQUIRED): when `inlineData.data` is absent and no fallback `text` is present, return an error that logs both `candidates[0].finishReason` and `promptFeedback.blockReason` (use "unknown" / "none" when either is absent). This is the only way the user diagnoses safety blocks.
+- **PCM → WAV → disk**: decode base64 → `pcmToWav` → write to `path.join(AUDIO_DIR, \`tts-${Date.now()}-${random}.wav\`)` where `random = Math.random().toString(36).slice(2, 6)`. `fs.mkdirSync(AUDIO_DIR, { recursive: true })` first.
+- **Return shape** (DO NOT CHANGE — `send_voice` and `src/ipc.ts` depend on it): `{ content: [{ type: 'text', text: JSON.stringify({ path, duration_seconds }) }] }`. `duration_seconds = Math.max(0, Math.round((wavBuffer.length - 44) / 48000))`.
+- **Outer `try/catch`**: thrown errors → `"Error: TTS request failed: ${message}"`.
+
+The constant `TTS_MAX_TEXT_LENGTH` is already defined at the top of the file (kept from the Mistral version). `AUDIO_DIR` likewise.
 
 - [ ] **Step 4: Confirm no `MISTRAL` string remains in this file**
 
@@ -709,64 +613,43 @@ Near the top of the file (below the imports, above the exports), add:
 const GEMINI_STT_MODEL = 'gemini-2.5-flash-lite';
 ```
 
-- [ ] **Step 3: Replace the STT body inside the `message:voice` handler**
+- [ ] **Step 3: Replace the STT body inside the `message:voice` handler — fetch verbatim, surrounding flow up to you**
 
-The current Mistral block is the `try { const audioData = fs.readFileSync(...); const formData = new FormData(); ... fetch('https://api.mistral.ai/v1/audio/transcriptions', ...) ...}` block. Replace it with a Gemini inline-base64 equivalent.
+The current Mistral block (read the handler first — look for `const formData = new FormData();` and the `fetch('https://api.mistral.ai/v1/audio/transcriptions', ...)` call) is the inner `try { ... } finally { fs.unlink(localPath, () => {}); }` body. Replace only that inner body. The outer download/file-handling and the `transcribedText` → `storeNonText(ctx, transcribedText)` flow stay as-is.
 
-Inside the outer `try { ... const file = await ctx.getFile(); ... await file.download(localPath); try { ... } finally { fs.unlink(localPath, () => {}); } }` structure, the inner try/finally block should look like this after the change:
+**Verbatim — the Gemini fetch** (wire format; do not alter keys, header case, or path shape):
 
 ```ts
-try {
-  if (!this.geminiApiKey) {
-    logger.warn('Skipping transcription — no GEMINI_API_KEY');
-  } else {
-    const audioData = fs.readFileSync(localPath);
-    const base64Audio = audioData.toString('base64');
-
-    const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_STT_MODEL}:generateContent`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-goog-api-key': this.geminiApiKey,
-        },
-        body: JSON.stringify({
-          contents: [
-            {
-              parts: [
-                { inlineData: { mimeType: 'audio/ogg', data: base64Audio } },
-                { text: 'Generate a transcript of this speech.' },
-              ],
-            },
+const response = await fetch(
+  `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_STT_MODEL}:generateContent`,
+  {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-goog-api-key': this.geminiApiKey,
+    },
+    body: JSON.stringify({
+      contents: [
+        {
+          parts: [
+            { inlineData: { mimeType: 'audio/ogg', data: audioData.toString('base64') } },
+            { text: 'Generate a transcript of this speech.' },
           ],
-        }),
-        signal: AbortSignal.timeout(60_000),
-      },
-    );
-
-    if (response.ok) {
-      const result = (await response.json()) as {
-        candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
-      };
-      const text = result.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
-      if (text) {
-        transcribedText = `[Voice]: ${text}`;
-      }
-    } else {
-      const errText = await response.text().catch(() => '');
-      logger.error(
-        { status: response.status, body: errText },
-        'Gemini STT request failed',
-      );
-    }
-  }
-} finally {
-  fs.unlink(localPath, () => {});
-}
+        },
+      ],
+    }),
+    signal: AbortSignal.timeout(60_000),
+  },
+);
 ```
 
-The surrounding `transcribedText` variable, outer try/catch, `storeNonText(ctx, transcribedText)` call, and error-log structure all stay as-is.
+**Invariants you must preserve** (compose the surrounding logic however reads best):
+
+- **Missing key short-circuit**: if `!this.geminiApiKey`, log `"Skipping transcription — no GEMINI_API_KEY"` via `logger.warn` and skip the fetch entirely. Do not attempt the POST. `transcribedText` retains its default `"[Voice message (transcription failed)]"` value.
+- **Response extraction**: transcript is at `candidates[0].content.parts[0].text`. Trim it. If truthy, set `transcribedText = \`[Voice]: ${text}\`` — the `[Voice]:` prefix is load-bearing; the agent uses it to recognize audio origin.
+- **Non-2xx branch**: `logger.error({ status: response.status, body: errText }, 'Gemini STT request failed')` where `errText = await response.text().catch(() => '')`. Leaves `transcribedText` at its failure-default so the agent sees the failure placeholder.
+- **File cleanup**: `fs.unlink(localPath, () => {})` runs in the `finally` regardless of branch taken.
+- **No new exception surface**: the outer try/catch (around `ctx.getFile()` / `file.download()` / inner block) is kept intact. Do not add new try/catches around the fetch — let thrown errors bubble to the existing outer catch, which already logs and leaves `transcribedText` at the failure-default.
 
 - [ ] **Step 4: Update the `registerChannel` callback at the bottom of the file**
 
@@ -990,18 +873,30 @@ git commit -m "docs(arch): replace Mistral node with Gemini in architecture diag
 **Files:**
 - Modify: `docs/speech.md`
 
-**Rewrite scope:** The entire file. Keep the high-level sections ("How It Works", "Architecture Decisions", "Configuration", "Components", "Error Handling", "Cost", "Limitations", "Security") but rewrite each section for Gemini. Key changes:
+**Rewrite scope:** The entire file. Structure the new doc in this section order (same top-level shape as today, so readers who know the old doc don't get lost):
 
-- **Intro sentence:** describe both paths as using Gemini.
-- **STT flow:** update the endpoint, auth header, model name, request shape (inline base64 JSON, not multipart).
-- **TTS flow:** update the endpoint, auth header, model name, describe PCM → WAV wrap in container.
-- **Architecture Decisions:** remove "Why a cloud API for TTS" (obsolete historical decision). Keep "Why STT runs on the host (not in container)" (still applies). Add a short section: "Why wrap PCM as WAV in the container" — preserves the existing host ffmpeg pipeline contract.
-- **Configuration table:** replace `MISTRAL_API_KEY` row with `GEMINI_API_KEY` row.
-- **Error Handling:** update all timeouts (TTS timeout is 300s, not 60s — previously stale), update text-length limit (50000, not 5000 — previously stale), add Gemini-specific rows: `finishReason` / `promptFeedback` logging, modality-mismatch error.
-- **Cost:** Gemini rates. Per spec: TTS $1/M text input tokens, $20/M audio output tokens; STT = input-text priced at `gemini-2.5-flash-lite` rates (look up the current price from Google Cloud pricing when rewriting). If current pricing can't be confirmed cheaply, write the rate card with a footnote citing the Gemini pricing page as the source.
-- **Limitations:** remove "No Norwegian TTS" (now supported). Add "No mid-conversation voice swap" and "No streaming TTS".
-- **Components:** Unchanged except for the security note about the API key.
-- **Security:** Update references from `MISTRAL_API_KEY` to `GEMINI_API_KEY`; note the same direct-env pattern.
+1. **Intro** — one sentence: both inbound (STT) and outbound (TTS) audio use Google Gemini cloud APIs.
+2. **How It Works**
+   - `### Inbound: Voice Message → Text (STT)` — prose + the STT ASCII flow block (Telegram voice → host download → POST to Gemini `generateContent` at `gemini-2.5-flash-lite` with `inlineData` `audio/ogg` + prompt → transcript → `[Voice]: ...` to agent → temp cleanup).
+   - `### Outbound: Agent → Voice Message (TTS)` — prose + the TTS ASCII flow block (agent calls `synthesize_speech(text, style_prompt?)` → container POSTs Gemini `generateContent` at `gemini-3.1-flash-tts-preview` → base64 PCM → `pcmToWav` → `/workspace/group/audio/*.wav` → `send_voice` IPC → host ffmpeg WAV→OGG → Telegram voice bubble → cleanup).
+3. **Architecture Decisions** (subsections, in this order):
+   - `### Why STT runs on the host (not in container)` — retained from the old doc (same rationale).
+   - `### Why wrap PCM as WAV in the container` — new. Gemini returns raw 24kHz s16le mono PCM. We prepend a 44-byte RIFF/WAVE header in-container so the existing host IPC contract + ffmpeg invocation do not change; intermediate `.wav` files remain playable standalone, which helps debugging.
+   - Do NOT include "Why a cloud API for TTS" — that decision is obsolete history.
+4. **Configuration** — single-row table: `GEMINI_API_KEY` (host `.env`), purpose: "STT authentication (Telegram channel) and TTS (passed into containers as env var)". State that no local binaries/model files are needed.
+5. **Components**
+   - `### Host Dependencies` — `ffmpeg` (WAV→OGG conversion), `@grammyjs/files` (voice downloads). Same as today.
+   - `### Files` — updated table: `src/channels/telegram.ts`, `src/ipc.ts`, `src/index.ts`, `src/types.ts`, `container/agent-runner/src/ipc-mcp-stdio.ts`, plus the new `container/agent-runner/src/pcm-to-wav.ts` and `container/agent-runner/src/gemini-tts-request.ts` helpers.
+6. **Error Handling** — the rows from the spec §"Error handling" (including the new Gemini rows: `finishReason`/`promptFeedback` logging, modality-mismatch text-instead-of-audio). Use the correct timeouts (STT 60s, TTS 300s) and the correct text-length limit (50000 chars). Do not carry forward the old doc's stale "5000 chars" or "TTS timeout (60s)" phrasings.
+7. **Cost** — per spec: TTS $1/M text-input tokens, $20/M audio-output tokens (batch: half). STT priced at `gemini-2.5-flash-lite` input-audio rates. If you can confirm current audio-input pricing cheaply during the rewrite, include concrete per-minute and per-voice-reply estimates; otherwise write the rate card as above and add a footnote: `*Pricing confirmed at https://ai.google.dev/pricing on {date}; check the live page for current rates.*`
+8. **Limitations** — remove "No Norwegian TTS" (Gemini supports `nb` and `nn`). Add:
+   - "No mid-conversation voice swap" (voice is a compile-time constant).
+   - "No streaming TTS" (audio is fully generated before sending).
+   - Retain "Only Telegram has voice support" (still true).
+   - Retain "No voice cloning" (still true, rewording optional).
+9. **Security** — update references to use `GEMINI_API_KEY`. Retain the existing bullets about path restriction, IPC path validation, and authorization model. Add one line: key injection bypasses OneCLI intentionally, matching the prior Mistral pattern.
+
+Do not carry over any sentence that mentions Mistral or Voxtral. Do not retain the "Why a cloud API for TTS" section.
 
 - [ ] **Step 1: Rewrite the file end-to-end**
 
@@ -1038,19 +933,23 @@ limitation; Gemini supports nb and nn."
 
 **Files:** None to modify in this task (it's a verification task). If this task finds a stray reference, open a new task to fix it; do not silently patch.
 
-- [ ] **Step 1: Search for any `MISTRAL` / `mistral` reference outside the historical plans**
+- [ ] **Step 1: Search for any `MISTRAL` / `mistral` reference outside the historical plans and build artifacts**
 
 Run:
 ```
 grep -rn -i mistral . \
   --include='*.ts' --include='*.tsx' --include='*.js' --include='*.json' \
   --include='*.md' --include='*.sh' --include='.env.example' \
-  | grep -v docs/superpowers/plans/ \
-  | grep -v docs/superpowers/specs/2026-04-12- \
-  | grep -v docs/superpowers/specs/2026-04-18-gemini- \
-  | grep -v node_modules
+  --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.git \
+  --exclude-dir=.next --exclude-dir=data --exclude-dir=store \
+  | grep -v 'docs/superpowers/plans/' \
+  | grep -v 'docs/superpowers/specs/2026-04-12-' \
+  | grep -v 'docs/superpowers/specs/2026-04-18-gemini-'
 ```
-Expected: Empty. Any hit that is NOT in `node_modules` or the excluded historical paths is a bug that needs a fix.
+
+Expected: Empty. Anything that surfaces is a live reference that the preceding tasks missed.
+
+**Excluded (intentionally):** `node_modules/`, `dist/` and other build output, `.git/`, `.next/`, `data/` (LightRAG working dir), `store/` (binary SQLite). Historical plan and spec docs are excluded by the trailing `grep -v` filters because the migration spec explicitly lists them as "Docs left alone".
 
 - [ ] **Step 2: If anything surfaces, file it as a follow-up**
 
@@ -1096,12 +995,16 @@ Expected: Exits 0.
 Run: `npm test`
 Expected: All tests pass.
 
-- [ ] **Step 4: Rebuild the container**
+- [ ] **Step 4: Rebuild the container (prune builder first — default for this PR)**
 
-Per `CLAUDE.md`: the builder cache is aggressive. If the container's Gemini-backed `ipc-mcp-stdio.ts` doesn't behave as expected after a normal rebuild, prune the builder and retry.
+Per `CLAUDE.md`: the builder cache is aggressive and `--no-cache` alone does NOT invalidate COPY steps. Since this migration rewrites a container-side file (`ipc-mcp-stdio.ts`) AND adds two new source files (`pcm-to-wav.ts`, `gemini-tts-request.ts`) that must land in the image, prune the builder before rebuilding rather than treating the prune as a fallback.
 
-Run: `./container/build.sh`
-Expected: Build succeeds. Note the image tag.
+Run:
+```
+docker builder prune -af
+./container/build.sh
+```
+Expected: Build succeeds and the new helper files appear in the compiled image. Note the image tag.
 
 - [ ] **Step 5: Restart NanoClaw**
 
@@ -1119,7 +1022,7 @@ Run each check and tick it off only after observing the expected behavior:
 - [ ] Send a Norwegian voice note → transcript is Norwegian with accented characters (æ, ø, å) rendered correctly as UTF-8.
 - [ ] Ask agent to speak → receive a Telegram voice bubble that plays, has a waveform, and sounds like the Kore voice.
 - [ ] Ask agent to speak Norwegian → plays Norwegian audio.
-- [ ] Ask agent to speak using `style_prompt: "Say warmly and slowly"` → tone is noticeably warmer and slower.
+- [ ] Ask agent to speak using `style_prompt: "Say warmly and slowly"` → tone is noticeably warmer and slower. **A/B check** (turns the subjective call into an observable one): first ask the agent to speak the same sentence WITHOUT `style_prompt`, then WITH it. Listen to both back-to-back. The two must audibly differ; if they sound identical the `style_prompt` prepend path is broken.
 - [ ] Ask agent to speak with inline `[whispering]` / `[slowly]` tags → tags honored at the tagged position.
 - [ ] Temporarily unset `GEMINI_API_KEY` and restart; send a voice note → `[Voice message (transcription failed)]`. Ask agent to speak → text-only fallback with sensible error message. Restore `GEMINI_API_KEY` and restart.
 

--- a/docs/superpowers/specs/2026-04-18-gemini-tts-stt-migration-design.md
+++ b/docs/superpowers/specs/2026-04-18-gemini-tts-stt-migration-design.md
@@ -1,0 +1,266 @@
+# Gemini TTS/STT Migration — Design
+
+**Status:** Draft
+**Date:** 2026-04-18
+**Author:** Simon
+**Scope:** Replace Mistral with Google Gemini for both speech-to-text (voice note transcription) and text-to-speech (agent voice replies). Hard cutover — no dual-provider setup, no feature flag.
+
+## Goals
+
+- Replace Mistral cloud APIs with Gemini across both audio paths.
+- Enable Norwegian TTS (Mistral did not support it; Gemini supports `nb` and `nn`).
+- Expose utterance-level style control to the agent via an optional `style_prompt` parameter.
+- Preserve the host-side WAV → OGG Opus conversion pipeline untouched. Migration stays localized to the two provider-facing surfaces.
+- Standardize the env variable name to `GEMINI_API_KEY`.
+
+## Non-goals
+
+- Live / real-time voice chat (separate project).
+- Voice cloning from reference samples.
+- Streaming TTS.
+- Mid-conversation voice swapping. Voice is hardcoded to a single prebuilt and only swappable via a constant in source.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    user["Telegram user"]
+    tg["Telegram Bot API"]
+    host["NanoClaw host<br/>(src/channels/telegram.ts, src/ipc.ts)"]
+    container["Agent container<br/>(ipc-mcp-stdio.ts)"]
+    gemini["Gemini API<br/>(TTS + STT)"]
+
+    user -->|"voice note .oga"| tg
+    tg -->|"download"| host
+    host -->|"generateContent<br/>gemini-2.5-flash-lite"| gemini
+    gemini -->|"transcript"| host
+    host -->|"[Voice]: text"| container
+
+    container -->|"generateContent<br/>gemini-3.1-flash-tts-preview"| gemini
+    gemini -->|"base64 PCM"| container
+    container -->|"WAV file via IPC"| host
+    host -->|"ffmpeg WAV→OGG Opus"| tg
+    tg -->|"voice bubble"| user
+```
+
+Two provider-facing surfaces change:
+
+1. **STT — host side**, `src/channels/telegram.ts`. Voice downloads and transcription already happen on the host before the agent is invoked. Only the HTTP call is swapped.
+2. **TTS — container side**, `container/agent-runner/src/ipc-mcp-stdio.ts` `synthesize_speech` tool. The tool's output contract (a WAV file path under `/workspace/group/audio/`) is preserved so the downstream IPC and host ffmpeg pipeline do not change.
+
+Everything between the container's WAV file and the outbound voice bubble (IPC JSON, path resolution, ffmpeg invocation, cleanup, `send_voice` tool, Channel interface) is untouched by this migration.
+
+## STT — data flow
+
+```
+Telegram voice (.oga)
+  → grammY downloads to /tmp/ via @grammyjs/files
+  → POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent
+     headers: x-goog-api-key: $GEMINI_API_KEY
+     body:
+       { contents: [{ parts: [
+           { inlineData: { mimeType: "audio/ogg", data: <base64 .oga bytes> } },
+           { text: "Generate a transcript of this speech." }
+       ]}]}
+  → response.candidates[0].content.parts[0].text (trim)
+  → delivered to agent as "[Voice]: {text}"
+  → temp file unlinked
+```
+
+No language hint is sent. Gemini auto-detects Norwegian / English / other from the audio itself. The `[Voice]:` prefix is preserved so the agent knows the input originated from audio.
+
+## TTS — data flow
+
+```
+Agent calls synthesize_speech({ text, style_prompt? })
+  → container builds prompt text:
+       style_prompt ? `${style_prompt}: ${text}` : text
+  → POST https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:generateContent
+     headers: x-goog-api-key: $GEMINI_API_KEY
+     body:
+       { contents: [{ parts: [{ text: prompt }] }],
+         generationConfig: {
+           responseModalities: ["AUDIO"],
+           speechConfig: { voiceConfig: { prebuiltVoiceConfig: { voiceName: "Kore" } } }
+         } }
+  → response.candidates[0].content.parts[0].inlineData.data
+     (base64 raw PCM, 24kHz mono 16-bit little-endian — NOT a WAV)
+  → decode to Buffer, prepend 44-byte RIFF/WAVE header
+  → write to /workspace/group/audio/tts-{timestamp}-{rand}.wav
+  → return { path, duration_seconds }
+Agent then calls send_voice(path)
+  → unchanged IPC flow → host ffmpeg WAV→OGG Opus → Telegram voice bubble
+```
+
+### WAV header format
+
+44-byte standard RIFF/WAVE header. Fields:
+
+| Offset | Bytes | Value |
+|---|---|---|
+| 0 | 4 | `"RIFF"` |
+| 4 | 4 | fileSize - 8 (little-endian u32) |
+| 8 | 4 | `"WAVE"` |
+| 12 | 4 | `"fmt "` |
+| 16 | 4 | 16 (PCM chunk size) |
+| 20 | 2 | 1 (PCM audio format) |
+| 22 | 2 | 1 (mono) |
+| 24 | 4 | 24000 (sample rate) |
+| 28 | 4 | 48000 (byte rate = 24000 × 1 × 2) |
+| 32 | 2 | 2 (block align) |
+| 34 | 2 | 16 (bits per sample) |
+| 36 | 4 | `"data"` |
+| 40 | 4 | pcmByteLength |
+
+The existing duration estimate formula (`(fileSize - 44) / 48000`) remains correct because byte rate is also 48000 bytes/sec.
+
+## MCP tool contract — `synthesize_speech`
+
+```ts
+{
+  text: z.string().max(50000).describe(
+    'Text to synthesize. You can embed Gemini audio tags like [warmly], ' +
+    '[slowly], [whispering], [excitedly] inline to color specific moments ' +
+    'within the speech.'
+  ),
+  style_prompt: z.string().optional().describe(
+    'Natural-language utterance-level style directive, e.g. "Say warmly ' +
+    'and slowly" or "Speak with calm encouragement". Prepended to the text ' +
+    'before synthesis. Use style_prompt for whole-utterance tone; use ' +
+    '[inline tags] inside text for moment-specific expression.'
+  ),
+}
+```
+
+Returned JSON is unchanged: `{ path, duration_seconds }`.
+
+`send_voice` is unchanged. `TTS_MAX_TEXT_LENGTH` stays at 50000. The voice is hardcoded to a module-level constant:
+
+```ts
+// Voice is a single prebuilt. To try another, change this constant.
+// Kore is a balanced multilingual default. Other good starting points:
+// "Charon", "Puck", "Zephyr", "Aoede". Full list: 30 prebuilts in Gemini TTS docs.
+const GEMINI_TTS_VOICE = "Kore";
+const GEMINI_TTS_MODEL = "gemini-3.1-flash-tts-preview";
+const GEMINI_TTS_URL = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_TTS_MODEL}:generateContent`;
+```
+
+## Env & config
+
+### `.env` (user runs manually, not checked in)
+
+```diff
+- MISTRAL_API_KEY=...
+- google_api_key=...
++ GEMINI_API_KEY=...
+```
+
+### `.env.example`
+
+Replace the `# --- Mistral API (TTS + STT) ---` block with:
+
+```
+# --- Gemini API (TTS + STT) ---
+GEMINI_API_KEY=
+```
+
+### `src/container-runner.ts`
+
+Replace the Mistral key injection (lines 251-257) with:
+
+```ts
+const geminiKey =
+  process.env.GEMINI_API_KEY ||
+  readEnvFile(['GEMINI_API_KEY']).GEMINI_API_KEY;
+if (geminiKey) {
+  args.push('-e', `GEMINI_API_KEY=${geminiKey}`);
+}
+```
+
+### `src/channels/telegram.ts`
+
+- Constructor param `mistralApiKey` → `geminiApiKey`.
+- Private field `mistralApiKey` → `geminiApiKey`.
+- `registerChannel` reads `GEMINI_API_KEY` instead of `MISTRAL_API_KEY`.
+- Warning message: `"Telegram: GEMINI_API_KEY not set — voice transcription disabled"`.
+- Voice handler: swap the Mistral multipart `FormData` POST for the Gemini inline-base64 JSON POST described in the STT data flow. The `.oga` bytes are base64-encoded and sent as `inlineData` with `mimeType: "audio/ogg"`.
+
+### `container/agent-runner/src/ipc-mcp-stdio.ts`
+
+- Delete `MISTRAL_TTS_URL` and `MISTRAL_DEFAULT_VOICE_ID`.
+- Add `GEMINI_TTS_URL`, `GEMINI_TTS_MODEL`, `GEMINI_TTS_VOICE` constants.
+- `process.env.MISTRAL_API_KEY` → `process.env.GEMINI_API_KEY`.
+- Rewrite the `synthesize_speech` body to match the TTS data flow and tool contract above.
+- Add a small pure function `pcmToWav(pcm: Buffer): Buffer` that prepends the 44-byte header. Unit-testable in isolation.
+
+## Error handling
+
+Same categories and fallback behavior as the current Mistral integration — no new failure modes are introduced.
+
+| Condition | Behavior |
+|---|---|
+| `GEMINI_API_KEY` missing (STT) | Log warning, skip transcription, agent receives `[Voice message (transcription failed)]` |
+| `GEMINI_API_KEY` missing (TTS) | MCP tool returns error with `isError: true`; agent falls back to text |
+| Gemini STT non-2xx / timeout (60s) | Log error with status + body, agent receives `[Voice message (transcription failed)]` |
+| Gemini TTS non-2xx / timeout (300s) | MCP tool returns error with body; agent falls back to text |
+| TTS response missing `candidates[0].content.parts[0].inlineData.data` | MCP tool returns error (analog of the current `audio_data` missing check) |
+| Empty / oversized text | Rejected in-tool before API call (unchanged) |
+| ffmpeg / IPC path validation | Unchanged — WAV output preserves the current invariant |
+
+Timeouts: STT `60_000`, TTS `300_000`. Unchanged from the current Mistral integration.
+
+## Docs to update (this migration)
+
+| File | Change |
+|---|---|
+| `docs/speech.md` | Full rewrite. Replace provider name, endpoints, flow diagrams. Remove "No Norwegian TTS" limitation. Update cost table with Gemini rates. Keep the "Why STT on host" rationale (still applies). Drop the "Why a cloud API for TTS" rationale (obsolete history). |
+| `docs/ARCHITECTURE.md` | Mermaid: `mistral["Mistral API<br/>(TTS / STT)"]` → `gemini["Gemini API<br/>(TTS / STT)"]`. Edge label `"audio synthesis"` → `"audio synthesis + transcription"`. |
+| `CLAUDE.md` | Env var table row (line 175): `MISTRAL_API_KEY` → `GEMINI_API_KEY`, purpose updated. |
+| `.env.example` | Provider block swap. |
+
+## Docs left alone
+
+Historical specs and plans are not rewritten. Active-reference docs above are the only ones updated.
+
+- `docs/superpowers/specs/2026-04-12-multi-method-study-system-design.md` — historical design, leave as-is.
+- `docs/superpowers/plans/2026-04-13-study-system-master-plan.md` — historical plan, leave as-is.
+- `docs/superpowers/plans/2026-04-16-s8b-audio-scaffolding.md` — historical plan, leave as-is.
+
+## Testing
+
+No existing Vitest coverage of the Mistral paths to port. Strategy: unit-test the deterministic pieces, manual smoke-test the end-to-end audio.
+
+### Unit tests (new)
+
+- `container/agent-runner/src/pcm-to-wav.test.ts` — verify `pcmToWav` produces a valid 44-byte RIFF/WAVE header for a PCM buffer of known length. Golden byte-level comparison of the header region and length bookkeeping.
+- `container/agent-runner/src/gemini-tts-request.test.ts` — unit-test the request-body builder (or, if inlined, the `JSON.stringify`'d body shape): with/without `style_prompt`, verify prompt composition and `speechConfig` structure.
+
+### Manual smoke tests (checklist, run before merging)
+
+1. Send a short English voice note to Telegram → agent receives `[Voice]: ...` with correct transcript.
+2. Send a Norwegian voice note → transcript is Norwegian.
+3. Ask agent to speak → receive a Telegram voice bubble that plays, has a waveform, and sounds like the Kore voice.
+4. Ask agent to speak Norwegian → plays Norwegian audio.
+5. Ask agent to speak using `style_prompt: "Say warmly and slowly"` → tone is noticeably warmer and slower.
+6. Ask agent to speak with inline `[whispering]` / `[slowly]` tags → tags honored at the tagged position.
+7. With `GEMINI_API_KEY` unset — send a voice note → agent receives `[Voice message (transcription failed)]`. Ask agent to speak → agent replies in text with a sensible fallback.
+
+### Pre-merge gate
+
+- `npm run build` clean.
+- `npm test` green.
+- `./container/build.sh` succeeds (builder cache may need pruning per `CLAUDE.md`).
+
+## Rollout
+
+1. Merge on `feat/gemini-tts-stt-migration` via PR to `SimonKvalheim/universityClaw`.
+2. User updates local `.env` (rename `google_api_key` → `GEMINI_API_KEY`, delete `MISTRAL_API_KEY`) before pulling.
+3. Rebuild container: `./container/build.sh`.
+4. Restart NanoClaw.
+5. Run the manual smoke checklist.
+
+No migration is needed for stored data — audio files are per-session and ephemeral.
+
+## Open questions
+
+None — all six open decisions resolved during brainstorming.

--- a/docs/superpowers/specs/2026-04-18-gemini-tts-stt-migration-design.md
+++ b/docs/superpowers/specs/2026-04-18-gemini-tts-stt-migration-design.md
@@ -9,7 +9,7 @@
 
 - Replace Mistral cloud APIs with Gemini across both audio paths.
 - Enable Norwegian TTS (Mistral did not support it; Gemini supports `nb` and `nn`).
-- Expose utterance-level style control to the agent via an optional `style_prompt` parameter.
+- Expose whole-utterance style control to the agent via an optional `style_prompt` parameter.
 - Preserve the host-side WAV → OGG Opus conversion pipeline untouched. Migration stays localized to the two provider-facing surfaces.
 - Standardize the env variable name to `GEMINI_API_KEY`.
 
@@ -69,12 +69,20 @@ Telegram voice (.oga)
 
 No language hint is sent. Gemini auto-detects Norwegian / English / other from the audio itself. The `[Voice]:` prefix is preserved so the agent knows the input originated from audio.
 
+### STT model choice & fallback
+
+Primary model: `gemini-2.5-flash-lite` — cheapest, suitable for short voice notes. Google's audio-understanding docs list multimodal input support for the 2.5 Flash family, but the public model cards do not explicitly enumerate `lite` against the audio modality. If `lite` returns a 400 on audio input during smoke testing, the implementer should swap the STT model constant to `gemini-2.5-flash` (documented multimodal, stable, ~3-5x cost on voice-note-sized inputs). Isolate this as a single named constant (`GEMINI_STT_MODEL`) at the top of the voice handler so the swap is a one-line change.
+
+### Inline audio size limit
+
+Gemini's `inlineData` cap is 20 MB per request. Telegram voice notes are Opus-encoded and typically well under 1 MB for several-minute recordings, so this is not a practical concern — but the spec acknowledges the cap. No explicit size guard is added; if a voice note somehow exceeds 20 MB, Gemini's 400 is caught by the existing non-2xx error branch and the agent receives `[Voice message (transcription failed)]`.
+
 ## TTS — data flow
 
 ```
 Agent calls synthesize_speech({ text, style_prompt? })
   → container builds prompt text:
-       style_prompt ? `${style_prompt}: ${text}` : text
+       (style_prompt && style_prompt.trim()) ? `${style_prompt.trim()}: ${text}` : text
   → POST https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-tts-preview:generateContent
      headers: x-goog-api-key: $GEMINI_API_KEY
      body:
@@ -124,7 +132,7 @@ The existing duration estimate formula (`(fileSize - 44) / 48000`) remains corre
     'within the speech.'
   ),
   style_prompt: z.string().optional().describe(
-    'Natural-language utterance-level style directive, e.g. "Say warmly ' +
+    'Natural-language whole-utterance style directive, e.g. "Say warmly ' +
     'and slowly" or "Speak with calm encouragement". Prepended to the text ' +
     'before synthesis. Use style_prompt for whole-utterance tone; use ' +
     '[inline tags] inside text for moment-specific expression.'
@@ -132,15 +140,19 @@ The existing duration estimate formula (`(fileSize - 44) / 48000`) remains corre
 }
 ```
 
+`style_prompt` is treated as absent when it is undefined, empty, or whitespace-only — in all three cases the prompt is just `text`. Otherwise it is trimmed and prepended as `"{style_prompt}: {text}"`. The `text` cap of 50000 chars is retained; at English/Norwegian token ratios this fits Gemini's 32k token context window with headroom.
+
 Returned JSON is unchanged: `{ path, duration_seconds }`.
 
-`send_voice` is unchanged. `TTS_MAX_TEXT_LENGTH` stays at 50000. The voice is hardcoded to a module-level constant:
+`send_voice` is unchanged. The TTS model and voice are hardcoded module-level constants:
 
 ```ts
 // Voice is a single prebuilt. To try another, change this constant.
 // Kore is a balanced multilingual default. Other good starting points:
 // "Charon", "Puck", "Zephyr", "Aoede". Full list: 30 prebuilts in Gemini TTS docs.
 const GEMINI_TTS_VOICE = "Kore";
+// TTS model is currently a preview. If it is deprecated or promoted to GA,
+// swap this constant — that is the only coupling point to the preview name.
 const GEMINI_TTS_MODEL = "gemini-3.1-flash-tts-preview";
 const GEMINI_TTS_URL = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_TTS_MODEL}:generateContent`;
 ```
@@ -166,7 +178,7 @@ GEMINI_API_KEY=
 
 ### `src/container-runner.ts`
 
-Replace the Mistral key injection (lines 251-257) with:
+Replace the Mistral-key injection block (the `process.env.MISTRAL_API_KEY || readEnvFile(...)` block that pushes `-e MISTRAL_API_KEY=...` into `args`) with the equivalent Gemini block:
 
 ```ts
 const geminiKey =
@@ -176,6 +188,8 @@ if (geminiKey) {
   args.push('-e', `GEMINI_API_KEY=${geminiKey}`);
 }
 ```
+
+Comment above the block mentions both TTS (container) and the fact that key injection bypasses OneCLI — matching the pre-existing Mistral pattern. This is intentional: the Gemini key uses the same direct env-injection approach Mistral used; it does not route through OneCLI.
 
 ### `src/channels/telegram.ts`
 
@@ -195,7 +209,7 @@ if (geminiKey) {
 
 ## Error handling
 
-Same categories and fallback behavior as the current Mistral integration — no new failure modes are introduced.
+Same categories and fallback behavior as the current Mistral integration, plus two Gemini-specific branches for safety blocks and modality mismatches.
 
 | Condition | Behavior |
 |---|---|
@@ -203,7 +217,8 @@ Same categories and fallback behavior as the current Mistral integration — no 
 | `GEMINI_API_KEY` missing (TTS) | MCP tool returns error with `isError: true`; agent falls back to text |
 | Gemini STT non-2xx / timeout (60s) | Log error with status + body, agent receives `[Voice message (transcription failed)]` |
 | Gemini TTS non-2xx / timeout (300s) | MCP tool returns error with body; agent falls back to text |
-| TTS response missing `candidates[0].content.parts[0].inlineData.data` | MCP tool returns error (analog of the current `audio_data` missing check) |
+| TTS response missing `candidates[0].content.parts[0].inlineData.data` | MCP tool returns error; before returning, log `candidates[0].finishReason` and top-level `promptFeedback.blockReason` if present so the cause (safety block, max tokens, modality mismatch) is diagnosable |
+| TTS response `parts[0]` contains `text` instead of `inlineData` (modality negotiation failure) | MCP tool returns an error distinguishing this from a missing-data error, logging the returned text for debugging |
 | Empty / oversized text | Rejected in-tool before API call (unchanged) |
 | ffmpeg / IPC path validation | Unchanged — WAV output preserves the current invariant |
 
@@ -213,9 +228,9 @@ Timeouts: STT `60_000`, TTS `300_000`. Unchanged from the current Mistral integr
 
 | File | Change |
 |---|---|
-| `docs/speech.md` | Full rewrite. Replace provider name, endpoints, flow diagrams. Remove "No Norwegian TTS" limitation. Update cost table with Gemini rates. Keep the "Why STT on host" rationale (still applies). Drop the "Why a cloud API for TTS" rationale (obsolete history). |
+| `docs/speech.md` | Full rewrite. Replace provider name, endpoints, flow diagrams. Remove "No Norwegian TTS" limitation. Update cost table with Gemini rates. Keep the "Why STT on host" rationale (still applies). Drop the "Why a cloud API for TTS" rationale (obsolete history). Also correct pre-existing staleness: `docs/speech.md` currently says "Text too long (>5000 chars)" (actual `TTS_MAX_TEXT_LENGTH` is 50000) and "TTS timeout (60s)" (actual is 300s). Fix both while rewriting. |
 | `docs/ARCHITECTURE.md` | Mermaid: `mistral["Mistral API<br/>(TTS / STT)"]` → `gemini["Gemini API<br/>(TTS / STT)"]`. Edge label `"audio synthesis"` → `"audio synthesis + transcription"`. |
-| `CLAUDE.md` | Env var table row (line 175): `MISTRAL_API_KEY` → `GEMINI_API_KEY`, purpose updated. |
+| `CLAUDE.md` | Env var table row (currently near line 175): `MISTRAL_API_KEY` → `GEMINI_API_KEY`, purpose updated. |
 | `.env.example` | Provider block swap. |
 
 ## Docs left alone
@@ -225,6 +240,7 @@ Historical specs and plans are not rewritten. Active-reference docs above are th
 - `docs/superpowers/specs/2026-04-12-multi-method-study-system-design.md` — historical design, leave as-is.
 - `docs/superpowers/plans/2026-04-13-study-system-master-plan.md` — historical plan, leave as-is.
 - `docs/superpowers/plans/2026-04-16-s8b-audio-scaffolding.md` — historical plan, leave as-is.
+- `container/skills/` — reviewed, no Mistral or Voxtral references. No changes.
 
 ## Testing
 
@@ -238,7 +254,7 @@ No existing Vitest coverage of the Mistral paths to port. Strategy: unit-test th
 ### Manual smoke tests (checklist, run before merging)
 
 1. Send a short English voice note to Telegram → agent receives `[Voice]: ...` with correct transcript.
-2. Send a Norwegian voice note → transcript is Norwegian.
+2. Send a Norwegian voice note → transcript is Norwegian with accented characters (æ, ø, å) rendered correctly as UTF-8.
 3. Ask agent to speak → receive a Telegram voice bubble that plays, has a waveform, and sounds like the Kore voice.
 4. Ask agent to speak Norwegian → plays Norwegian audio.
 5. Ask agent to speak using `style_prompt: "Say warmly and slowly"` → tone is noticeably warmer and slower.
@@ -254,7 +270,10 @@ No existing Vitest coverage of the Mistral paths to port. Strategy: unit-test th
 ## Rollout
 
 1. Merge on `feat/gemini-tts-stt-migration` via PR to `SimonKvalheim/universityClaw`.
-2. User updates local `.env` (rename `google_api_key` → `GEMINI_API_KEY`, delete `MISTRAL_API_KEY`) before pulling.
+2. **One-time user-visible migration step** — before pulling, update local `.env`:
+   - Rename the existing lowercase `google_api_key` entry to `GEMINI_API_KEY` (same value).
+   - Delete `MISTRAL_API_KEY`.
+   The new name is what every runtime code path (host + container) will look for. No code path reads `google_api_key` today, so there is no silent break on other consumers.
 3. Rebuild container: `./container/build.sh`.
 4. Restart NanoClaw.
 5. Run the manual smoke checklist.

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -19,6 +19,9 @@ import {
 
 type FilesContext = FileFlavor<Context>;
 
+// STT model. Swap to 'gemini-2.5-flash' if 'lite' returns 400 on audio input.
+const GEMINI_STT_MODEL = 'gemini-2.5-flash-lite';
+
 export interface TelegramChannelOpts {
   onMessage: OnInboundMessage;
   onChatMetadata: OnChatMetadata;
@@ -146,16 +149,16 @@ export class TelegramChannel implements Channel {
   private bot: Bot<FilesContext> | null = null;
   private opts: TelegramChannelOpts;
   private botToken: string;
-  private mistralApiKey: string;
+  private geminiApiKey: string;
 
   constructor(
     botToken: string,
     opts: TelegramChannelOpts,
-    mistralApiKey: string = '',
+    geminiApiKey: string = '',
   ) {
     this.botToken = botToken;
     this.opts = opts;
-    this.mistralApiKey = mistralApiKey;
+    this.geminiApiKey = geminiApiKey;
   }
 
   async connect(): Promise<void> {
@@ -379,33 +382,45 @@ export class TelegramChannel implements Channel {
         await file.download(localPath);
 
         try {
-          if (!this.mistralApiKey) {
-            logger.warn('Skipping transcription — no MISTRAL_API_KEY');
+          if (!this.geminiApiKey) {
+            logger.warn('Skipping transcription — no GEMINI_API_KEY');
           } else {
             const audioData = fs.readFileSync(localPath);
-            const formData = new FormData();
-            formData.append('model', 'voxtral-mini-latest');
-            formData.append(
-              'file',
-              new Blob([audioData], { type: 'audio/ogg' }),
-              'voice.oga',
-            );
-
             const response = await fetch(
-              'https://api.mistral.ai/v1/audio/transcriptions',
+              `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_STT_MODEL}:generateContent`,
               {
                 method: 'POST',
                 headers: {
-                  Authorization: `Bearer ${this.mistralApiKey}`,
+                  'Content-Type': 'application/json',
+                  'x-goog-api-key': this.geminiApiKey,
                 },
-                body: formData,
+                body: JSON.stringify({
+                  contents: [
+                    {
+                      parts: [
+                        {
+                          inlineData: {
+                            mimeType: 'audio/ogg',
+                            data: audioData.toString('base64'),
+                          },
+                        },
+                        { text: 'Generate a transcript of this speech.' },
+                      ],
+                    },
+                  ],
+                }),
                 signal: AbortSignal.timeout(60_000),
               },
             );
 
             if (response.ok) {
-              const result = (await response.json()) as { text?: string };
-              const text = result.text?.trim();
+              const result = (await response.json()) as {
+                candidates?: Array<{
+                  content?: { parts?: Array<{ text?: string }> };
+                }>;
+              };
+              const text =
+                result.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
               if (text) {
                 transcribedText = `[Voice]: ${text}`;
               }
@@ -413,7 +428,7 @@ export class TelegramChannel implements Channel {
               const errText = await response.text().catch(() => '');
               logger.error(
                 { status: response.status, body: errText },
-                'Mistral STT request failed',
+                'Gemini STT request failed',
               );
             }
           }
@@ -603,19 +618,19 @@ export class TelegramChannel implements Channel {
 }
 
 registerChannel('telegram', (opts: ChannelOpts) => {
-  const envVars = readEnvFile(['TELEGRAM_BOT_TOKEN', 'MISTRAL_API_KEY']);
+  const envVars = readEnvFile(['TELEGRAM_BOT_TOKEN', 'GEMINI_API_KEY']);
   const token =
     process.env.TELEGRAM_BOT_TOKEN || envVars.TELEGRAM_BOT_TOKEN || '';
   if (!token) {
     logger.warn('Telegram: TELEGRAM_BOT_TOKEN not set');
     return null;
   }
-  const mistralApiKey =
-    process.env.MISTRAL_API_KEY || envVars.MISTRAL_API_KEY || '';
-  if (!mistralApiKey) {
+  const geminiApiKey =
+    process.env.GEMINI_API_KEY || envVars.GEMINI_API_KEY || '';
+  if (!geminiApiKey) {
     logger.warn(
-      'Telegram: MISTRAL_API_KEY not set — voice transcription disabled',
+      'Telegram: GEMINI_API_KEY not set — voice transcription disabled',
     );
   }
-  return new TelegramChannel(token, opts, mistralApiKey);
+  return new TelegramChannel(token, opts, geminiApiKey);
 });

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -248,12 +248,14 @@ async function buildContainerArgs(
     .replace('127.0.0.1', 'host.docker.internal');
   args.push('-e', `LIGHTRAG_URL=${containerLightragUrl}`);
 
-  // Mistral API key for TTS (synthesize_speech tool in container)
-  const mistralKey =
-    process.env.MISTRAL_API_KEY ||
-    readEnvFile(['MISTRAL_API_KEY']).MISTRAL_API_KEY;
-  if (mistralKey) {
-    args.push('-e', `MISTRAL_API_KEY=${mistralKey}`);
+  // Gemini API key for STT (on host) and TTS (synthesize_speech tool in container).
+  // This bypasses the OneCLI gateway intentionally — it matches the direct env
+  // injection pattern the previous Mistral key used.
+  const geminiKey =
+    process.env.GEMINI_API_KEY ||
+    readEnvFile(['GEMINI_API_KEY']).GEMINI_API_KEY;
+  if (geminiKey) {
+    args.push('-e', `GEMINI_API_KEY=${geminiKey}`);
   }
 
   // OneCLI gateway handles credential injection — containers never see real secrets.

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -249,8 +249,7 @@ async function buildContainerArgs(
   args.push('-e', `LIGHTRAG_URL=${containerLightragUrl}`);
 
   // Gemini API key for STT (on host) and TTS (synthesize_speech tool in container).
-  // This bypasses the OneCLI gateway intentionally — it matches the direct env
-  // injection pattern the previous Mistral key used.
+  // Injected directly as an env var, bypassing the OneCLI gateway intentionally.
   const geminiKey =
     process.env.GEMINI_API_KEY ||
     readEnvFile(['GEMINI_API_KEY']).GEMINI_API_KEY;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,11 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts', 'setup/**/*.test.ts', 'dashboard/src/**/*.test.ts'],
+    include: [
+      'src/**/*.test.ts',
+      'setup/**/*.test.ts',
+      'dashboard/src/**/*.test.ts',
+      'container/agent-runner/src/**/*.test.ts',
+    ],
   },
 });


### PR DESCRIPTION
## Summary

- Replaces Mistral with Google Gemini across both audio paths: host-side STT (`src/channels/telegram.ts`) and container-side TTS (`container/agent-runner/src/ipc-mcp-stdio.ts`). Hard cutover, no dual-provider setup.
- Enables Norwegian TTS — Gemini supports `nb` (Bokmål) and `nn` (Nynorsk); Mistral did not.
- Adds optional `style_prompt` param to the `synthesize_speech` MCP tool for whole-utterance tone control (e.g. "Say warmly and slowly"). Inline Gemini audio tags (`[warmly]`, `[slowly]`, etc.) remain available inside `text` for moment-specific expression.
- Hardcodes TTS voice to `Kore` via a single constant (`GEMINI_TTS_VOICE` in `ipc-mcp-stdio.ts` — one-line swap). STT model is `gemini-2.5-flash-lite` with documented fallback to `gemini-2.5-flash` (one-line swap via `GEMINI_STT_MODEL` in `telegram.ts`).
- Standardizes env var to `GEMINI_API_KEY`. `MISTRAL_API_KEY` and the prior lowercase `google_api_key` entry are removed.
- Host ffmpeg WAV→OGG pipeline is untouched — the container wraps Gemini's base64 PCM as a 44-byte RIFF/WAVE header (via new pure helper `pcmToWav`) to preserve the existing IPC contract.

## Implementation

Decomposed into two pure helpers (TDD) plus the two handler rewrites plus env/docs updates:

- `container/agent-runner/src/pcm-to-wav.ts` + test — wraps 24kHz mono 16-bit PCM as 44-byte RIFF/WAVE.
- `container/agent-runner/src/gemini-tts-request.ts` + test — builds the Gemini `generateContent` body; encodes `style_prompt` empty/whitespace-as-absent semantics.
- TTS handler: new Gemini-specific error branches (`finishReason` / `promptFeedback.blockReason` logging; distinct error when the model returns text instead of audio).
- Docs: rewrote `docs/speech.md` end-to-end for Gemini, updated mermaid in `docs/ARCHITECTURE.md`, updated env-var row in `CLAUDE.md`, updated `.env.example`.

## Scope note

`docs/ARCHITECTURE.md` is added in this PR as a new file (not an edit). The content was pre-existing in the working tree, untracked, and authored independently of this migration. It was folded into this PR by the mermaid-update commit rather than split out — the migration-relevant change is only the `mistral` → `gemini` node rename inside the mermaid. The other 300 lines are unrelated architecture documentation that happens to land now.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 881 tests, 1 intermittent pre-existing `src/claw-skill.test.ts` timeout flake, unrelated
- [x] `./container/build.sh` succeeds; new helper files confirmed in the image
- [x] English STT smoke — Telegram voice note transcribed correctly
- [x] Norwegian STT smoke — transcribed with æ/ø/å intact
- [x] TTS smoke — Telegram voice bubble plays in the Kore voice

## Docs

- Spec: `docs/superpowers/specs/2026-04-18-gemini-tts-stt-migration-design.md`
- Plan: `docs/superpowers/plans/2026-04-18-gemini-tts-stt-migration-plan.md`

## User-visible migration step (already done locally)

`.env`: rename lowercase `google_api_key` → `GEMINI_API_KEY` (same value); delete `MISTRAL_API_KEY`.

## Known follow-ups (NOT fixed in this PR — separate PRs)

- **Session-cache invalidation bug** — `src/container-runner.ts:203-214` only compares `index.ts` mtimes when deciding whether to refresh `data/sessions/<group>/agent-runner-src/`. Edits to any other file in `container/agent-runner/src/` — or newly added files like the two helpers in this PR — go unnoticed; stale source gets bind-mounted into the container. Worked around during smoke testing by deleting the stale cache dir manually. Real bug, separate fix (one-line: replace the `index.ts` mtime check with a whole-tree max-mtime, or just always copy — the tree is small).
- **STT diagnostics parity with TTS** — the STT branch in `src/channels/telegram.ts` currently falls through to the generic `[Voice message (transcription failed)]` placeholder when a 2xx response lacks `candidates[0].content.parts[0].text`. The TTS side has richer diagnostics (`finishReason`, `promptFeedback.blockReason`, modality-mismatch branch). STT should get the same if Gemini ever starts safety-blocking voice notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)