### PR TITLE
Live Voice Chat v1 — Dev Assistant (/voice)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,8 @@ ZOTERO_USER_ID=
 # ZOTERO_POLL_INTERVAL=60000
 # ZOTERO_EXCLUDE_COLLECTION=Do Not Process
 # ZOTERO_LOCAL_URL=http://localhost:23119
+
+# --- Voice (live Gemini chat at /voice) ---
+# GEMINI_API_KEY is set by the migration spec; if only lowercase google_api_key
+# is present, the voice feature falls back to it with a one-time warning.
+VOICE_MONTHLY_BUDGET_USD=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ This is a fork of NanoClaw customized as a personal university teaching assistan
 | RAG Indexer | `src/rag/indexer.ts` | Chokidar watcher with content-hash dedup, delete-before-reinsert lifecycle |
 | Student Profile | `src/profile/` | Learning progress tracking, knowledge map, study log rotation |
 | Web Dashboard | `dashboard/` | Next.js app for upload, verification status, vault browsing |
+| Live Voice (`/voice`) | `dashboard/src/app/voice/` + `src/voice/` | Gemini Live brainstorm partner (Dev Assistant persona). See `docs/superpowers/specs/2026-04-18-live-voice-chat-design.md`. |
 
 ### Key Paths
 
@@ -98,6 +99,9 @@ This is a fork of NanoClaw customized as a personal university teaching assistan
 - `scripts/docling-extract.py` — Python document extraction script
 - `store/messages.db` — SQLite database (messages, tasks, ingestion jobs, RAG tracker)
 - `data/` — IPC files, extraction artifacts
+- `data/voice.log` — JSON-line structured log for the live voice feature (session start/end, tool calls)
+- `docs/superpowers/brainstorm-sessions/` — voice session transcripts (dogfooded; NOT indexed by RAG)
+- `docs/superpowers/mockups/` — Dev-Assistant-authored HTML mockups and mermaid diagrams
 - `onecli/` — OneCLI credential gateway config (containers already built; for new installs, run `/init-onecli`)
 
 ### Testing
@@ -173,6 +177,8 @@ Key env vars (set in `.env` or shell). All have sensible defaults:
 | `EXTRACTION_TIMEOUT` | `600000` (10min) | Docling per-document timeout |
 | `DASHBOARD_PORT` | `3100` | Dashboard web UI port |
 | `MISTRAL_API_KEY` | — | Mistral API key (TTS + STT) |
+| `GEMINI_API_KEY` | — | Gemini API key (required by `/voice`; fallback to legacy `google_api_key` until migration lands) |
+| `VOICE_MONTHLY_BUDGET_USD` | — | Optional — surfaces an amber banner on `/voice` when monthly cost exceeds this |
 | `LIGHTRAG_LLM_BINDING` | `openai` | LightRAG LLM provider |
 | `LIGHTRAG_LLM_MODEL` | `gpt-4o-mini` | LightRAG LLM model |
 | `LIGHTRAG_EMBED_BINDING` | `openai` | LightRAG embedding provider |

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -14,6 +14,7 @@
         "@types/better-sqlite3": "^7.6.13",
         "better-sqlite3": "^12.8.0",
         "drizzle-orm": "^0.45.2",
+        "glob": "^13.0.6",
         "gray-matter": "^4.0.3",
         "jszip": "^3.10.1",
         "mermaid": "^11.14.0",
@@ -26,6 +27,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/glob": "^8.1.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2475,6 +2477,17 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
+    "node_modules/@types/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "^5.1.2",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -2506,6 +2519,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -5937,6 +5957,23 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5948,6 +5985,42 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -8293,6 +8366,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -8848,6 +8930,31 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -9,23 +9,27 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@google/genai": "^1.50.1",
         "@tailwindcss/typography": "^0.5.19",
         "@types/better-sqlite3": "^7.6.13",
         "better-sqlite3": "^12.8.0",
         "drizzle-orm": "^0.45.2",
         "gray-matter": "^4.0.3",
         "jszip": "^3.10.1",
+        "mermaid": "^11.14.0",
         "next": "16.2.1",
         "pdfjs-dist": "^5.6.205",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "react-markdown": "^10.1.0"
+        "react-markdown": "^10.1.0",
+        "uuid": "^13.0.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/uuid": "^10.0.0",
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
         "jsdom": "^29.0.2",
@@ -44,6 +48,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -326,6 +343,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
@@ -338,6 +361,43 @@
       "bin": {
         "specificity": "bin/cli.js"
       }
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
@@ -676,6 +736,29 @@
         }
       }
     },
+    "node_modules/@google/genai": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.50.1.tgz",
+      "integrity": "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -726,6 +809,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "mlly": "^1.8.0"
       }
     },
     "node_modules/@img/colour": {
@@ -1244,6 +1344,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+      "license": "MIT",
+      "dependencies": {
+        "langium": "^4.0.0"
+      }
+    },
     "node_modules/@napi-rs/canvas": {
       "version": "0.1.97",
       "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.97.tgz",
@@ -1699,6 +1808,70 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2019,6 +2192,259 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2042,6 +2468,12 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -2110,10 +2542,30 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2687,11 +3139,20 @@
         "win32"
       ]
     },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -2709,6 +3170,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -3048,6 +3518,15 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -3150,6 +3629,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -3298,6 +3783,35 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chevrotain": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.1.tgz",
+      "integrity": "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      },
+      "peerDependencies": {
+        "chevrotain": "^12.0.0"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -3340,11 +3854,26 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
@@ -3359,6 +3888,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3407,12 +3945,522 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
+      "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -3481,6 +4529,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3586,6 +4640,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3628,6 +4691,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/drizzle-orm": {
@@ -3768,6 +4840,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -4564,6 +5645,29 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -4650,6 +5754,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -4695,6 +5811,34 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/generator-function": {
@@ -4836,6 +5980,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -4892,6 +6062,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -5067,6 +6243,31 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -5161,6 +6362,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {
@@ -5776,6 +6986,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -5874,6 +7093,52 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5884,6 +7149,11 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -5891,6 +7161,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/langium": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
+      "integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.1",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -5912,6 +7200,12 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -6213,12 +7507,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -6261,6 +7567,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -6441,6 +7759,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/micromark": {
@@ -6939,6 +8299,18 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7097,6 +8469,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -7114,6 +8506,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-readable-to-web-readable-stream": {
@@ -7330,6 +8740,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -7387,6 +8816,12 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7412,6 +8847,12 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
     "node_modules/pdfjs-dist": {
@@ -7444,6 +8885,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -7561,6 +9029,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/pump": {
@@ -7827,6 +9319,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7836,6 +9337,24 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
       }
     },
     "node_modules/run-parallel": {
@@ -7861,6 +9380,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -7936,6 +9461,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -8491,6 +10022,12 @@
         }
       }
     },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8571,6 +10108,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -8712,6 +10258,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -8887,6 +10442,12 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
@@ -9092,6 +10653,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -9120,6 +10694,55 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -9131,6 +10754,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -9288,6 +10920,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -32,11 +32,13 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.18.1",
         "eslint": "^9",
         "eslint-config-next": "16.2.1",
         "jsdom": "^29.0.2",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "ws": "^8.20.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2587,6 +2589,16 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.2",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -15,6 +15,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "better-sqlite3": "^12.8.0",
     "drizzle-orm": "^0.45.2",
+    "glob": "^13.0.6",
     "gray-matter": "^4.0.3",
     "jszip": "^3.10.1",
     "mermaid": "^11.14.0",
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/glob": "^8.1.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -33,10 +33,12 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/uuid": "^10.0.0",
+    "@types/ws": "^8.18.1",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
     "jsdom": "^29.0.2",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "ws": "^8.20.0"
   }
 }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -10,23 +10,27 @@
     "postinstall": "cp node_modules/pdfjs-dist/build/pdf.worker.min.mjs public/pdf.worker.min.mjs"
   },
   "dependencies": {
+    "@google/genai": "^1.50.1",
     "@tailwindcss/typography": "^0.5.19",
     "@types/better-sqlite3": "^7.6.13",
     "better-sqlite3": "^12.8.0",
     "drizzle-orm": "^0.45.2",
     "gray-matter": "^4.0.3",
     "jszip": "^3.10.1",
+    "mermaid": "^11.14.0",
     "next": "16.2.1",
     "pdfjs-dist": "^5.6.205",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/uuid": "^10.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
     "jsdom": "^29.0.2",

--- a/dashboard/public/voice/pcm-capture.js
+++ b/dashboard/public/voice/pcm-capture.js
@@ -1,0 +1,42 @@
+// Plain JS copy of audio-worklet-processor.ts. Kept in sync manually; this
+// is what audioContext.audioWorklet.addModule('/voice/pcm-capture.js') loads.
+// Modifications must be mirrored in the TS reference file.
+
+const TARGET_RATE = 16000;
+const TARGET_FRAMES = 320; // 20 ms at 16 kHz
+
+class PcmCaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.buf = [];
+    this.ratio = sampleRate / TARGET_RATE;
+    this.phase = 0;
+  }
+
+  process(inputs) {
+    const ch = inputs[0] && inputs[0][0];
+    if (!ch) return true;
+
+    for (let i = 0; i < ch.length; i++) {
+      this.phase += 1;
+      if (this.phase >= this.ratio) {
+        this.buf.push(ch[i]);
+        this.phase -= this.ratio;
+      }
+    }
+
+    while (this.buf.length >= TARGET_FRAMES) {
+      const slice = this.buf.splice(0, TARGET_FRAMES);
+      const out = new Int16Array(TARGET_FRAMES);
+      for (let i = 0; i < TARGET_FRAMES; i++) {
+        const s = Math.max(-1, Math.min(1, slice[i]));
+        out[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+      }
+      this.port.postMessage(out, [out.buffer]);
+    }
+
+    return true;
+  }
+}
+
+registerProcessor('pcm-capture', PcmCaptureProcessor);

--- a/dashboard/src/app/api/voice/__tests__/context.test.ts
+++ b/dashboard/src/app/api/voice/__tests__/context.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { GET } from '../context/dev/route';
+
+function makeReq(host = 'localhost:3100') {
+  return new Request('http://localhost:3100/api/voice/context/dev', {
+    headers: { host },
+  });
+}
+
+describe('GET /api/voice/context/dev', () => {
+  it('returns 403 off loopback', async () => {
+    const res = await GET(makeReq('public.example.com'));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns full context payload shape', async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(typeof body.claudeMd).toBe('string');
+    expect(body.claudeMd.length).toBeGreaterThan(100); // CLAUDE.md exists in this repo
+
+    expect(typeof body.architecture).toBe('string'); // may be empty; type still string
+
+    expect(Array.isArray(body.subsystemMap)).toBe(true);
+    expect(body.subsystemMap.length).toBeGreaterThan(0);
+    expect(body.subsystemMap[0]).toHaveProperty('path');
+    expect(body.subsystemMap[0]).toHaveProperty('purpose');
+
+    expect(typeof body.scripts.root).toBe('object');
+    expect(typeof body.scripts.dashboard).toBe('object');
+    expect(typeof body.scripts.root.test).toBe('string'); // root package has a "test" script
+
+    expect(typeof body.repoState.branch).toBe('string');
+    expect(typeof body.repoState.statusShort).toBe('string');
+    expect(Array.isArray(body.repoState.recentCommits)).toBe(true);
+    expect(body.repoState.recentCommits.length).toBeGreaterThan(0);
+    expect(body.repoState.recentCommits[0]).toHaveProperty('sha');
+    expect(body.repoState.recentCommits[0]).toHaveProperty('subject');
+    expect(Array.isArray(body.repoState.specNames)).toBe(true);
+    expect(Array.isArray(body.repoState.planNames)).toBe(true);
+
+    expect(body.sessionMeta.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('tolerates missing docs/ARCHITECTURE.md with a warning', async () => {
+    // In this worktree, docs/ARCHITECTURE.md is currently absent.
+    // The handler must not 500; it should return '' with a warning.
+    const res = await GET(makeReq());
+    const body = await res.json();
+    if (body.architecture === '') {
+      // Either the warning mentions the missing file, or it's simply absent — both acceptable.
+      // We just assert the server didn't crash.
+      expect(body.architecture).toBe('');
+    }
+  });
+});

--- a/dashboard/src/app/api/voice/__tests__/session-close.test.ts
+++ b/dashboard/src/app/api/voice/__tests__/session-close.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+// Set STORE_DIR BEFORE the route imports getDb(), so getDb resolves
+// <repoRoot>/store/messages.db under vitest (cwd == repoRoot).
+const REPO_ROOT = process.cwd().endsWith('/dashboard')
+  ? path.resolve(process.cwd(), '..')
+  : process.cwd();
+
+process.env.STORE_DIR = path.join(REPO_ROOT, 'store');
+
+import { POST } from '../session-close/route';
+
+const cleanupIds: string[] = [];
+const cleanupFiles: string[] = [];
+
+afterAll(() => {
+  const db = new Database(path.join(REPO_ROOT, 'store', 'messages.db'));
+  for (const sid of cleanupIds) {
+    db.prepare('DELETE FROM voice_sessions WHERE id = ?').run(sid);
+  }
+  db.close();
+  for (const f of cleanupFiles) {
+    if (existsSync(f)) rmSync(f, { force: true });
+  }
+});
+
+function newSid(): string {
+  const sid = 'test-' + Math.random().toString(36).slice(2, 10) + '-' + Date.now();
+  cleanupIds.push(sid);
+  return sid;
+}
+
+async function close(body: unknown, host = 'localhost:3100') {
+  const req = new Request('http://localhost:3100/api/voice/session-close', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', host },
+    body: JSON.stringify(body),
+  });
+  const res = await POST(req);
+  return { status: res.status, body: await res.json() };
+}
+
+describe('POST /api/voice/session-close', () => {
+  it('returns 403 off loopback', async () => {
+    const res = await close({}, 'public.example.com');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 on missing voiceSessionId', async () => {
+    const res = await close({ persona: 'dev' });
+    expect(res.status).toBe(400);
+  });
+
+  it('persists transcript file + session row', async () => {
+    const sid = newSid();
+    const startedAt = new Date(Date.now() - 60_000).toISOString();
+    const endedAt   = new Date().toISOString();
+    const { status, body } = await close({
+      voiceSessionId: sid,
+      persona: 'dev',
+      startedAt,
+      endedAt,
+      transcript: [
+        { role: 'user', text: 'hi', ts: startedAt },
+        { role: 'assistant', text: 'hello there', ts: endedAt },
+      ],
+      usage: { textIn: 1000, textOut: 2000, audioIn: 50_000, audioOut: 100_000 },
+      artifacts: [],
+      endReason: 'user_stop',
+    });
+
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.transcriptPath).toMatch(/brainstorm-sessions/);
+    expect(typeof body.costUsd).toBe('number');
+
+    const absPath = path.join(REPO_ROOT, body.transcriptPath);
+    cleanupFiles.push(absPath);
+    expect(existsSync(absPath)).toBe(true);
+
+    const md = readFileSync(absPath, 'utf8');
+    expect(md).toContain('## User');
+    expect(md).toContain('> hi');
+    expect(md).toContain('## Assistant');
+    expect(md).toContain('hello there');
+    expect(md).toContain(`voiceSessionId: ${sid}`);
+
+    const db = new Database(path.join(REPO_ROOT, 'store', 'messages.db'));
+    const row = db.prepare('SELECT * FROM voice_sessions WHERE id = ?').get(sid) as {
+      id: string;
+      persona: string;
+      duration_seconds: number;
+      cost_usd: number;
+      rates_version: string;
+      transcript_path: string | null;
+      artifacts: string | null;
+    };
+    db.close();
+    expect(row.persona).toBe('dev');
+    expect(row.duration_seconds).toBeGreaterThan(0);
+    expect(row.cost_usd).toBeGreaterThanOrEqual(0);
+    expect(row.rates_version).toBeTruthy();
+    expect(row.transcript_path).toBe(body.transcriptPath);
+  });
+
+  it('skips transcript file when transcript is empty (but still inserts session row)', async () => {
+    const sid = newSid();
+    const startedAt = new Date(Date.now() - 5_000).toISOString();
+    const endedAt   = new Date().toISOString();
+    const { body } = await close({
+      voiceSessionId: sid,
+      persona: 'dev',
+      startedAt,
+      endedAt,
+      transcript: [],
+      usage: { textIn: 0, textOut: 0, audioIn: 0, audioOut: 0 },
+      artifacts: [],
+      endReason: 'ws_drop',
+    });
+    expect(body.ok).toBe(true);
+    expect(body.transcriptPath).toBeNull();
+    expect(body.costUsd).toBe(0);
+
+    const db = new Database(path.join(REPO_ROOT, 'store', 'messages.db'));
+    const row = db.prepare('SELECT transcript_path FROM voice_sessions WHERE id = ?').get(sid) as { transcript_path: string | null };
+    db.close();
+    expect(row.transcript_path).toBeNull();
+  });
+
+  it('stores artifacts as JSON array', async () => {
+    const sid = newSid();
+    const startedAt = new Date(Date.now() - 1000).toISOString();
+    const endedAt   = new Date().toISOString();
+    const artifacts = ['docs/superpowers/mockups/2026-04-18-foo.html'];
+    const { body } = await close({
+      voiceSessionId: sid,
+      persona: 'dev',
+      startedAt,
+      endedAt,
+      transcript: [],
+      usage: { textIn: 0, textOut: 0, audioIn: 0, audioOut: 0 },
+      artifacts,
+      endReason: 'user_stop',
+    });
+    expect(body.ok).toBe(true);
+
+    const db = new Database(path.join(REPO_ROOT, 'store', 'messages.db'));
+    const row = db.prepare('SELECT artifacts FROM voice_sessions WHERE id = ?').get(sid) as { artifacts: string | null };
+    db.close();
+    expect(row.artifacts).toBeTruthy();
+    expect(JSON.parse(row.artifacts!)).toEqual(artifacts);
+  });
+});

--- a/dashboard/src/app/api/voice/__tests__/session-close.test.ts
+++ b/dashboard/src/app/api/voice/__tests__/session-close.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { describe, it, expect, afterAll } from 'vitest';
 import { existsSync, readFileSync, rmSync } from 'node:fs';
 import path from 'node:path';
 import Database from 'better-sqlite3';

--- a/dashboard/src/app/api/voice/__tests__/stats.test.ts
+++ b/dashboard/src/app/api/voice/__tests__/stats.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+const REPO_ROOT = process.cwd().endsWith('/dashboard')
+  ? path.resolve(process.cwd(), '..')
+  : process.cwd();
+
+process.env.STORE_DIR = path.join(REPO_ROOT, 'store');
+
+import { GET } from '../stats/route';
+
+const SID = 'stats-test-' + Date.now() + '-' + Math.random().toString(36).slice(2, 6);
+
+beforeAll(() => {
+  // Seed a known row so today/month rollups are non-zero.
+  const db = new Database(path.join(REPO_ROOT, 'store', 'messages.db'));
+  db.prepare(
+    `INSERT INTO voice_sessions (id, persona, started_at, ended_at, duration_seconds,
+       text_tokens_in, text_tokens_out, audio_tokens_in, audio_tokens_out,
+       cost_usd, rates_version, transcript_path, artifacts)
+     VALUES (?, 'dev', ?, ?, 60, 0, 0, 0, 0, 1.23, 'test', NULL, '[]')`,
+  ).run(SID, new Date().toISOString(), new Date().toISOString());
+  db.close();
+});
+
+afterAll(() => {
+  const db = new Database(path.join(REPO_ROOT, 'store', 'messages.db'));
+  db.prepare('DELETE FROM voice_sessions WHERE id = ?').run(SID);
+  db.close();
+});
+
+describe('GET /api/voice/stats', () => {
+  it('returns 403 off loopback', async () => {
+    const req = new Request('http://localhost:3100/api/voice/stats', {
+      headers: { host: 'public.example.com' },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns today and month totals plus optional budget', async () => {
+    const req = new Request('http://localhost:3100/api/voice/stats', {
+      headers: { host: 'localhost' },
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.todayUsd).toBe('number');
+    expect(typeof body.monthUsd).toBe('number');
+    expect(body.todayUsd).toBeGreaterThanOrEqual(1.23);
+    expect(body.monthUsd).toBeGreaterThanOrEqual(1.23);
+    expect(body.budgetUsd === null || typeof body.budgetUsd === 'number').toBe(true);
+  });
+
+  it('reads VOICE_MONTHLY_BUDGET_USD from env when set', async () => {
+    const prev = process.env.VOICE_MONTHLY_BUDGET_USD;
+    process.env.VOICE_MONTHLY_BUDGET_USD = '50';
+    try {
+      const req = new Request('http://localhost:3100/api/voice/stats', {
+        headers: { host: 'localhost' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+      expect(body.budgetUsd).toBe(50);
+    } finally {
+      if (prev === undefined) delete process.env.VOICE_MONTHLY_BUDGET_USD;
+      else process.env.VOICE_MONTHLY_BUDGET_USD = prev;
+    }
+  });
+});

--- a/dashboard/src/app/api/voice/__tests__/token.test.ts
+++ b/dashboard/src/app/api/voice/__tests__/token.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../token/route';
+
+// Mock @google/genai — the real SDK is only used at runtime.
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: class {
+    authTokens = {
+      create: vi.fn().mockResolvedValue({ name: 'tokens/fake-ephemeral' }),
+    };
+  },
+}));
+
+function makeReq(body: unknown, host = 'localhost:3100') {
+  return new Request('http://localhost:3100/api/voice/token', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', host },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/voice/token', () => {
+  beforeEach(() => {
+    process.env.GEMINI_API_KEY = 'test-key';
+    delete process.env.google_api_key;
+  });
+
+  it('returns 400 when persona missing', async () => {
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when persona is not "dev"', async () => {
+    const res = await POST(makeReq({ persona: 'teacher' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 403 when host is not loopback', async () => {
+    const res = await POST(makeReq({ persona: 'dev' }, 'public.example.com'));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 500 when no API key is set', async () => {
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.google_api_key;
+    const res = await POST(makeReq({ persona: 'dev' }));
+    expect(res.status).toBe(500);
+  });
+
+  it('falls back to lowercase google_api_key when GEMINI_API_KEY is absent', async () => {
+    delete process.env.GEMINI_API_KEY;
+    process.env.google_api_key = 'legacy-lowercase-key';
+    const res = await POST(makeReq({ persona: 'dev' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('returns an ephemeral token + voiceSessionId on success', async () => {
+    const res = await POST(makeReq({ persona: 'dev' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.token).toBe('string');
+    expect(body.token.length).toBeGreaterThan(0);
+    expect(body.voiceSessionId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('accepts (and ignores) resumeHandle in v1', async () => {
+    const res = await POST(makeReq({ persona: 'dev', resumeHandle: 'abc' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('treats 127.0.0.1 as loopback', async () => {
+    const res = await POST(makeReq({ persona: 'dev' }, '127.0.0.1:3100'));
+    expect(res.status).toBe(200);
+  });
+});

--- a/dashboard/src/app/api/voice/__tests__/tools-read.test.ts
+++ b/dashboard/src/app/api/voice/__tests__/tools-read.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { POST } from '../tools/dev/[tool]/route';
+
+async function call(tool: string, args: unknown) {
+  const req = new Request(`http://localhost:3100/api/voice/tools/dev/${tool}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', host: 'localhost' },
+    body: JSON.stringify(args),
+  });
+  const res = await POST(req, { params: Promise.resolve({ tool }) });
+  return { status: res.status, body: await res.json() };
+}
+
+describe('read tools', () => {
+  it('read_file: returns contents for an allowed root config', async () => {
+    const { status, body } = await call('read_file', { path: 'package.json' });
+    expect(status).toBe(200);
+    expect(body.content).toContain('"name"');
+  });
+
+  it('read_file: returns contents for a src/ file', async () => {
+    const { status, body } = await call('read_file', { path: 'src/voice/path-scope.ts' });
+    expect(status).toBe(200);
+    expect(body.content).toContain('sanitizeSlug');
+  });
+
+  it('read_file: rejects .env with a clear error (200 with body.error)', async () => {
+    const { status, body } = await call('read_file', { path: '.env' });
+    expect(status).toBe(200);
+    expect(body.error).toMatch(/out of scope/);
+  });
+
+  it('read_file: rejects node_modules', async () => {
+    const { body } = await call('read_file', { path: 'node_modules/foo/index.js' });
+    expect(body.error).toMatch(/out of scope/);
+  });
+
+  it('read_file: returns a truncation marker when file exceeds 256 KB', async () => {
+    // Use a known-large file if available. package-lock.json is usually >256 KB.
+    const { body } = await call('read_file', { path: 'package-lock.json' });
+    // If it's short, the test still passes (just no truncation marker).
+    // If it's large, we expect the marker.
+    if (body.content && body.content.length >= 256 * 1024) {
+      expect(body.content).toContain('[truncated at 256 KB');
+    }
+  });
+
+  it('glob: returns matching paths', async () => {
+    const { status, body } = await call('glob', { pattern: 'src/**/*.test.ts' });
+    expect(status).toBe(200);
+    expect(Array.isArray(body.paths)).toBe(true);
+    expect(body.paths.length).toBeGreaterThan(0);
+    expect(body.paths[0]).toMatch(/\.test\.ts$/);
+  });
+
+  it('glob: rejects patterns starting with ..', async () => {
+    const { body } = await call('glob', { pattern: '../../etc/*' });
+    expect(body.error).toMatch(/out of scope|invalid pattern/);
+  });
+
+  it('grep: returns matches with path/line/text', async () => {
+    const { status, body } = await call('grep', { pattern: 'sanitizeSlug', glob: 'src/voice/*.ts' });
+    expect(status).toBe(200);
+    expect(Array.isArray(body.matches)).toBe(true);
+    expect(body.matches.length).toBeGreaterThan(0);
+    expect(body.matches[0]).toHaveProperty('path');
+    expect(body.matches[0]).toHaveProperty('line');
+    expect(body.matches[0]).toHaveProperty('text');
+  });
+
+  it('git_log: returns recent commits, honoring limit', async () => {
+    const { status, body } = await call('git_log', { limit: 3 });
+    expect(status).toBe(200);
+    expect(Array.isArray(body.commits)).toBe(true);
+    expect(body.commits.length).toBeLessThanOrEqual(3);
+    expect(body.commits.length).toBeGreaterThan(0);
+    expect(body.commits[0]).toHaveProperty('sha');
+    expect(body.commits[0]).toHaveProperty('subject');
+  });
+
+  it('git_status: returns branch and changes', async () => {
+    const { status, body } = await call('git_status', {});
+    expect(status).toBe(200);
+    expect(typeof body.branch).toBe('string');
+    expect(body.branch.length).toBeGreaterThan(0);
+  });
+
+  it('list_docs: lists spec filenames', async () => {
+    const { status, body } = await call('list_docs', { kind: 'specs' });
+    expect(status).toBe(200);
+    expect(Array.isArray(body.files)).toBe(true);
+    expect(body.files.some((f: string) => f.endsWith('.md'))).toBe(true);
+  });
+
+  it('list_docs: rejects unknown kind', async () => {
+    const { body } = await call('list_docs', { kind: 'secrets' });
+    expect(body.error).toBeDefined();
+  });
+
+  it('read_doc: returns a spec file', async () => {
+    const { status, body } = await call('read_doc', {
+      kind: 'specs',
+      name: '2026-04-18-live-voice-chat-design.md',
+    });
+    expect(status).toBe(200);
+    expect(body.content).toContain('# Live Voice Chat');
+  });
+
+  it('read_doc: rejects traversal in name', async () => {
+    const { body } = await call('read_doc', { kind: 'specs', name: '../../etc/passwd' });
+    expect(body.error).toBeDefined();
+  });
+
+  it('unknown tool returns 404', async () => {
+    const req = new Request('http://localhost:3100/api/voice/tools/dev/bogus', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', host: 'localhost' },
+      body: JSON.stringify({}),
+    });
+    const res = await POST(req, { params: Promise.resolve({ tool: 'bogus' }) });
+    expect(res.status).toBe(404);
+  });
+
+  it('off-loopback returns 403', async () => {
+    const req = new Request('http://public.example.com/api/voice/tools/dev/read_file', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', host: 'public.example.com' },
+      body: JSON.stringify({ path: 'package.json' }),
+    });
+    const res = await POST(req, { params: Promise.resolve({ tool: 'read_file' }) });
+    expect(res.status).toBe(403);
+  });
+});

--- a/dashboard/src/app/api/voice/__tests__/tools-write.test.ts
+++ b/dashboard/src/app/api/voice/__tests__/tools-write.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { existsSync, readFileSync, rmSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { POST } from '../tools/dev/[tool]/route';
+
+async function call(tool: string, args: unknown) {
+  const req = new Request(`http://localhost:3100/api/voice/tools/dev/${tool}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', host: 'localhost' },
+    body: JSON.stringify(args),
+  });
+  const res = await POST(req, { params: Promise.resolve({ tool }) });
+  return { status: res.status, body: await res.json() };
+}
+
+const UNIQUE_SLUG = `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+// Absolute paths for cleanup
+const REPO_ROOT = process.cwd().endsWith('/dashboard')
+  ? path.resolve(process.cwd(), '..')
+  : process.cwd();
+
+const DIRS = {
+  specs: path.join(REPO_ROOT, 'docs', 'superpowers', 'specs'),
+  plans: path.join(REPO_ROOT, 'docs', 'superpowers', 'plans'),
+  mockups: path.join(REPO_ROOT, 'docs', 'superpowers', 'mockups'),
+};
+
+function cleanup() {
+  for (const dir of Object.values(DIRS)) {
+    if (!existsSync(dir)) continue;
+    for (const name of readdirSync(dir)) {
+      if (name.includes(UNIQUE_SLUG)) {
+        rmSync(path.join(dir, name), { force: true });
+      }
+    }
+  }
+}
+
+afterAll(() => cleanup());
+
+describe('write tools', () => {
+  it("write_spec: writes to docs/superpowers/specs/ with today's date", async () => {
+    const { status, body } = await call('write_spec', {
+      slug: UNIQUE_SLUG,
+      content: '# Hello\n',
+    });
+    expect(status).toBe(200);
+    expect(body.path).toMatch(
+      new RegExp(`docs/superpowers/specs/\\d{4}-\\d{2}-\\d{2}-${UNIQUE_SLUG}\\.md$`),
+    );
+    const abs = path.join(REPO_ROOT, body.path);
+    expect(existsSync(abs)).toBe(true);
+    expect(readFileSync(abs, 'utf8')).toBe('# Hello\n');
+  });
+
+  it('write_plan: writes to docs/superpowers/plans/', async () => {
+    const slug = UNIQUE_SLUG + '-plan';
+    const { body } = await call('write_plan', { slug, content: '# Plan\n' });
+    expect(body.path).toMatch(
+      new RegExp(`docs/superpowers/plans/\\d{4}-\\d{2}-\\d{2}-${slug}\\.md$`),
+    );
+  });
+
+  it('write_mockup: writes .html and returns previewUrl', async () => {
+    const slug = UNIQUE_SLUG + '-m';
+    const { body } = await call('write_mockup', {
+      slug,
+      html: '<!doctype html><html><body>hi</body></html>',
+    });
+    expect(body.path).toMatch(/\.html$/);
+    expect(body.previewUrl).toContain('/voice/preview?file=');
+    expect(body.previewUrl).toContain(encodeURIComponent(body.path));
+  });
+
+  it('write_diagram: wraps mermaid in a fenced code block', async () => {
+    const slug = UNIQUE_SLUG + '-d';
+    const { body } = await call('write_diagram', {
+      slug,
+      mermaid: 'graph TD; A-->B;',
+      title: 'Test',
+    });
+    expect(body.path).toMatch(/\.md$/);
+    const abs = path.join(REPO_ROOT, body.path);
+    const contents = readFileSync(abs, 'utf8');
+    expect(contents).toContain('```mermaid');
+    expect(contents).toContain('graph TD; A-->B;');
+    expect(contents).toContain('# Test');
+    expect(body.previewUrl).toContain('/voice/preview?file=');
+  });
+
+  it('rejects slug with path separator', async () => {
+    const { body } = await call('write_spec', { slug: 'bad/slug', content: 'x' });
+    expect(body.error).toBeDefined();
+  });
+
+  it('rejects uppercase slug', async () => {
+    const { body } = await call('write_spec', { slug: 'BAD-SLUG', content: 'x' });
+    expect(body.error).toBeDefined();
+  });
+
+  it('rejects oversized content (> 256 KB)', async () => {
+    const { body } = await call('write_spec', {
+      slug: UNIQUE_SLUG + '-big',
+      content: 'x'.repeat(260 * 1024),
+    });
+    expect(body.error).toMatch(/too large/i);
+  });
+
+  it('refuses to overwrite existing file with different content', async () => {
+    const slug = UNIQUE_SLUG + '-dup';
+    const first = (await call('write_spec', { slug, content: 'A' })).body;
+    expect(first.path).toBeDefined();
+
+    const second = (await call('write_spec', { slug, content: 'B' })).body;
+    expect(second.error).toMatch(/would overwrite/);
+    expect(second.existingContent).toBe('A');
+  });
+
+  it('no-op when re-writing identical content', async () => {
+    const slug = UNIQUE_SLUG + '-idem';
+    const first = (await call('write_spec', { slug, content: 'same' })).body;
+    const second = (await call('write_spec', { slug, content: 'same' })).body;
+    expect(second.error).toBeUndefined();
+    expect(second.path).toBe(first.path);
+  });
+});

--- a/dashboard/src/app/api/voice/context/dev/route.ts
+++ b/dashboard/src/app/api/voice/context/dev/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse } from 'next/server';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { SUBSYSTEMS } from '../../../../../../../src/voice/subsystem-map';
+
+const execFileP = promisify(execFile);
+
+function isLoopback(host: string | null): boolean {
+  if (!host) return false;
+  let h = host.trim();
+  if (h.startsWith('[')) {
+    const end = h.indexOf(']');
+    h = end >= 0 ? h.slice(1, end) : h;
+  } else {
+    h = h.split(':')[0];
+  }
+  return h === 'localhost' || h === '127.0.0.1' || h === '::1';
+}
+
+function getRepoRoot(): string {
+  const cwd = process.cwd();
+  return cwd.endsWith(path.sep + 'dashboard') || cwd.endsWith('/dashboard')
+    ? path.resolve(cwd, '..')
+    : cwd;
+}
+
+async function readOrEmpty(p: string): Promise<string> {
+  try {
+    return await fs.readFile(p, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+async function readJsonScripts(p: string): Promise<Record<string, string>> {
+  try {
+    const raw = await fs.readFile(p, 'utf8');
+    const parsed = JSON.parse(raw) as { scripts?: Record<string, string> };
+    return parsed.scripts ?? {};
+  } catch {
+    return {};
+  }
+}
+
+async function gitLine(repoRoot: string, args: string[]): Promise<string> {
+  try {
+    const { stdout } = await execFileP('git', args, { cwd: repoRoot });
+    return stdout.trim();
+  } catch {
+    return '';
+  }
+}
+
+async function listDir(p: string): Promise<string[]> {
+  try {
+    const entries = await fs.readdir(p);
+    return entries.filter((n) => !n.startsWith('.')).sort();
+  } catch {
+    return [];
+  }
+}
+
+export async function GET(req: Request) {
+  if (!isLoopback(req.headers.get('host'))) {
+    return NextResponse.json(
+      { error: 'voice endpoints are localhost-only' },
+      { status: 403 },
+    );
+  }
+
+  const repoRoot = getRepoRoot();
+  const warnings: string[] = [];
+
+  const claudeMd = await readOrEmpty(path.join(repoRoot, 'CLAUDE.md'));
+  if (!claudeMd) warnings.push('CLAUDE.md missing');
+
+  const architecture = await readOrEmpty(
+    path.join(repoRoot, 'docs', 'ARCHITECTURE.md'),
+  );
+  if (!architecture) warnings.push('docs/ARCHITECTURE.md missing');
+
+  const rootScripts = await readJsonScripts(path.join(repoRoot, 'package.json'));
+  const dashboardScripts = await readJsonScripts(
+    path.join(repoRoot, 'dashboard', 'package.json'),
+  );
+
+  const branch = await gitLine(repoRoot, ['rev-parse', '--abbrev-ref', 'HEAD']);
+  const statusShort = await gitLine(repoRoot, ['status', '--short']);
+  const logOut = await gitLine(repoRoot, [
+    'log',
+    '-n',
+    '10',
+    '--pretty=format:%h%x09%s',
+  ]);
+  const recentCommits = logOut
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const [sha, ...rest] = line.split('\t');
+      return { sha, subject: rest.join('\t') };
+    });
+
+  const specNames = await listDir(
+    path.join(repoRoot, 'docs', 'superpowers', 'specs'),
+  );
+  const planNames = await listDir(
+    path.join(repoRoot, 'docs', 'superpowers', 'plans'),
+  );
+
+  const body = {
+    claudeMd,
+    architecture,
+    subsystemMap: SUBSYSTEMS,
+    scripts: { root: rootScripts, dashboard: dashboardScripts },
+    repoState: {
+      branch,
+      statusShort,
+      recentCommits,
+      specNames,
+      planNames,
+    },
+    sessionMeta: {
+      generatedAt: new Date().toISOString(),
+    },
+    ...(warnings.length ? { warnings } : {}),
+  };
+
+  return NextResponse.json(body);
+}

--- a/dashboard/src/app/api/voice/session-close/route.ts
+++ b/dashboard/src/app/api/voice/session-close/route.ts
@@ -1,0 +1,160 @@
+import { NextResponse } from 'next/server';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { getDb } from '../../../../lib/db/index';
+import { voice_sessions } from '../../../../lib/db/schema';
+import { computeCostUsd, RATES } from '../../../voice/rates';
+
+interface SessionCloseBody {
+  voiceSessionId: string;
+  persona: 'dev';
+  startedAt: string;
+  endedAt: string;
+  transcript: Array<{ role: 'user' | 'assistant'; text: string; ts: string }>;
+  usage: { textIn: number; textOut: number; audioIn: number; audioOut: number };
+  artifacts: string[];
+  endReason: 'user_stop' | 'tab_close' | 'soft_cap' | 'hard_cap' | 'ws_drop';
+}
+
+function isLoopback(host: string | null): boolean {
+  if (!host) return false;
+  let h = host.trim();
+  if (h.startsWith('[')) {
+    const end = h.indexOf(']');
+    h = end >= 0 ? h.slice(1, end) : h;
+  } else {
+    h = h.split(':')[0];
+  }
+  return h === 'localhost' || h === '127.0.0.1' || h === '::1';
+}
+
+function getRepoRoot(): string {
+  const cwd = process.cwd();
+  return cwd.endsWith(path.sep + 'dashboard') || cwd.endsWith('/dashboard')
+    ? path.resolve(cwd, '..')
+    : cwd;
+}
+
+function formatFilename(sid: string, endedAtIso: string): string {
+  // UTC timestamp, format YYYY-MM-DD-HHmm-<short-sid>.md
+  const d = new Date(endedAtIso);
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  const yyyy = d.getUTCFullYear();
+  const mm = pad(d.getUTCMonth() + 1);
+  const dd = pad(d.getUTCDate());
+  const hh = pad(d.getUTCHours());
+  const mi = pad(d.getUTCMinutes());
+  const shortSid = sid.slice(0, 8).replace(/[^a-zA-Z0-9-]/g, '');
+  return `${yyyy}-${mm}-${dd}-${hh}${mi}-${shortSid}.md`;
+}
+
+function buildTranscriptMarkdown(
+  body: SessionCloseBody,
+  durationSeconds: number,
+  costUsd: number,
+): string {
+  const lines: string[] = [];
+  lines.push('---');
+  lines.push(`voiceSessionId: ${body.voiceSessionId}`);
+  lines.push(`persona: ${body.persona}`);
+  lines.push(`startedAt: ${body.startedAt}`);
+  lines.push(`endedAt: ${body.endedAt}`);
+  lines.push(`durationSeconds: ${durationSeconds}`);
+  lines.push(`costUsd: ${costUsd}`);
+  if (body.artifacts.length > 0) {
+    lines.push('artifacts:');
+    for (const a of body.artifacts) lines.push(`  - ${a}`);
+  }
+  lines.push('---');
+  lines.push('');
+  for (const turn of body.transcript) {
+    const header = turn.role === 'user' ? '## User' : '## Assistant';
+    lines.push(header);
+    lines.push('');
+    if (turn.role === 'user') {
+      for (const row of turn.text.split('\n')) lines.push('> ' + row);
+    } else {
+      lines.push(turn.text);
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+export async function POST(req: Request) {
+  if (!isLoopback(req.headers.get('host'))) {
+    return NextResponse.json(
+      { error: 'voice endpoints are localhost-only' },
+      { status: 403 },
+    );
+  }
+
+  let raw: SessionCloseBody;
+  try {
+    raw = (await req.json()) as SessionCloseBody;
+  } catch {
+    return NextResponse.json({ error: 'invalid json' }, { status: 400 });
+  }
+
+  if (!raw || typeof raw.voiceSessionId !== 'string' || !raw.voiceSessionId) {
+    return NextResponse.json({ error: 'voiceSessionId required' }, { status: 400 });
+  }
+  if (raw.persona !== 'dev') {
+    return NextResponse.json({ error: 'persona must be "dev"' }, { status: 400 });
+  }
+  const startedAtMs = Date.parse(raw.startedAt);
+  const endedAtMs = Date.parse(raw.endedAt);
+  if (!Number.isFinite(startedAtMs) || !Number.isFinite(endedAtMs)) {
+    return NextResponse.json({ error: 'invalid timestamps' }, { status: 400 });
+  }
+  if (endedAtMs < startedAtMs) {
+    return NextResponse.json({ error: 'endedAt before startedAt' }, { status: 400 });
+  }
+
+  const durationSeconds = Math.max(0, Math.round((endedAtMs - startedAtMs) / 1000));
+  const usage = raw.usage ?? { textIn: 0, textOut: 0, audioIn: 0, audioOut: 0 };
+  const costUsd = computeCostUsd(usage, RATES);
+
+  const repoRoot = getRepoRoot();
+
+  let transcriptPathRel: string | null = null;
+  if (Array.isArray(raw.transcript) && raw.transcript.length > 0) {
+    const dir = path.join(repoRoot, 'docs', 'superpowers', 'brainstorm-sessions');
+    await fs.mkdir(dir, { recursive: true });
+    const filename = formatFilename(raw.voiceSessionId, raw.endedAt);
+    const abs = path.join(dir, filename);
+    const md = buildTranscriptMarkdown(raw, durationSeconds, costUsd);
+    await fs.writeFile(abs, md, 'utf8');
+    transcriptPathRel = path.relative(repoRoot, abs);
+  }
+
+  const db = getDb();
+  try {
+    await db.insert(voice_sessions).values({
+      id: raw.voiceSessionId,
+      persona: raw.persona,
+      started_at: raw.startedAt,
+      ended_at: raw.endedAt,
+      duration_seconds: durationSeconds,
+      text_tokens_in: usage.textIn ?? 0,
+      text_tokens_out: usage.textOut ?? 0,
+      audio_tokens_in: usage.audioIn ?? 0,
+      audio_tokens_out: usage.audioOut ?? 0,
+      cost_usd: costUsd,
+      rates_version: RATES.version,
+      transcript_path: transcriptPathRel,
+      artifacts: JSON.stringify(raw.artifacts ?? []),
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'db insert failed: ' + (err as Error).message },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    transcriptPath: transcriptPathRel,
+    costUsd,
+  });
+}

--- a/dashboard/src/app/api/voice/session-close/route.ts
+++ b/dashboard/src/app/api/voice/session-close/route.ts
@@ -4,6 +4,13 @@ import path from 'node:path';
 import { getDb } from '../../../../lib/db/index';
 import { voice_sessions } from '../../../../lib/db/schema';
 import { computeCostUsd, RATES } from '../../../voice/rates';
+import { voiceLog } from '../../../../lib/voice-logger';
+
+function logFire(record: Record<string, unknown>): void {
+  voiceLog(record).catch(() => {
+    /* ignore — logging is best-effort, must never break the route */
+  });
+}
 
 interface SessionCloseBody {
   voiceSessionId: string;
@@ -146,11 +153,27 @@ export async function POST(req: Request) {
       artifacts: JSON.stringify(raw.artifacts ?? []),
     });
   } catch (err) {
+    logFire({
+      event: 'error.db_insert',
+      voiceSessionId: raw.voiceSessionId,
+      message: (err as Error).message,
+    });
     return NextResponse.json(
       { error: 'db insert failed: ' + (err as Error).message },
       { status: 500 },
     );
   }
+
+  logFire({
+    event: 'session.end',
+    voiceSessionId: raw.voiceSessionId,
+    persona: raw.persona,
+    endReason: raw.endReason,
+    durationSeconds,
+    costUsd,
+    transcriptPath: transcriptPathRel,
+    artifactCount: raw.artifacts?.length ?? 0,
+  });
 
   return NextResponse.json({
     ok: true,

--- a/dashboard/src/app/api/voice/stats/route.ts
+++ b/dashboard/src/app/api/voice/stats/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { sql } from 'drizzle-orm';
+import { getDb } from '../../../../lib/db/index';
+
+function isLoopback(host: string | null): boolean {
+  if (!host) return false;
+  let h = host.trim();
+  if (h.startsWith('[')) {
+    const end = h.indexOf(']');
+    h = end >= 0 ? h.slice(1, end) : h;
+  } else {
+    h = h.split(':')[0];
+  }
+  return h === 'localhost' || h === '127.0.0.1' || h === '::1';
+}
+
+function readBudget(): number | null {
+  const raw = process.env.VOICE_MONTHLY_BUDGET_USD;
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+export async function GET(req: Request) {
+  if (!isLoopback(req.headers.get('host'))) {
+    return NextResponse.json(
+      { error: 'voice endpoints are localhost-only' },
+      { status: 403 },
+    );
+  }
+
+  const db = getDb();
+
+  const todayRow = db.all<{ total: number }>(sql`
+    SELECT COALESCE(SUM(cost_usd), 0) AS total
+    FROM voice_sessions
+    WHERE date(started_at) = date('now','localtime')
+  `);
+  const monthRow = db.all<{ total: number }>(sql`
+    SELECT COALESCE(SUM(cost_usd), 0) AS total
+    FROM voice_sessions
+    WHERE strftime('%Y-%m', started_at) = strftime('%Y-%m', 'now','localtime')
+  `);
+
+  const todayUsd = Number(todayRow[0]?.total ?? 0);
+  const monthUsd = Number(monthRow[0]?.total ?? 0);
+
+  return NextResponse.json({
+    todayUsd,
+    monthUsd,
+    budgetUsd: readBudget(),
+  });
+}

--- a/dashboard/src/app/api/voice/token/route.ts
+++ b/dashboard/src/app/api/voice/token/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from 'next/server';
 import { GoogleGenAI } from '@google/genai';
 import { randomUUID } from 'node:crypto';
+import { voiceLog } from '../../../../lib/voice-logger';
+
+function logFire(record: Record<string, unknown>): void {
+  voiceLog(record).catch(() => {
+    /* ignore — logging is best-effort, must never break the route */
+  });
+}
 
 function isLoopback(host: string | null): boolean {
   if (!host) return false;
@@ -65,11 +72,22 @@ export async function POST(req: Request) {
         newSessionExpireTime: new Date(Date.now() + 60 * 1000).toISOString(),
       },
     });
+    logFire({
+      event: 'session.start',
+      voiceSessionId,
+      persona: 'dev',
+      model: 'gemini-3.1-flash-live-preview',
+    });
     return NextResponse.json({
       token: token.name ?? '',
       voiceSessionId,
     });
   } catch (err) {
+    logFire({
+      event: 'error.token_mint',
+      voiceSessionId,
+      message: (err as Error).message,
+    });
     return NextResponse.json(
       { error: 'token mint failed: ' + (err as Error).message },
       { status: 502 },

--- a/dashboard/src/app/api/voice/token/route.ts
+++ b/dashboard/src/app/api/voice/token/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+import { GoogleGenAI } from '@google/genai';
+import { randomUUID } from 'node:crypto';
+
+function isLoopback(host: string | null): boolean {
+  if (!host) return false;
+  // Strip the port. The host header is either "host", "host:port", "[ipv6]", or "[ipv6]:port".
+  let h = host.trim();
+  if (h.startsWith('[')) {
+    const end = h.indexOf(']');
+    h = end >= 0 ? h.slice(1, end) : h;
+  } else {
+    h = h.split(':')[0];
+  }
+  return h === 'localhost' || h === '127.0.0.1' || h === '::1';
+}
+
+// TODO(remove-after-migration): drop `google_api_key` fallback once
+// feat/gemini-tts-stt-migration lands on main.
+function getApiKey(): string | undefined {
+  return process.env.GEMINI_API_KEY || process.env.google_api_key;
+}
+
+export async function POST(req: Request) {
+  if (!isLoopback(req.headers.get('host'))) {
+    return NextResponse.json(
+      { error: 'voice endpoints are localhost-only' },
+      { status: 403 },
+    );
+  }
+
+  let body: { persona?: unknown; resumeHandle?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid json' }, { status: 400 });
+  }
+
+  if (body.persona !== 'dev') {
+    return NextResponse.json(
+      { error: 'persona required (only "dev" supported in v1)' },
+      { status: 400 },
+    );
+  }
+
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'GEMINI_API_KEY is not set' },
+      { status: 500 },
+    );
+  }
+
+  const voiceSessionId = randomUUID();
+
+  try {
+    const client = new GoogleGenAI({ apiKey });
+    const token = await client.authTokens.create({
+      config: {
+        uses: 1,
+        liveConnectConstraints: {
+          model: 'gemini-3.1-flash-live-preview',
+        },
+        expireTime: new Date(Date.now() + 31 * 60 * 1000).toISOString(),
+        newSessionExpireTime: new Date(Date.now() + 60 * 1000).toISOString(),
+      },
+    });
+    return NextResponse.json({
+      token: token.name ?? '',
+      voiceSessionId,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'token mint failed: ' + (err as Error).message },
+      { status: 502 },
+    );
+  }
+}

--- a/dashboard/src/app/api/voice/tools/dev/[tool]/route.ts
+++ b/dashboard/src/app/api/voice/tools/dev/[tool]/route.ts
@@ -8,8 +8,31 @@ import {
   resolveReadPath,
   resolveWritePath,
 } from '../../../../../../../../src/voice/path-scope';
+import { voiceLog } from '../../../../../../lib/voice-logger';
 
 const execFileP = promisify(execFile);
+
+function logFire(record: Record<string, unknown>): void {
+  voiceLog(record).catch(() => {
+    /* ignore — logging is best-effort, must never break the route */
+  });
+}
+
+/** Redact heavy content fields so tool.call logs stay readable and don't leak
+ *  user-authored text into the log file. */
+function summarizeArgs(args: unknown): unknown {
+  if (!args || typeof args !== 'object') return args;
+  const REDACTED = ['content', 'html', 'mermaid'];
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(args as Record<string, unknown>)) {
+    if (REDACTED.includes(k) && typeof v === 'string') {
+      out[k] = { length: v.length };
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
 
 const READ_MAX = 256 * 1024;
 const WRITE_MAX = 256 * 1024;
@@ -370,11 +393,26 @@ export async function POST(
   }
 
   const repoRoot = getRepoRoot();
+  const t0 = Date.now();
+  logFire({ event: 'tool.call', tool, args: summarizeArgs(args) });
   try {
     const out = await TOOLS[tool](repoRoot, args);
+    logFire({
+      event: 'tool.result',
+      tool,
+      durationMs: Date.now() - t0,
+      isError:
+        typeof out === 'object' && out !== null && 'error' in out ? true : false,
+    });
     return NextResponse.json(out);
   } catch (err) {
     const message = (err as Error).message ?? 'unknown';
+    logFire({
+      event: 'tool.error',
+      tool,
+      durationMs: Date.now() - t0,
+      message,
+    });
     if (
       message.startsWith('out of scope') ||
       message.startsWith('invalid slug')

--- a/dashboard/src/app/api/voice/tools/dev/[tool]/route.ts
+++ b/dashboard/src/app/api/voice/tools/dev/[tool]/route.ts
@@ -4,11 +4,15 @@ import path from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { glob } from 'glob';
-import { resolveReadPath } from '../../../../../../../../src/voice/path-scope';
+import {
+  resolveReadPath,
+  resolveWritePath,
+} from '../../../../../../../../src/voice/path-scope';
 
 const execFileP = promisify(execFile);
 
 const READ_MAX = 256 * 1024;
+const WRITE_MAX = 256 * 1024;
 const TRUNC_MARKER = '\n\n[truncated at 256 KB — use grep/glob for larger files]';
 const DOC_KINDS = new Set(['specs', 'plans', 'mockups', 'sessions']);
 
@@ -230,6 +234,99 @@ async function readDocTool(
   return { content: raw };
 }
 
+// ---------- write tools ----------
+
+type WriteDocResult =
+  | { path: string }
+  | { error: string; existingContent?: string };
+
+async function writeDoc(
+  repoRoot: string,
+  kind: 'specs' | 'plans' | 'mockups',
+  slug: string,
+  ext: string,
+  body: string,
+): Promise<WriteDocResult> {
+  if (body.length > WRITE_MAX) {
+    return {
+      error: `content too large: ${body.length} bytes (max ${WRITE_MAX})`,
+    };
+  }
+  const dest = await resolveWritePath(repoRoot, kind, slug, ext);
+  try {
+    const existing = await fs.readFile(dest, 'utf8');
+    if (existing === body) {
+      return { path: path.relative(repoRoot, dest) };
+    }
+    return {
+      error: `would overwrite ${dest}`,
+      existingContent: existing.slice(0, WRITE_MAX),
+    };
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e;
+  }
+  await fs.writeFile(dest, body, 'utf8');
+  return { path: path.relative(repoRoot, dest) };
+}
+
+function withPreview(
+  result: WriteDocResult,
+): WriteDocResult & { previewUrl?: string } {
+  if ('path' in result) {
+    return {
+      ...result,
+      previewUrl: `/voice/preview?file=${encodeURIComponent(result.path)}`,
+    };
+  }
+  return result;
+}
+
+async function writeSpecTool(
+  repoRoot: string,
+  args: { slug?: string; content?: string },
+) {
+  if (typeof args.slug !== 'string') throw new Error('invalid slug: missing');
+  if (typeof args.content !== 'string')
+    throw new Error('out of scope: missing content');
+  return writeDoc(repoRoot, 'specs', args.slug, 'md', args.content);
+}
+
+async function writePlanTool(
+  repoRoot: string,
+  args: { slug?: string; content?: string },
+) {
+  if (typeof args.slug !== 'string') throw new Error('invalid slug: missing');
+  if (typeof args.content !== 'string')
+    throw new Error('out of scope: missing content');
+  return writeDoc(repoRoot, 'plans', args.slug, 'md', args.content);
+}
+
+async function writeMockupTool(
+  repoRoot: string,
+  args: { slug?: string; html?: string },
+) {
+  if (typeof args.slug !== 'string') throw new Error('invalid slug: missing');
+  if (typeof args.html !== 'string')
+    throw new Error('out of scope: missing html');
+  return withPreview(
+    await writeDoc(repoRoot, 'mockups', args.slug, 'html', args.html),
+  );
+}
+
+async function writeDiagramTool(
+  repoRoot: string,
+  args: { slug?: string; mermaid?: string; title?: string },
+) {
+  if (typeof args.slug !== 'string') throw new Error('invalid slug: missing');
+  if (typeof args.mermaid !== 'string')
+    throw new Error('out of scope: missing mermaid');
+  const titleBlock = args.title ? `# ${args.title}\n\n` : '';
+  const md = titleBlock + '```mermaid\n' + args.mermaid + '\n```\n';
+  return withPreview(
+    await writeDoc(repoRoot, 'mockups', args.slug, 'md', md),
+  );
+}
+
 // ---------- dispatcher ----------
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -243,6 +340,10 @@ const TOOLS: Record<string, ToolFn> = {
   git_status: gitStatusTool,
   list_docs: listDocsTool,
   read_doc: readDocTool,
+  write_spec: writeSpecTool,
+  write_plan: writePlanTool,
+  write_mockup: writeMockupTool,
+  write_diagram: writeDiagramTool,
 };
 
 export async function POST(

--- a/dashboard/src/app/api/voice/tools/dev/[tool]/route.ts
+++ b/dashboard/src/app/api/voice/tools/dev/[tool]/route.ts
@@ -1,0 +1,288 @@
+import { NextResponse } from 'next/server';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { glob } from 'glob';
+import { resolveReadPath } from '../../../../../../../../src/voice/path-scope';
+
+const execFileP = promisify(execFile);
+
+const READ_MAX = 256 * 1024;
+const TRUNC_MARKER = '\n\n[truncated at 256 KB — use grep/glob for larger files]';
+const DOC_KINDS = new Set(['specs', 'plans', 'mockups', 'sessions']);
+
+function isLoopback(host: string | null): boolean {
+  if (!host) return false;
+  let h = host.trim();
+  if (h.startsWith('[')) {
+    const end = h.indexOf(']');
+    h = end >= 0 ? h.slice(1, end) : h;
+  } else {
+    h = h.split(':')[0];
+  }
+  return h === 'localhost' || h === '127.0.0.1' || h === '::1';
+}
+
+function getRepoRoot(): string {
+  const cwd = process.cwd();
+  return cwd.endsWith(path.sep + 'dashboard') || cwd.endsWith('/dashboard')
+    ? path.resolve(cwd, '..')
+    : cwd;
+}
+
+// ---------- read tools ----------
+
+async function readFileTool(repoRoot: string, args: { path?: string }) {
+  if (!args.path) throw new Error('out of scope: missing path');
+  const abs = await resolveReadPath(repoRoot, args.path);
+  const raw = await fs.readFile(abs, 'utf8');
+  if (raw.length > READ_MAX) {
+    return { content: raw.slice(0, READ_MAX) + TRUNC_MARKER, truncated: true };
+  }
+  return { content: raw };
+}
+
+function rejectPattern(pattern: string) {
+  // Must not start with "/" or contain ".." segments.
+  if (!pattern || typeof pattern !== 'string') return true;
+  if (pattern.startsWith('/')) return true;
+  const normalized = path.posix.normalize(pattern);
+  if (normalized.startsWith('..')) return true;
+  return false;
+}
+
+async function globTool(repoRoot: string, args: { pattern?: string }) {
+  if (!args.pattern) throw new Error('out of scope: missing pattern');
+  if (rejectPattern(args.pattern)) throw new Error('out of scope: invalid pattern');
+  const matches = await glob(args.pattern, {
+    cwd: repoRoot,
+    nodir: false,
+    ignore: [
+      'node_modules/**',
+      'dashboard/node_modules/**',
+      '.git/**',
+      '.venv/**',
+      'store/**',
+      'onecli/**',
+      'groups/**',
+      'data/**',
+      '.env',
+      '.env.*',
+    ],
+    dot: false,
+  });
+  return { paths: matches.slice(0, 500) };
+}
+
+async function grepTool(
+  repoRoot: string,
+  args: { pattern?: string; glob?: string; path?: string },
+) {
+  if (!args.pattern) throw new Error('out of scope: missing pattern');
+  const globPattern = args.glob || args.path || 'src/**/*.{ts,tsx,md}';
+  if (rejectPattern(globPattern)) throw new Error('out of scope: invalid pattern');
+
+  const files = await glob(globPattern, {
+    cwd: repoRoot,
+    nodir: true,
+    ignore: [
+      'node_modules/**',
+      'dashboard/node_modules/**',
+      '.git/**',
+      '.venv/**',
+      'store/**',
+      'onecli/**',
+      'groups/**',
+      'data/**',
+    ],
+  });
+
+  const re = new RegExp(args.pattern);
+  const matches: Array<{ path: string; line: number; text: string }> = [];
+  const MAX = 200;
+
+  for (const relFile of files) {
+    if (matches.length >= MAX) break;
+    try {
+      const abs = await resolveReadPath(repoRoot, relFile);
+      const body = await fs.readFile(abs, 'utf8');
+      const lines = body.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (re.test(lines[i])) {
+          matches.push({
+            path: relFile,
+            line: i + 1,
+            text: lines[i].slice(0, 500),
+          });
+          if (matches.length >= MAX) break;
+        }
+      }
+    } catch {
+      // scope rejection or unreadable — skip
+    }
+  }
+
+  return { matches };
+}
+
+async function gitLogTool(
+  repoRoot: string,
+  args: { limit?: number; path?: string },
+) {
+  const limit = Math.max(1, Math.min(200, args.limit ?? 10));
+  const gitArgs = [
+    'log',
+    '-n',
+    String(limit),
+    '--pretty=format:%h%x09%ae%x09%ad%x09%s',
+    '--date=iso',
+  ];
+  if (args.path) {
+    // Scope-check the path.
+    await resolveReadPath(repoRoot, args.path);
+    gitArgs.push('--', args.path);
+  }
+  try {
+    const { stdout } = await execFileP('git', gitArgs, { cwd: repoRoot });
+    const commits = stdout
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        const [sha, author, date, ...rest] = line.split('\t');
+        return { sha, author, date, subject: rest.join('\t') };
+      });
+    return { commits };
+  } catch {
+    return { commits: [] };
+  }
+}
+
+async function gitStatusTool(repoRoot: string) {
+  const branch = await execFileP('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    cwd: repoRoot,
+  })
+    .then((r) => r.stdout.trim())
+    .catch(() => '');
+  const statusOut = await execFileP('git', ['status', '--porcelain'], {
+    cwd: repoRoot,
+  })
+    .then((r) => r.stdout)
+    .catch(() => '');
+  const staged: string[] = [];
+  const modified: string[] = [];
+  const untracked: string[] = [];
+  for (const line of statusOut.split('\n')) {
+    if (!line) continue;
+    const x = line.charAt(0);
+    const y = line.charAt(1);
+    const file = line.slice(3);
+    if (x === '?' && y === '?') untracked.push(file);
+    else {
+      if (x !== ' ') staged.push(file);
+      if (y !== ' ') modified.push(file);
+    }
+  }
+  return { branch, staged, modified, untracked };
+}
+
+async function listDocsTool(repoRoot: string, args: { kind?: string }) {
+  if (!args.kind || !DOC_KINDS.has(args.kind)) {
+    throw new Error('out of scope: unknown kind');
+  }
+  const map: Record<string, string[]> = {
+    specs: ['docs', 'superpowers', 'specs'],
+    plans: ['docs', 'superpowers', 'plans'],
+    mockups: ['docs', 'superpowers', 'mockups'],
+    sessions: ['docs', 'superpowers', 'brainstorm-sessions'],
+  };
+  const dir = path.join(repoRoot, ...map[args.kind]);
+  try {
+    const entries = await fs.readdir(dir);
+    return { files: entries.filter((n) => !n.startsWith('.')).sort() };
+  } catch {
+    return { files: [] };
+  }
+}
+
+async function readDocTool(
+  repoRoot: string,
+  args: { kind?: string; name?: string },
+) {
+  if (!args.kind || !DOC_KINDS.has(args.kind)) {
+    throw new Error('out of scope: unknown kind');
+  }
+  if (!args.name || args.name.includes('/') || args.name.includes('..')) {
+    throw new Error('out of scope: invalid name');
+  }
+  const dirMap: Record<string, string[]> = {
+    specs: ['docs', 'superpowers', 'specs'],
+    plans: ['docs', 'superpowers', 'plans'],
+    mockups: ['docs', 'superpowers', 'mockups'],
+    sessions: ['docs', 'superpowers', 'brainstorm-sessions'],
+  };
+  const relative = path.join(...dirMap[args.kind], args.name);
+  const abs = await resolveReadPath(repoRoot, relative);
+  const raw = await fs.readFile(abs, 'utf8');
+  if (raw.length > READ_MAX) {
+    return { content: raw.slice(0, READ_MAX) + TRUNC_MARKER, truncated: true };
+  }
+  return { content: raw };
+}
+
+// ---------- dispatcher ----------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ToolFn = (repoRoot: string, args: any) => Promise<unknown>;
+
+const TOOLS: Record<string, ToolFn> = {
+  read_file: readFileTool,
+  glob: globTool,
+  grep: grepTool,
+  git_log: gitLogTool,
+  git_status: gitStatusTool,
+  list_docs: listDocsTool,
+  read_doc: readDocTool,
+};
+
+export async function POST(
+  req: Request,
+  ctx: { params: Promise<{ tool: string }> },
+) {
+  if (!isLoopback(req.headers.get('host'))) {
+    return NextResponse.json(
+      { error: 'voice endpoints are localhost-only' },
+      { status: 403 },
+    );
+  }
+
+  const { tool } = await ctx.params;
+  if (!(tool in TOOLS)) {
+    return NextResponse.json({ error: 'unknown tool' }, { status: 404 });
+  }
+
+  let args: unknown;
+  try {
+    args = await req.json();
+  } catch {
+    args = {};
+  }
+
+  const repoRoot = getRepoRoot();
+  try {
+    const out = await TOOLS[tool](repoRoot, args);
+    return NextResponse.json(out);
+  } catch (err) {
+    const message = (err as Error).message ?? 'unknown';
+    if (
+      message.startsWith('out of scope') ||
+      message.startsWith('invalid slug')
+    ) {
+      return NextResponse.json({ error: message });
+    }
+    return NextResponse.json(
+      { error: 'tool execution failed: ' + message },
+      { status: 500 },
+    );
+  }
+}

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -17,6 +17,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <a href="/read" className="hover:text-gray-100">Read</a>
               <a href="/read/book" className="hover:text-gray-100">Book</a>
               <a href="/study" className="hover:text-gray-100">Study</a>
+              {process.env.NODE_ENV === 'development' && (
+                <a href="/voice" className="hover:text-gray-100">Voice</a>
+              )}
             </div>
           </div>
         </nav>

--- a/dashboard/src/app/voice/__tests__/cost-tracker.test.ts
+++ b/dashboard/src/app/voice/__tests__/cost-tracker.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { CostTracker } from '../cost-tracker';
+import { RATES } from '../rates';
+
+describe('CostTracker', () => {
+  it('starts at zero', () => {
+    const t = new CostTracker(RATES);
+    expect(t.totals).toEqual({ textIn: 0, textOut: 0, audioIn: 0, audioOut: 0 });
+    expect(t.costUsd).toBe(0);
+  });
+
+  it('accumulates token counts across turns', () => {
+    const t = new CostTracker(RATES);
+    t.addUsage({ textIn: 10, textOut: 20, audioIn: 100, audioOut: 200 });
+    t.addUsage({ textIn: 5, textOut: 0, audioIn: 0, audioOut: 50 });
+    expect(t.totals).toEqual({ textIn: 15, textOut: 20, audioIn: 100, audioOut: 250 });
+  });
+
+  it('exposes a live cost figure', () => {
+    const rates = { textInPerM: 1_000_000, textOutPerM: 0, audioInPerM: 0, audioOutPerM: 0, asOf: 'x', version: 'x' };
+    const t = new CostTracker(rates);
+    t.addUsage({ textIn: 1, textOut: 0, audioIn: 0, audioOut: 0 });
+    expect(t.costUsd).toBeCloseTo(1, 6);
+  });
+
+  it('emits change events on addUsage', () => {
+    const t = new CostTracker(RATES);
+    const seen: number[] = [];
+    t.onChange((c) => seen.push(c));
+    t.addUsage({ textIn: 100, textOut: 0, audioIn: 0, audioOut: 0 });
+    t.addUsage({ textIn: 0, textOut: 50, audioIn: 0, audioOut: 0 });
+    expect(seen.length).toBe(2);
+    expect(seen[0]).toBeGreaterThanOrEqual(0);
+    expect(seen[1]).toBeGreaterThan(seen[0]);
+  });
+
+  it('stops emitting when listener is removed', () => {
+    const t = new CostTracker(RATES);
+    const seen: number[] = [];
+    const cb = (c: number) => seen.push(c);
+    t.onChange(cb);
+    t.addUsage({ textIn: 100, textOut: 0, audioIn: 0, audioOut: 0 });
+    t.offChange(cb);
+    t.addUsage({ textIn: 100, textOut: 0, audioIn: 0, audioOut: 0 });
+    expect(seen.length).toBe(1);
+  });
+
+  it('resets totals and cost', () => {
+    const t = new CostTracker(RATES);
+    t.addUsage({ textIn: 100, textOut: 200, audioIn: 300, audioOut: 400 });
+    t.reset();
+    expect(t.totals).toEqual({ textIn: 0, textOut: 0, audioIn: 0, audioOut: 0 });
+    expect(t.costUsd).toBe(0);
+  });
+
+  it('fires onChange on reset', () => {
+    const t = new CostTracker(RATES);
+    t.addUsage({ textIn: 1000, textOut: 0, audioIn: 0, audioOut: 0 });
+    const seen: number[] = [];
+    t.onChange((c) => seen.push(c));
+    t.reset();
+    expect(seen).toEqual([0]);
+  });
+
+  it('treats addUsage with all zeros as a no-op for totals but still emits', () => {
+    const t = new CostTracker(RATES);
+    const seen: number[] = [];
+    t.onChange((c) => seen.push(c));
+    t.addUsage({ textIn: 0, textOut: 0, audioIn: 0, audioOut: 0 });
+    // The contract: emit on every addUsage call, even zeros. This keeps the
+    // UI in sync whenever the server pings us with a usage turn.
+    expect(seen.length).toBe(1);
+    expect(t.totals).toEqual({ textIn: 0, textOut: 0, audioIn: 0, audioOut: 0 });
+  });
+});

--- a/dashboard/src/app/voice/__tests__/e2e.test.ts
+++ b/dashboard/src/app/voice/__tests__/e2e.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
+import path from 'node:path';
+import { existsSync, readFileSync, rmSync, readdirSync } from 'node:fs';
+import Database from 'better-sqlite3';
+import { WebSocket as WsClient } from 'ws';
+
+const REPO_ROOT = process.cwd().endsWith('/dashboard')
+  ? path.resolve(process.cwd(), '..')
+  : process.cwd();
+
+process.env.STORE_DIR = path.join(REPO_ROOT, 'store');
+
+import { startFakeGemini, type FakeGemini } from './fake-gemini-server';
+import { VoiceSession } from '../voice-session';
+import { DEV_PERSONA } from '../personas';
+
+import { POST as tokenPOST } from '../../api/voice/token/route';
+import { GET as contextGET } from '../../api/voice/context/dev/route';
+import { POST as toolsPOST } from '../../api/voice/tools/dev/[tool]/route';
+import { POST as sessionClosePOST } from '../../api/voice/session-close/route';
+
+const wsFactory = (url: string) => new WsClient(url) as unknown as WebSocket;
+
+const UNIQUE_SLUG = `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+
+function cleanupArtifacts() {
+  const dirs = [
+    path.join(REPO_ROOT, 'docs', 'superpowers', 'specs'),
+    path.join(REPO_ROOT, 'docs', 'superpowers', 'plans'),
+    path.join(REPO_ROOT, 'docs', 'superpowers', 'mockups'),
+    path.join(REPO_ROOT, 'docs', 'superpowers', 'brainstorm-sessions'),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) continue;
+    for (const name of readdirSync(dir)) {
+      if (name.includes(UNIQUE_SLUG)) {
+        rmSync(path.join(dir, name), { force: true });
+      }
+    }
+  }
+}
+
+function cleanupSessions(sids: string[]) {
+  if (sids.length === 0) return;
+  const db = new Database(path.join(REPO_ROOT, 'store', 'messages.db'));
+  for (const sid of sids) {
+    db.prepare('DELETE FROM voice_sessions WHERE id = ?').run(sid);
+  }
+  db.close();
+}
+
+/**
+ * Dispatches fetch() calls to the real Next.js route handlers based on URL
+ * path. This keeps the e2e test in-process — no Next.js dev server required.
+ */
+function makeRoutedFetch() {
+  const spies = {
+    tool: vi.fn(),
+    close: vi.fn(),
+  };
+
+  const routed: typeof fetch = async (input, init) => {
+    const rawUrl =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const url = new URL(rawUrl, 'http://localhost:3100');
+    const pathname = url.pathname;
+    const host = (init?.headers as Record<string, string> | undefined)?.host ?? 'localhost';
+
+    const mkReq = (body?: string): Request => {
+      return new Request(url.toString(), {
+        method: init?.method ?? 'GET',
+        headers: { host, 'content-type': 'application/json' },
+        body,
+      });
+    };
+
+    if (pathname === '/api/voice/token' && init?.method === 'POST') {
+      return tokenPOST(mkReq(init.body as string));
+    }
+    if (pathname === '/api/voice/context/dev') {
+      return contextGET(mkReq());
+    }
+    if (pathname.startsWith('/api/voice/tools/dev/')) {
+      const tool = pathname.slice('/api/voice/tools/dev/'.length);
+      spies.tool(tool, init?.body);
+      return toolsPOST(mkReq(init?.body as string), {
+        params: Promise.resolve({ tool }),
+      });
+    }
+    if (pathname === '/api/voice/session-close' && init?.method === 'POST') {
+      spies.close(init?.body);
+      return sessionClosePOST(mkReq(init.body as string));
+    }
+    throw new Error('routedFetch: unmatched ' + pathname);
+  };
+
+  return { routed, spies };
+}
+
+describe('VoiceSession e2e against fake server + real route handlers', () => {
+  let fake: FakeGemini;
+  let originalFetch: typeof globalThis.fetch;
+  const sids: string[] = [];
+
+  beforeAll(() => {
+    // Guarantee the token endpoint has an API key even if tests nuked it.
+    if (!process.env.GEMINI_API_KEY) process.env.GEMINI_API_KEY = 'e2e-test-key';
+  });
+
+  beforeEach(async () => {
+    fake = await startFakeGemini();
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    await fake.close();
+  });
+
+  afterAll(() => {
+    cleanupArtifacts();
+    cleanupSessions(sids);
+  });
+
+  it('runs a full session: context → usage → write_spec tool → session-close', async () => {
+    const { routed, spies } = makeRoutedFetch();
+    globalThis.fetch = routed;
+
+    // Pre-mock @google/genai so the token route doesn't need a real key
+    vi.doMock('@google/genai', () => ({
+      GoogleGenAI: class {
+        authTokens = {
+          create: async () => ({ name: 'tokens/e2e' }),
+        };
+      },
+    }));
+
+    let endedSid: string | null = null;
+    let endCost = 0;
+
+    const session = new VoiceSession({
+      persona: DEV_PERSONA,
+      liveApiUrl: fake.url,
+      wsFactory,
+      events: {
+        onInputTranscript: () => {},
+        onOutputTranscript: () => {},
+        onAudio: () => {},
+        onCost: (c) => {
+          endCost = c;
+        },
+        onToolCall: async (call) => {
+          // Route the tool call through the real dispatcher.
+          const res = await fetch(`/api/voice/tools/dev/${call.name}`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(call.args ?? {}),
+          });
+          return await res.json();
+        },
+        onEnd: (p) => {
+          // VoiceSession generates its own sid when liveApiUrl is set.
+          // Fish it out of the session-close POST body instead.
+        },
+      },
+    });
+
+    await session.start();
+    fake.sendUsage({ textIn: 500, textOut: 1000, audioIn: 10_000, audioOut: 20_000 });
+
+    // Drive a write_spec tool call from the fake server, round-trip through
+    // the real dispatcher.
+    fake.sendToolCall({
+      id: 'call-1',
+      name: 'write_spec',
+      args: { slug: UNIQUE_SLUG, content: '# E2E\n\nhello' },
+    });
+    const toolRes = await fake.waitForToolResponse('call-1');
+    expect(toolRes).toMatchObject({ path: expect.stringMatching(new RegExp(`docs/superpowers/specs/\\d{4}-\\d{2}-\\d{2}-${UNIQUE_SLUG}\\.md`)) });
+
+    await new Promise((r) => setTimeout(r, 80));
+    await session.stop('user_stop');
+
+    expect(endCost).toBeGreaterThan(0);
+
+    // session-close was POSTed.
+    expect(spies.close).toHaveBeenCalledTimes(1);
+    const closeBody = JSON.parse(spies.close.mock.calls[0][0]);
+    const sid: string = closeBody.voiceSessionId;
+    sids.push(sid);
+    endedSid = sid;
+
+    // DB row exists with the right sid and a positive cost.
+    const db = new Database(path.join(REPO_ROOT, 'store', 'messages.db'));
+    const row = db.prepare('SELECT * FROM voice_sessions WHERE id = ?').get(sid) as
+      | { cost_usd: number; artifacts: string | null }
+      | undefined;
+    db.close();
+    expect(row).toBeDefined();
+    expect(row!.cost_usd).toBeGreaterThan(0);
+  }, 15_000);
+});

--- a/dashboard/src/app/voice/__tests__/e2e.test.ts
+++ b/dashboard/src/app/voice/__tests__/e2e.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from 'vitest';
 import path from 'node:path';
-import { existsSync, readFileSync, rmSync, readdirSync } from 'node:fs';
+import { existsSync, rmSync, readdirSync } from 'node:fs';
 import Database from 'better-sqlite3';
 import { WebSocket as WsClient } from 'ws';
 
@@ -139,7 +139,6 @@ describe('VoiceSession e2e against fake server + real route handlers', () => {
       },
     }));
 
-    let endedSid: string | null = null;
     let endCost = 0;
 
     const session = new VoiceSession({
@@ -162,7 +161,7 @@ describe('VoiceSession e2e against fake server + real route handlers', () => {
           });
           return await res.json();
         },
-        onEnd: (p) => {
+        onEnd: () => {
           // VoiceSession generates its own sid when liveApiUrl is set.
           // Fish it out of the session-close POST body instead.
         },
@@ -192,7 +191,6 @@ describe('VoiceSession e2e against fake server + real route handlers', () => {
     const closeBody = JSON.parse(spies.close.mock.calls[0][0]);
     const sid: string = closeBody.voiceSessionId;
     sids.push(sid);
-    endedSid = sid;
 
     // DB row exists with the right sid and a positive cost.
     const db = new Database(path.join(REPO_ROOT, 'store', 'messages.db'));

--- a/dashboard/src/app/voice/__tests__/fake-gemini-server.ts
+++ b/dashboard/src/app/voice/__tests__/fake-gemini-server.ts
@@ -1,0 +1,170 @@
+import { WebSocketServer, WebSocket } from 'ws';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+interface ToolResponseResolver {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+}
+
+export interface FakeGemini {
+  url: string;
+  close: () => Promise<void>;
+  sendAssistantAudio: (base64Chunk: string) => void;
+  sendInputTranscription: (text: string, partial?: boolean) => void;
+  sendOutputTranscription: (text: string, partial?: boolean) => void;
+  sendToolCall: (call: { id: string; name: string; args: unknown }) => void;
+  sendUsage: (usage: {
+    textIn: number;
+    textOut: number;
+    audioIn: number;
+    audioOut: number;
+  }) => void;
+  terminate: () => void;
+  waitForClientAudio: () => Promise<Buffer>;
+  waitForToolResponse: (toolCallId: string) => Promise<unknown>;
+}
+
+export async function startFakeGemini(
+  opts: { port?: number } = {},
+): Promise<FakeGemini> {
+  const httpServer: Server = createServer();
+  const wss = new WebSocketServer({ server: httpServer });
+
+  const clients = new Set<WebSocket>();
+
+  const audioResolvers: Array<(buf: Buffer) => void> = [];
+  const pendingAudio: Buffer[] = [];
+
+  const toolResolvers = new Map<string, ToolResponseResolver>();
+  const bufferedToolResponses = new Map<string, unknown>();
+
+  wss.on('connection', (ws) => {
+    clients.add(ws);
+    ws.on('message', (raw) => {
+      let msg: {
+        type?: string;
+        data?: string;
+        id?: string;
+        response?: unknown;
+      };
+      try {
+        msg = JSON.parse(raw.toString('utf8'));
+      } catch {
+        return;
+      }
+      if (msg.type === 'client_audio' && typeof msg.data === 'string') {
+        const buf = Buffer.from(msg.data, 'base64');
+        if (audioResolvers.length > 0) {
+          const r = audioResolvers.shift()!;
+          r(buf);
+        } else {
+          pendingAudio.push(buf);
+        }
+      } else if (msg.type === 'tool_response' && typeof msg.id === 'string') {
+        const r = toolResolvers.get(msg.id);
+        if (r) {
+          r.resolve(msg.response);
+          toolResolvers.delete(msg.id);
+        } else {
+          bufferedToolResponses.set(msg.id, msg.response);
+        }
+      }
+      // client_content / bye / unknown → ignore
+    });
+    ws.on('close', () => clients.delete(ws));
+  });
+
+  function broadcast(obj: unknown): void {
+    const line = JSON.stringify(obj);
+    for (const c of clients) {
+      if (c.readyState === WebSocket.OPEN) c.send(line);
+    }
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(opts.port ?? 0, '127.0.0.1', () => resolve());
+  });
+
+  const addr = httpServer.address() as AddressInfo;
+  const url = `ws://127.0.0.1:${addr.port}`;
+
+  async function close(): Promise<void> {
+    for (const r of toolResolvers.values()) {
+      r.reject(new Error('fake gemini closed'));
+    }
+    toolResolvers.clear();
+    for (const c of clients) {
+      try {
+        c.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    clients.clear();
+    await new Promise<void>((r) => wss.close(() => r()));
+    await new Promise<void>((r) => httpServer.close(() => r()));
+  }
+
+  return {
+    url,
+    close,
+
+    sendAssistantAudio: (data) => broadcast({ type: 'audio', data }),
+
+    sendInputTranscription: (text, partial = false) =>
+      broadcast({ type: 'input_transcription', text, partial }),
+
+    sendOutputTranscription: (text, partial = false) =>
+      broadcast({ type: 'output_transcription', text, partial }),
+
+    sendToolCall: (call) =>
+      broadcast({
+        type: 'tool_call',
+        id: call.id,
+        name: call.name,
+        args: call.args,
+      }),
+
+    sendUsage: (usage) =>
+      broadcast({
+        type: 'usage',
+        textIn: usage.textIn,
+        textOut: usage.textOut,
+        audioIn: usage.audioIn,
+        audioOut: usage.audioOut,
+      }),
+
+    terminate: () => {
+      broadcast({ type: 'server_end' });
+      for (const c of clients) {
+        try {
+          c.close(1000, 'server_end');
+        } catch {
+          /* ignore */
+        }
+      }
+    },
+
+    waitForClientAudio: () => {
+      if (pendingAudio.length > 0) {
+        return Promise.resolve(pendingAudio.shift()!);
+      }
+      return new Promise<Buffer>((resolve) => {
+        audioResolvers.push(resolve);
+      });
+    },
+
+    waitForToolResponse: (toolCallId) => {
+      if (bufferedToolResponses.has(toolCallId)) {
+        const v = bufferedToolResponses.get(toolCallId);
+        bufferedToolResponses.delete(toolCallId);
+        return Promise.resolve(v);
+      }
+      return new Promise((resolve, reject) => {
+        toolResolvers.set(toolCallId, { resolve, reject });
+      });
+    },
+  };
+}

--- a/dashboard/src/app/voice/__tests__/preview-route.test.ts
+++ b/dashboard/src/app/voice/__tests__/preview-route.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { GET } from '../preview/route';
+
+const REPO_ROOT = process.cwd().endsWith('/dashboard')
+  ? path.resolve(process.cwd(), '..')
+  : process.cwd();
+
+const MOCKUP_DIR = path.join(REPO_ROOT, 'docs', 'superpowers', 'mockups');
+const SLUG = `preview-route-test-${Date.now()}`;
+const TEST_HTML = path.join(MOCKUP_DIR, `2026-04-19-${SLUG}.html`);
+const TEST_MD = path.join(MOCKUP_DIR, `2026-04-19-${SLUG}.md`);
+
+beforeAll(() => {
+  mkdirSync(MOCKUP_DIR, { recursive: true });
+  writeFileSync(TEST_HTML, '<!doctype html><html><body>preview</body></html>');
+  writeFileSync(TEST_MD, '```mermaid\ngraph TD; A-->B;\n```\n');
+});
+
+afterAll(() => {
+  for (const p of [TEST_HTML, TEST_MD]) {
+    if (existsSync(p)) rmSync(p, { force: true });
+  }
+});
+
+function reqWith(qs: string, host = 'localhost:3100'): Request {
+  return new Request(`http://localhost:3100/voice/preview?${qs}`, {
+    headers: { host },
+  });
+}
+
+describe('GET /voice/preview', () => {
+  it('403 off loopback', async () => {
+    const res = await GET(reqWith('file=docs/superpowers/mockups/x.html', 'public.example.com'));
+    expect(res.status).toBe(403);
+  });
+
+  it('400 when file param is missing', async () => {
+    const res = await GET(reqWith(''));
+    expect(res.status).toBe(400);
+  });
+
+  it('403 when file is not under docs/superpowers/mockups/', async () => {
+    const res = await GET(reqWith('file=src/config.ts'));
+    expect(res.status).toBe(403);
+  });
+
+  it('403 on parent-traversal attempt', async () => {
+    const res = await GET(
+      reqWith('file=docs/superpowers/mockups/../../sources/secret.md'),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('403 on absolute path', async () => {
+    const res = await GET(reqWith('file=/etc/passwd'));
+    expect(res.status).toBe(403);
+  });
+
+  it('200 with text/html for a real mockup', async () => {
+    const rel = path.relative(REPO_ROOT, TEST_HTML);
+    const res = await GET(reqWith('file=' + encodeURIComponent(rel)));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toMatch(/text\/html/);
+    const body = await res.text();
+    expect(body).toContain('preview');
+  });
+
+  it('200 with text/markdown for a real diagram', async () => {
+    const rel = path.relative(REPO_ROOT, TEST_MD);
+    const res = await GET(reqWith('file=' + encodeURIComponent(rel)));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toMatch(/text\/markdown/);
+  });
+
+  it('404 for a non-existent file under the mockup dir', async () => {
+    const res = await GET(
+      reqWith('file=docs/superpowers/mockups/2026-01-01-does-not-exist.html'),
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/dashboard/src/app/voice/__tests__/rates.test.ts
+++ b/dashboard/src/app/voice/__tests__/rates.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { computeCostUsd, RATES } from '../rates';
+
+describe('rates', () => {
+  it('computes zero cost for zero tokens', () => {
+    expect(computeCostUsd({ textIn: 0, textOut: 0, audioIn: 0, audioOut: 0 }, RATES)).toBe(0);
+  });
+
+  it('computes cost as the sum of per-modality rates (per million tokens)', () => {
+    const rates = { textInPerM: 1, textOutPerM: 2, audioInPerM: 4, audioOutPerM: 8, asOf: '2026-04-18', version: 'test' };
+    const usage = { textIn: 500_000, textOut: 1_000_000, audioIn: 2_000_000, audioOut: 500_000 };
+    // 0.5 * 1 + 1 * 2 + 2 * 4 + 0.5 * 8 = 0.5 + 2 + 8 + 4 = 14.5
+    expect(computeCostUsd(usage, rates)).toBeCloseTo(14.5, 6);
+  });
+
+  it('exposes a rates version string for persistence', () => {
+    expect(RATES.version).toMatch(/^[a-z0-9-]+$/);
+    expect(RATES.asOf).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/dashboard/src/app/voice/__tests__/voice-session.test.ts
+++ b/dashboard/src/app/voice/__tests__/voice-session.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { WebSocket as WsClient } from 'ws';
+import { startFakeGemini, type FakeGemini } from './fake-gemini-server';
+import { VoiceSession } from '../voice-session';
+import { DEV_PERSONA } from '../personas';
+
+// Node WebSocket client (from `ws`) drives the fake server. VoiceSession
+// accepts a factory so tests can inject it.
+const wsFactory = (url: string) => new WsClient(url) as unknown as WebSocket;
+
+function mockFetchSuccess() {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({}),
+  });
+}
+
+describe('VoiceSession', () => {
+  let fake: FakeGemini;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(async () => {
+    fake = await startFakeGemini();
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    await fake.close();
+  });
+
+  it('opens WS, accumulates cost on usage events, surfaces audio', async () => {
+    globalThis.fetch = mockFetchSuccess() as unknown as typeof globalThis.fetch;
+
+    const audio: Int16Array[] = [];
+    let lastCost = 0;
+
+    const session = new VoiceSession({
+      persona: DEV_PERSONA,
+      liveApiUrl: fake.url,
+      tokenEndpoint: '/test/token',
+      contextEndpoint: '/test/ctx',
+      toolEndpoint: '/test/tool',
+      closeEndpoint: '/test/close',
+      wsFactory,
+      events: {
+        onAudio: (pcm) => audio.push(pcm),
+        onCost: (c) => {
+          lastCost = c;
+        },
+        onInputTranscript: () => {},
+        onOutputTranscript: () => {},
+        onToolCall: async () => ({}),
+        onEnd: () => {},
+      },
+    });
+
+    await session.start();
+
+    fake.sendUsage({
+      textIn: 100_000,
+      textOut: 200_000,
+      audioIn: 1_000_000,
+      audioOut: 1_000_000,
+    });
+    // Send two bytes of audio (one Int16 sample)
+    fake.sendAssistantAudio(
+      Buffer.from(new Uint8Array([0x01, 0x00])).toString('base64'),
+    );
+
+    await new Promise((r) => setTimeout(r, 80));
+    expect(audio.length).toBeGreaterThan(0);
+    expect(audio[0]).toBeInstanceOf(Int16Array);
+    expect(lastCost).toBeGreaterThan(0);
+
+    await session.stop('user_stop');
+  }, 10_000);
+
+  it('captures final transcripts only (ignores partials in buffer) and POSTs session-close with transcript', async () => {
+    const fetchSpy = vi.fn(async (_url: string, _init?: RequestInit) => ({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    }));
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    let endedPayload: unknown = null;
+
+    const session = new VoiceSession({
+      persona: DEV_PERSONA,
+      liveApiUrl: fake.url,
+      wsFactory,
+      tokenEndpoint: '/test/token',
+      contextEndpoint: '/test/ctx',
+      toolEndpoint: '/test/tool',
+      closeEndpoint: '/test/close',
+      events: {
+        onAudio: () => {},
+        onCost: () => {},
+        onInputTranscript: () => {},
+        onOutputTranscript: () => {},
+        onToolCall: async () => ({}),
+        onEnd: (p) => {
+          endedPayload = p;
+        },
+      },
+    });
+
+    await session.start();
+
+    fake.sendInputTranscription('hel', true); // partial → skip
+    fake.sendInputTranscription('hello world', false); // final → buffer
+    fake.sendOutputTranscription('hi the', true); // partial → skip
+    fake.sendOutputTranscription('hi there', false); // final → buffer
+
+    await new Promise((r) => setTimeout(r, 50));
+    await session.stop('user_stop');
+
+    expect(endedPayload).toBeTruthy();
+    const payload = endedPayload as {
+      transcript: Array<{ role: string; text: string }>;
+    };
+    expect(payload.transcript).toHaveLength(2);
+    expect(payload.transcript[0]).toMatchObject({
+      role: 'user',
+      text: 'hello world',
+    });
+    expect(payload.transcript[1]).toMatchObject({
+      role: 'assistant',
+      text: 'hi there',
+    });
+
+    // session-close POSTed
+    const closeCall = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes('/test/close'),
+    );
+    expect(closeCall).toBeDefined();
+    const body = JSON.parse((closeCall![1] as RequestInit).body as string);
+    expect(body.endReason).toBe('user_stop');
+    expect(body.transcript).toHaveLength(2);
+  }, 10_000);
+
+  it('round-trips a tool call (receives call, returns response)', async () => {
+    globalThis.fetch = mockFetchSuccess() as unknown as typeof globalThis.fetch;
+
+    const session = new VoiceSession({
+      persona: DEV_PERSONA,
+      liveApiUrl: fake.url,
+      wsFactory,
+      tokenEndpoint: '/test/token',
+      contextEndpoint: '/test/ctx',
+      toolEndpoint: '/test/tool',
+      closeEndpoint: '/test/close',
+      events: {
+        onAudio: () => {},
+        onCost: () => {},
+        onInputTranscript: () => {},
+        onOutputTranscript: () => {},
+        onToolCall: async (c) => ({ ok: true, echoed: c.name }),
+        onEnd: () => {},
+      },
+    });
+
+    await session.start();
+
+    fake.sendToolCall({
+      id: 'call-42',
+      name: 'read_file',
+      args: { path: 'package.json' },
+    });
+
+    const response = await fake.waitForToolResponse('call-42');
+    expect(response).toEqual({ ok: true, echoed: 'read_file' });
+
+    await session.stop('user_stop');
+  }, 10_000);
+
+  it('fires onEnd with ws_drop when the server terminates unexpectedly', async () => {
+    globalThis.fetch = mockFetchSuccess() as unknown as typeof globalThis.fetch;
+
+    let ended: { endReason?: string } = {};
+
+    const session = new VoiceSession({
+      persona: DEV_PERSONA,
+      liveApiUrl: fake.url,
+      wsFactory,
+      tokenEndpoint: '/test/token',
+      contextEndpoint: '/test/ctx',
+      toolEndpoint: '/test/tool',
+      closeEndpoint: '/test/close',
+      events: {
+        onAudio: () => {},
+        onCost: () => {},
+        onInputTranscript: () => {},
+        onOutputTranscript: () => {},
+        onToolCall: async () => ({}),
+        onEnd: (p) => {
+          ended = p as { endReason?: string };
+        },
+      },
+    });
+
+    await session.start();
+    fake.terminate(); // server closes WS unilaterally
+
+    await new Promise((r) => setTimeout(r, 200));
+    expect(ended.endReason === 'hard_cap' || ended.endReason === 'ws_drop').toBe(
+      true,
+    );
+  }, 10_000);
+});

--- a/dashboard/src/app/voice/__tests__/voice-session.test.ts
+++ b/dashboard/src/app/voice/__tests__/voice-session.test.ts
@@ -78,6 +78,7 @@ describe('VoiceSession', () => {
   }, 10_000);
 
   it('captures final transcripts only (ignores partials in buffer) and POSTs session-close with transcript', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const fetchSpy = vi.fn(async (_url: string, _init?: RequestInit) => ({
       ok: true,
       status: 200,

--- a/dashboard/src/app/voice/audio-io.ts
+++ b/dashboard/src/app/voice/audio-io.ts
@@ -1,0 +1,112 @@
+// Browser-only audio I/O for /voice. Tests don't cover this file (jsdom has
+// no Web Audio); the Task 20 integration test exercises the session path.
+
+export interface MicCapture {
+  stream: MediaStream;
+  onFrame: (cb: (pcm: Int16Array) => void) => void;
+  stop: () => void;
+}
+
+export async function startMicCapture(): Promise<MicCapture> {
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: {
+      channelCount: 1,
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+    },
+  });
+
+  // A dedicated context for capture isolates sample-rate assumptions.
+  const AC =
+    window.AudioContext ||
+    (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext!;
+  const ctx = new AC();
+  await ctx.audioWorklet.addModule('/voice/pcm-capture.js');
+
+  const src = ctx.createMediaStreamSource(stream);
+  const worklet = new AudioWorkletNode(ctx, 'pcm-capture');
+  src.connect(worklet);
+
+  let cb: ((pcm: Int16Array) => void) | null = null;
+  worklet.port.onmessage = (e: MessageEvent<Int16Array>) => {
+    if (cb) cb(e.data);
+  };
+
+  let stopped = false;
+  function stop(): void {
+    if (stopped) return;
+    stopped = true;
+    try {
+      worklet.disconnect();
+    } catch {
+      /* ignore */
+    }
+    try {
+      src.disconnect();
+    } catch {
+      /* ignore */
+    }
+    for (const t of stream.getTracks()) t.stop();
+    ctx.close().catch(() => {
+      /* ignore */
+    });
+  }
+
+  return {
+    stream,
+    onFrame: (fn) => {
+      cb = fn;
+    },
+    stop,
+  };
+}
+
+export interface Playback {
+  enqueue: (pcm24: Int16Array) => void;
+  stop: () => void;
+}
+
+export function createPlayback(): Playback {
+  const AC =
+    window.AudioContext ||
+    (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext!;
+  const ctx = new AC({ sampleRate: 24000 });
+
+  let cursor = 0;
+  const sources = new Set<AudioBufferSourceNode>();
+
+  function enqueue(pcm: Int16Array): void {
+    if (pcm.length === 0) return;
+    const buf = ctx.createBuffer(1, pcm.length, 24000);
+    const data = buf.getChannelData(0);
+    for (let i = 0; i < pcm.length; i++) {
+      data[i] = pcm[i] / (pcm[i] < 0 ? 0x8000 : 0x7fff);
+    }
+    const src = ctx.createBufferSource();
+    src.buffer = buf;
+    src.connect(ctx.destination);
+    const now = ctx.currentTime;
+    const start = Math.max(now, cursor);
+    src.start(start);
+    cursor = start + buf.duration;
+    sources.add(src);
+    src.onended = () => sources.delete(src);
+  }
+
+  function stop(): void {
+    for (const s of sources) {
+      try {
+        s.stop();
+      } catch {
+        /* ignore */
+      }
+    }
+    sources.clear();
+    ctx.close().catch(() => {
+      /* ignore */
+    });
+  }
+
+  return { enqueue, stop };
+}

--- a/dashboard/src/app/voice/audio-worklet-processor.ts
+++ b/dashboard/src/app/voice/audio-worklet-processor.ts
@@ -1,7 +1,10 @@
-// Reference-only source; runtime is dashboard/public/voice/pcm-capture.js.
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck
-// Reference TypeScript copy. The browser loads the compiled JS at
-// /voice/pcm-capture.js via audioContext.audioWorklet.addModule().
+// Reference-only source; runtime is dashboard/public/voice/pcm-capture.js.
+// Excluded from tsconfig because it declares worklet-scope globals
+// (sampleRate, registerProcessor, AudioWorkletProcessor) that don't exist in
+// the main-thread lib types. @ts-nocheck is belt-and-suspenders. Keep in
+// sync with the plain-JS copy in public/voice/pcm-capture.js by hand.
 //
 // Downsamples the native AudioContext sampleRate to 16 kHz mono, converts
 // Float32 [-1,1] to Int16, and posts Int16Array buffers to the main thread.

--- a/dashboard/src/app/voice/audio-worklet-processor.ts
+++ b/dashboard/src/app/voice/audio-worklet-processor.ts
@@ -1,0 +1,53 @@
+// Reference-only source; runtime is dashboard/public/voice/pcm-capture.js.
+// @ts-nocheck
+// Reference TypeScript copy. The browser loads the compiled JS at
+// /voice/pcm-capture.js via audioContext.audioWorklet.addModule().
+//
+// Downsamples the native AudioContext sampleRate to 16 kHz mono, converts
+// Float32 [-1,1] to Int16, and posts Int16Array buffers to the main thread.
+// Target chunk = 320 samples (20 ms at 16 kHz).
+
+declare const sampleRate: number;
+declare function registerProcessor(name: string, cls: unknown): void;
+
+declare class AudioWorkletProcessorBase {
+  port: MessagePort;
+  process(inputs: Float32Array[][], outputs: Float32Array[][], params: Record<string, Float32Array>): boolean;
+}
+
+const TARGET_RATE = 16_000;
+const TARGET_FRAMES = 320;
+
+class PcmCaptureProcessor extends AudioWorkletProcessorBase {
+  private buf: number[] = [];
+  private ratio = sampleRate / TARGET_RATE;
+  private phase = 0;
+
+  process(inputs: Float32Array[][]): boolean {
+    const ch = inputs[0]?.[0];
+    if (!ch) return true;
+
+    for (let i = 0; i < ch.length; i++) {
+      this.phase += 1;
+      if (this.phase >= this.ratio) {
+        // Simple decimation — not anti-aliased. Acceptable for speech.
+        this.buf.push(ch[i]);
+        this.phase -= this.ratio;
+      }
+    }
+
+    while (this.buf.length >= TARGET_FRAMES) {
+      const slice = this.buf.splice(0, TARGET_FRAMES);
+      const out = new Int16Array(TARGET_FRAMES);
+      for (let i = 0; i < TARGET_FRAMES; i++) {
+        const s = Math.max(-1, Math.min(1, slice[i]));
+        out[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+      }
+      this.port.postMessage(out, [out.buffer]);
+    }
+
+    return true;
+  }
+}
+
+registerProcessor('pcm-capture', PcmCaptureProcessor);

--- a/dashboard/src/app/voice/captions.tsx
+++ b/dashboard/src/app/voice/captions.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export interface CaptionLine {
+  role: 'user' | 'assistant';
+  text: string;
+  ts: string;
+  partial?: boolean;
+}
+
+interface CaptionsProps {
+  lines: CaptionLine[];
+  personaLabel?: string;
+}
+
+export function Captions({ lines, personaLabel = 'Dev Assistant' }: CaptionsProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [autoScroll, setAutoScroll] = useState(true);
+
+  useEffect(() => {
+    if (!autoScroll || !scrollRef.current) return;
+    const el = scrollRef.current;
+    el.scrollTop = el.scrollHeight;
+  }, [lines, autoScroll]);
+
+  function onScroll() {
+    const el = scrollRef.current;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+    setAutoScroll(atBottom);
+  }
+
+  async function copySession() {
+    const text = lines
+      .filter((l) => !l.partial)
+      .map((l) => `${l.role === 'user' ? 'You' : personaLabel}: ${l.text}`)
+      .join('\n\n');
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      /* ignore — user can manually select */
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b border-neutral-800 px-3 py-2">
+        <h2 className="text-sm font-semibold text-neutral-200">Transcript</h2>
+        <button
+          type="button"
+          onClick={copySession}
+          className="rounded border border-neutral-700 px-2 py-1 text-xs text-neutral-300 hover:bg-neutral-800"
+        >
+          Copy session
+        </button>
+      </div>
+      <div
+        ref={scrollRef}
+        onScroll={onScroll}
+        className="flex-1 overflow-y-auto px-3 py-2"
+      >
+        {lines.length === 0 ? (
+          <p className="text-sm text-neutral-500">Press Start to begin.</p>
+        ) : (
+          <ul className="space-y-3">
+            {lines.map((line, i) => (
+              <li key={i} className={line.role === 'user' ? 'text-left' : 'text-right'}>
+                <div
+                  className={
+                    (line.role === 'user'
+                      ? 'bg-neutral-800/60 text-neutral-400'
+                      : 'bg-blue-900/40 text-neutral-100') +
+                    (line.partial ? ' opacity-60 italic' : '') +
+                    ' inline-block max-w-[90%] rounded px-3 py-2 text-sm whitespace-pre-wrap'
+                  }
+                >
+                  <div className="mb-1 text-[10px] uppercase tracking-wide text-neutral-500">
+                    {line.role === 'user' ? 'You' : personaLabel}
+                  </div>
+                  {line.text}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/app/voice/cost-panel.tsx
+++ b/dashboard/src/app/voice/cost-panel.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { TokenUsage } from './rates';
+
+interface StatsResponse {
+  todayUsd: number;
+  monthUsd: number;
+  budgetUsd: number | null;
+}
+
+interface CostPanelProps {
+  sessionCostUsd: number;
+  sessionTotals: TokenUsage;
+}
+
+function formatUsd(n: number): string {
+  return '$' + n.toFixed(4);
+}
+
+function formatShortUsd(n: number): string {
+  return '$' + n.toFixed(2);
+}
+
+export function CostPanel({ sessionCostUsd, sessionTotals }: CostPanelProps) {
+  const [stats, setStats] = useState<StatsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/voice/stats')
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`stats ${r.status}`))))
+      .then((s: StatsResponse) => {
+        if (!cancelled) setStats(s);
+      })
+      .catch((e) => {
+        if (!cancelled) setError((e as Error).message);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const overBudget =
+    stats?.budgetUsd != null && stats.monthUsd + sessionCostUsd > stats.budgetUsd;
+
+  const todayTotal = (stats?.todayUsd ?? 0) + sessionCostUsd;
+  const monthTotal = (stats?.monthUsd ?? 0) + sessionCostUsd;
+
+  return (
+    <div className="flex items-center gap-6 border-t border-neutral-800 bg-neutral-950 px-4 py-3 text-sm">
+      <div title={tokenBreakdownTitle(sessionTotals)}>
+        <div className="text-[10px] uppercase tracking-wide text-neutral-500">Session</div>
+        <div className="font-mono text-neutral-100">{formatUsd(sessionCostUsd)}</div>
+      </div>
+      <div>
+        <div className="text-[10px] uppercase tracking-wide text-neutral-500">Today</div>
+        <div className="font-mono text-neutral-300">{formatShortUsd(todayTotal)}</div>
+      </div>
+      <div>
+        <div className="text-[10px] uppercase tracking-wide text-neutral-500">This month</div>
+        <div className="font-mono text-neutral-300">{formatShortUsd(monthTotal)}</div>
+      </div>
+      {stats?.budgetUsd != null && (
+        <div>
+          <div className="text-[10px] uppercase tracking-wide text-neutral-500">Budget</div>
+          <div className={'font-mono ' + (overBudget ? 'text-amber-400' : 'text-neutral-500')}>
+            {formatShortUsd(stats.budgetUsd)}
+          </div>
+        </div>
+      )}
+      {overBudget && (
+        <div className="rounded bg-amber-900/40 px-2 py-1 text-xs text-amber-200">
+          Monthly budget exceeded
+        </div>
+      )}
+      {error && (
+        <div className="text-xs text-red-400">stats unavailable: {error}</div>
+      )}
+    </div>
+  );
+}
+
+function tokenBreakdownTitle(t: TokenUsage): string {
+  return `textIn: ${t.textIn}\ntextOut: ${t.textOut}\naudioIn: ${t.audioIn}\naudioOut: ${t.audioOut}`;
+}

--- a/dashboard/src/app/voice/cost-tracker.ts
+++ b/dashboard/src/app/voice/cost-tracker.ts
@@ -1,0 +1,46 @@
+import { type Rates, type TokenUsage, computeCostUsd } from './rates';
+
+type ChangeListener = (costUsd: number) => void;
+
+export class CostTracker {
+  private _totals: TokenUsage = { textIn: 0, textOut: 0, audioIn: 0, audioOut: 0 };
+  private readonly _listeners = new Set<ChangeListener>();
+
+  constructor(private readonly rates: Rates) {}
+
+  get totals(): Readonly<TokenUsage> {
+    return { ...this._totals };
+  }
+
+  get costUsd(): number {
+    return computeCostUsd(this._totals, this.rates);
+  }
+
+  addUsage(usage: TokenUsage): void {
+    this._totals.textIn += usage.textIn ?? 0;
+    this._totals.textOut += usage.textOut ?? 0;
+    this._totals.audioIn += usage.audioIn ?? 0;
+    this._totals.audioOut += usage.audioOut ?? 0;
+    this._emit();
+  }
+
+  reset(): void {
+    this._totals = { textIn: 0, textOut: 0, audioIn: 0, audioOut: 0 };
+    this._emit();
+  }
+
+  onChange(cb: ChangeListener): void {
+    this._listeners.add(cb);
+  }
+
+  offChange(cb: ChangeListener): void {
+    this._listeners.delete(cb);
+  }
+
+  private _emit(): void {
+    const c = this.costUsd;
+    for (const cb of this._listeners) {
+      cb(c);
+    }
+  }
+}

--- a/dashboard/src/app/voice/page.tsx
+++ b/dashboard/src/app/voice/page.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Captions, type CaptionLine } from './captions';
+import { PreviewPane, type PreviewArtifact } from './preview-pane';
+import { CostPanel } from './cost-panel';
+import { DEV_PERSONA } from './personas';
+import { VoiceSession, type SessionEndPayload } from './voice-session';
+import { createPlayback, startMicCapture, type MicCapture, type Playback } from './audio-io';
+import type { TokenUsage } from './rates';
+
+type Status =
+  | { kind: 'idle' }
+  | { kind: 'starting' }
+  | { kind: 'running' }
+  | { kind: 'ending' }
+  | { kind: 'ended'; payload: SessionEndPayload }
+  | { kind: 'error'; message: string };
+
+const EMPTY_USAGE: TokenUsage = { textIn: 0, textOut: 0, audioIn: 0, audioOut: 0 };
+
+export default function VoicePage() {
+  const [status, setStatus] = useState<Status>({ kind: 'idle' });
+  const [captions, setCaptions] = useState<CaptionLine[]>([]);
+  const [artifacts, setArtifacts] = useState<PreviewArtifact[]>([]);
+  const [costUsd, setCostUsd] = useState(0);
+  const [sessionTotals, setSessionTotals] = useState<TokenUsage>(EMPTY_USAGE);
+  const [muted, setMuted] = useState(false);
+  const [elapsedSec, setElapsedSec] = useState(0);
+
+  const sessionRef = useRef<VoiceSession | null>(null);
+  const micRef = useRef<MicCapture | null>(null);
+  const playbackRef = useRef<Playback | null>(null);
+  const startedAtRef = useRef<number | null>(null);
+
+  // Session timer
+  useEffect(() => {
+    if (status.kind !== 'running') return;
+    const t = setInterval(() => {
+      if (startedAtRef.current != null) {
+        setElapsedSec(Math.floor((Date.now() - startedAtRef.current) / 1000));
+      }
+    }, 500);
+    return () => clearInterval(t);
+  }, [status.kind]);
+
+  // tab-close → best-effort stop
+  useEffect(() => {
+    function onBeforeUnload() {
+      if (sessionRef.current) {
+        void sessionRef.current.stop('tab_close');
+      }
+    }
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, []);
+
+  const cleanup = useCallback(() => {
+    micRef.current?.stop();
+    micRef.current = null;
+    playbackRef.current?.stop();
+    playbackRef.current = null;
+    sessionRef.current = null;
+    startedAtRef.current = null;
+  }, []);
+
+  async function handleStart() {
+    setStatus({ kind: 'starting' });
+    setCaptions([]);
+    setArtifacts([]);
+    setCostUsd(0);
+    setSessionTotals(EMPTY_USAGE);
+    setElapsedSec(0);
+    setMuted(false);
+
+    try {
+      const mic = await startMicCapture();
+      micRef.current = mic;
+      const playback = createPlayback();
+      playbackRef.current = playback;
+
+      const session = new VoiceSession({
+        persona: DEV_PERSONA,
+        events: {
+          onInputTranscript: (text, partial) => {
+            setCaptions((cur) => appendOrReplacePartial(cur, 'user', text, partial));
+          },
+          onOutputTranscript: (text, partial) => {
+            setCaptions((cur) => appendOrReplacePartial(cur, 'assistant', text, partial));
+          },
+          onAudio: (pcm) => {
+            playback.enqueue(pcm);
+          },
+          onToolCall: async (call) => {
+            const res = await fetch(`/api/voice/tools/dev/${call.name}`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify(call.args ?? {}),
+            });
+            const body = await res.json();
+            if (body && typeof body === 'object' && 'previewUrl' in body && 'path' in body) {
+              const p = String((body as { path: string }).path);
+              const isDiagram = p.endsWith('.md');
+              setArtifacts((cur) => [
+                ...cur,
+                { type: isDiagram ? 'diagram' : 'mockup', path: p },
+              ]);
+            }
+            return body;
+          },
+          onCost: (c) => {
+            setCostUsd(c);
+            if (sessionRef.current) {
+              // Pull the fresh usage totals from the tracker via session
+              // (VoiceSession forwards onCost only; we query directly).
+            }
+          },
+          onEnd: (payload) => {
+            setSessionTotals(payload.usage);
+            setStatus({ kind: 'ended', payload });
+            cleanup();
+          },
+        },
+      });
+
+      sessionRef.current = session;
+      mic.onFrame((pcm) => {
+        if (!muted) session.sendAudio(pcm);
+      });
+
+      await session.start();
+      startedAtRef.current = Date.now();
+      setStatus({ kind: 'running' });
+    } catch (e) {
+      cleanup();
+      setStatus({ kind: 'error', message: (e as Error).message });
+    }
+  }
+
+  async function handleStop() {
+    if (!sessionRef.current) return;
+    setStatus({ kind: 'ending' });
+    try {
+      await sessionRef.current.stop('user_stop');
+    } catch (e) {
+      setStatus({ kind: 'error', message: (e as Error).message });
+    }
+  }
+
+  function toggleMute() {
+    setMuted((m) => {
+      const next = !m;
+      if (sessionRef.current) {
+        if (next) sessionRef.current.mute();
+        else sessionRef.current.unmute();
+      }
+      return next;
+    });
+  }
+
+  return (
+    <div className="flex h-screen flex-col bg-neutral-950 text-neutral-100">
+      <header className="flex items-center justify-between border-b border-neutral-800 px-4 py-3">
+        <div className="flex items-center gap-3">
+          <h1 className="text-lg font-semibold">Voice · Dev Assistant</h1>
+          <span className="rounded bg-amber-900/40 px-2 py-0.5 text-xs text-amber-200">
+            Localhost only — do not expose without auth
+          </span>
+        </div>
+        <div className="flex items-center gap-3 text-sm">
+          {status.kind === 'running' && (
+            <>
+              <span className="font-mono text-neutral-400">
+                {formatElapsed(elapsedSec)}
+              </span>
+              <button
+                type="button"
+                onClick={toggleMute}
+                className={
+                  'rounded px-3 py-1 text-sm ' +
+                  (muted
+                    ? 'bg-amber-800 text-amber-100'
+                    : 'border border-neutral-700 text-neutral-300 hover:bg-neutral-800')
+                }
+              >
+                {muted ? 'Muted' : 'Mute'}
+              </button>
+              <button
+                type="button"
+                onClick={handleStop}
+                className="rounded bg-red-800 px-3 py-1 text-sm text-red-100 hover:bg-red-700"
+              >
+                Stop
+              </button>
+            </>
+          )}
+          {status.kind === 'idle' && (
+            <button
+              type="button"
+              onClick={handleStart}
+              className="rounded bg-blue-700 px-3 py-1 text-sm text-white hover:bg-blue-600"
+            >
+              Start
+            </button>
+          )}
+          {status.kind === 'starting' && <span className="text-neutral-400">Starting…</span>}
+          {status.kind === 'ending' && <span className="text-neutral-400">Ending…</span>}
+          {status.kind === 'ended' && (
+            <button
+              type="button"
+              onClick={() => setStatus({ kind: 'idle' })}
+              className="rounded bg-blue-700 px-3 py-1 text-sm text-white hover:bg-blue-600"
+            >
+              Start new session
+            </button>
+          )}
+        </div>
+      </header>
+
+      {status.kind === 'error' && (
+        <div className="border-b border-red-900 bg-red-950/60 px-4 py-2 text-sm text-red-200">
+          Error: {status.message}{' '}
+          <button
+            type="button"
+            onClick={() => setStatus({ kind: 'idle' })}
+            className="ml-2 underline"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {status.kind === 'ended' && (
+        <div className="border-b border-neutral-800 bg-neutral-900 px-4 py-2 text-sm text-neutral-300">
+          Session ended — cost ${status.payload.usage ? costUsd.toFixed(4) : '0.00'}.
+          {' '}
+          Transcript saved.
+        </div>
+      )}
+
+      <div className="grid flex-1 grid-cols-[minmax(0,2fr)_minmax(0,3fr)] overflow-hidden">
+        <div className="border-r border-neutral-800">
+          <Captions lines={captions} />
+        </div>
+        <div>
+          <PreviewPane artifacts={artifacts} />
+        </div>
+      </div>
+
+      <CostPanel sessionCostUsd={costUsd} sessionTotals={sessionTotals} />
+    </div>
+  );
+}
+
+function appendOrReplacePartial(
+  lines: CaptionLine[],
+  role: 'user' | 'assistant',
+  text: string,
+  partial: boolean,
+): CaptionLine[] {
+  const out = [...lines];
+  const last = out[out.length - 1];
+  if (last && last.role === role && last.partial) {
+    out[out.length - 1] = { role, text, ts: last.ts, partial };
+    if (!partial) {
+      // finalise: drop the partial flag
+      out[out.length - 1] = { role, text, ts: last.ts };
+    }
+    return out;
+  }
+  out.push({ role, text, ts: new Date().toISOString(), partial: partial || undefined });
+  return out;
+}
+
+function formatElapsed(sec: number): string {
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}

--- a/dashboard/src/app/voice/personas.ts
+++ b/dashboard/src/app/voice/personas.ts
@@ -1,0 +1,153 @@
+import { Type, type FunctionDeclaration } from '@google/genai';
+
+export interface PersonaConfig {
+  name: 'dev';
+  voice: string;
+  systemInstruction: string;
+  tools: FunctionDeclaration[];
+  contextPath: string;
+}
+
+const SYSTEM_INSTRUCTION = `You are the uniClaw Dev Assistant — a design and brainstorming partner speaking with the developer by voice. uniClaw is their personal Claude assistant / teaching platform, forked from NanoClaw.
+
+You have read-only access to the codebase and docs, plus write access to docs/superpowers/specs/, docs/superpowers/plans/, and docs/superpowers/mockups/. You do NOT edit source code, configs, or tests — Claude Code handles implementation; your job is to help the developer think, then capture the result as a written artifact.
+
+Use the context block that follows on session start. It contains the project's CLAUDE.md, architecture overview, a subsystem map, available npm scripts, and current repo state. Speak specifically about their codebase, not generically.
+
+Keep spoken turns short (aim at most 15 seconds). Think out loud. Ask about constraints before drafting. When writing specs or plans, match the structure of existing files in those directories. For mockups, produce single-file HTML with Tailwind via CDN — the mockup is rendered in a sandboxed iframe with scripts only (no same-origin, localStorage, or network access), so make it self-contained. For architecture or flow questions, prefer mermaid diagrams over prose.
+
+Tool choice hints: use grep/glob before read_file when searching; use git_log / git_status to read current branch state; use list_docs before read_doc; use write_spec / write_plan / write_mockup / write_diagram to capture the result of a conversation. The server generates date prefixes and paths from your slug; slugs must match ^[a-z0-9-]{1,80}$.`;
+
+const TOOLS: FunctionDeclaration[] = [
+  {
+    name: 'read_file',
+    description: 'Read a file from the repository. Scoped to src/, container/, dashboard/src/, docs/, scripts/, public/, and root config files. Output is truncated at 256 KB.',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        path: { type: Type.STRING, description: 'Repo-relative path, e.g. "src/voice/path-scope.ts"' },
+      },
+      required: ['path'],
+    },
+  },
+  {
+    name: 'glob',
+    description: 'Find files matching a glob pattern. Returns up to 500 repo-relative paths.',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        pattern: { type: Type.STRING, description: 'Glob pattern, e.g. "src/**/*.ts"' },
+      },
+      required: ['pattern'],
+    },
+  },
+  {
+    name: 'grep',
+    description: 'Search file contents for a regex pattern. Returns up to 200 matches with path/line/text.',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        pattern: { type: Type.STRING, description: 'Regex pattern' },
+        glob:    { type: Type.STRING, description: 'Optional glob to narrow files, e.g. "src/**/*.ts"' },
+        path:    { type: Type.STRING, description: 'Optional single-file scope (alternative to glob)' },
+      },
+      required: ['pattern'],
+    },
+  },
+  {
+    name: 'git_log',
+    description: 'Return recent git commits (sha, author, date, subject).',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        limit: { type: Type.INTEGER, description: 'Max commits to return (1-200, default 10)' },
+        path:  { type: Type.STRING,  description: 'Optional repo-relative path to filter history by' },
+      },
+    },
+  },
+  {
+    name: 'git_status',
+    description: 'Return current branch plus staged/modified/untracked file lists.',
+    parameters: { type: Type.OBJECT, properties: {} },
+  },
+  {
+    name: 'list_docs',
+    description: 'List filenames in a docs/superpowers subdirectory.',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        kind: { type: Type.STRING, description: 'One of: specs, plans, mockups, sessions' },
+      },
+      required: ['kind'],
+    },
+  },
+  {
+    name: 'read_doc',
+    description: 'Read a single file from a docs/superpowers subdirectory.',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        kind: { type: Type.STRING, description: 'One of: specs, plans, mockups, sessions' },
+        name: { type: Type.STRING, description: 'Filename without directory, e.g. "2026-04-18-foo.md"' },
+      },
+      required: ['kind', 'name'],
+    },
+  },
+  {
+    name: 'write_spec',
+    description: 'Write a design-spec markdown file to docs/superpowers/specs/. The server prefixes todays date and uses your slug.',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        slug:    { type: Type.STRING, description: 'Lowercase, digits, hyphens only. 1-80 chars.' },
+        content: { type: Type.STRING, description: 'Full markdown body. Max 256 KB.' },
+      },
+      required: ['slug', 'content'],
+    },
+  },
+  {
+    name: 'write_plan',
+    description: 'Write an implementation-plan markdown file to docs/superpowers/plans/. Server prefixes todays date.',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        slug:    { type: Type.STRING, description: 'Lowercase, digits, hyphens only. 1-80 chars.' },
+        content: { type: Type.STRING, description: 'Full markdown body. Max 256 KB.' },
+      },
+      required: ['slug', 'content'],
+    },
+  },
+  {
+    name: 'write_mockup',
+    description: 'Write a single-file HTML mockup to docs/superpowers/mockups/. Rendered in a sandboxed iframe (scripts only, no same-origin). Include Tailwind via CDN if needed; no external fetches.',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        slug: { type: Type.STRING, description: 'Lowercase, digits, hyphens only. 1-80 chars.' },
+        html: { type: Type.STRING, description: 'Full HTML document. Max 256 KB.' },
+      },
+      required: ['slug', 'html'],
+    },
+  },
+  {
+    name: 'write_diagram',
+    description: 'Write a mermaid diagram as a markdown file to docs/superpowers/mockups/. Server wraps your mermaid in a fenced code block.',
+    parameters: {
+      type: Type.OBJECT,
+      properties: {
+        slug:    { type: Type.STRING, description: 'Lowercase, digits, hyphens only. 1-80 chars.' },
+        mermaid: { type: Type.STRING, description: 'Mermaid diagram source (e.g. flowchart/sequenceDiagram). Max 256 KB.' },
+        title:   { type: Type.STRING, description: 'Optional title rendered as an H1 above the diagram.' },
+      },
+      required: ['slug', 'mermaid'],
+    },
+  },
+];
+
+export const DEV_PERSONA: PersonaConfig = {
+  name: 'dev',
+  voice: 'Zephyr',
+  systemInstruction: SYSTEM_INSTRUCTION,
+  tools: TOOLS,
+  contextPath: '/api/voice/context/dev',
+};

--- a/dashboard/src/app/voice/preview-pane.tsx
+++ b/dashboard/src/app/voice/preview-pane.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import mermaid from 'mermaid';
+
+export interface PreviewArtifact {
+  type: 'mockup' | 'diagram';
+  path: string;
+}
+
+interface PreviewPaneProps {
+  artifacts: PreviewArtifact[];
+}
+
+type Tab = 'mockup' | 'diagram';
+
+export function PreviewPane({ artifacts }: PreviewPaneProps) {
+  const [tab, setTab] = useState<Tab>('mockup');
+
+  const latestMockup = [...artifacts].reverse().find((a) => a.type === 'mockup');
+  const latestDiagram = [...artifacts].reverse().find((a) => a.type === 'diagram');
+
+  useEffect(() => {
+    if (latestMockup && tab === 'mockup') return;
+    if (latestDiagram && tab === 'diagram') return;
+    if (latestMockup) setTab('mockup');
+    else if (latestDiagram) setTab('diagram');
+  }, [latestMockup, latestDiagram, tab]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-2 border-b border-neutral-800 px-3 py-2">
+        <button
+          type="button"
+          className={
+            'rounded px-2 py-1 text-xs ' +
+            (tab === 'mockup'
+              ? 'bg-neutral-700 text-neutral-100'
+              : 'text-neutral-400 hover:bg-neutral-800')
+          }
+          onClick={() => setTab('mockup')}
+        >
+          Mockup
+        </button>
+        <button
+          type="button"
+          className={
+            'rounded px-2 py-1 text-xs ' +
+            (tab === 'diagram'
+              ? 'bg-neutral-700 text-neutral-100'
+              : 'text-neutral-400 hover:bg-neutral-800')
+          }
+          onClick={() => setTab('diagram')}
+        >
+          Diagram
+        </button>
+      </div>
+      <div className="flex-1 overflow-hidden">
+        {tab === 'mockup' ? (
+          latestMockup ? (
+            <iframe
+              key={latestMockup.path}
+              sandbox="allow-scripts"
+              src={`/voice/preview?file=${encodeURIComponent(latestMockup.path)}`}
+              className="h-full w-full border-0 bg-white"
+              title="Mockup preview"
+            />
+          ) : (
+            <EmptyState label="No mockup yet — ask the assistant to write one." />
+          )
+        ) : latestDiagram ? (
+          <DiagramView key={latestDiagram.path} filePath={latestDiagram.path} />
+        ) : (
+          <EmptyState label="No diagram yet — ask for a flowchart or sequence diagram." />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ label }: { label: string }) {
+  return (
+    <div className="flex h-full items-center justify-center px-6 text-center text-sm text-neutral-500">
+      {label}
+    </div>
+  );
+}
+
+function DiagramView({ filePath }: { filePath: string }) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function render() {
+      setError(null);
+      try {
+        const res = await fetch(
+          `/voice/preview?file=${encodeURIComponent(filePath)}`,
+        );
+        if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
+        const md = await res.text();
+        const match = md.match(/```mermaid\n([\s\S]*?)\n```/);
+        const mermaidSource = match ? match[1] : md.trim();
+        if (!mermaidSource) throw new Error('no mermaid source found');
+        mermaid.initialize({ startOnLoad: false, theme: 'dark' });
+        const id = 'm_' + Math.random().toString(36).slice(2);
+        const { svg } = await mermaid.render(id, mermaidSource);
+        if (cancelled) return;
+        if (ref.current) ref.current.innerHTML = svg;
+      } catch (e) {
+        if (!cancelled) setError((e as Error).message);
+      }
+    }
+    render();
+    return () => {
+      cancelled = true;
+    };
+  }, [filePath]);
+
+  return (
+    <div className="h-full w-full overflow-auto bg-neutral-900 p-4">
+      {error ? (
+        <p className="text-sm text-red-400">Diagram error: {error}</p>
+      ) : (
+        <div ref={ref} className="mermaid-diagram text-neutral-100" />
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/app/voice/preview-pane.tsx
+++ b/dashboard/src/app/voice/preview-pane.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import mermaid from 'mermaid';
+// useEffect is used by DiagramView below.
 
 export interface PreviewArtifact {
   type: 'mockup' | 'diagram';
@@ -15,17 +16,16 @@ interface PreviewPaneProps {
 type Tab = 'mockup' | 'diagram';
 
 export function PreviewPane({ artifacts }: PreviewPaneProps) {
-  const [tab, setTab] = useState<Tab>('mockup');
+  // User's explicit tab choice (null = auto-pick based on artifacts).
+  const [userTab, setUserTab] = useState<Tab | null>(null);
 
   const latestMockup = [...artifacts].reverse().find((a) => a.type === 'mockup');
   const latestDiagram = [...artifacts].reverse().find((a) => a.type === 'diagram');
 
-  useEffect(() => {
-    if (latestMockup && tab === 'mockup') return;
-    if (latestDiagram && tab === 'diagram') return;
-    if (latestMockup) setTab('mockup');
-    else if (latestDiagram) setTab('diagram');
-  }, [latestMockup, latestDiagram, tab]);
+  // Derived tab: user's pick wins; otherwise prefer mockup if present, then diagram.
+  const tab: Tab =
+    userTab ?? (latestMockup ? 'mockup' : latestDiagram ? 'diagram' : 'mockup');
+  const setTab = setUserTab;
 
   return (
     <div className="flex h-full flex-col">

--- a/dashboard/src/app/voice/preview/route.ts
+++ b/dashboard/src/app/voice/preview/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { resolveReadPath } from '../../../../../src/voice/path-scope';
+
+function isLoopback(host: string | null): boolean {
+  if (!host) return false;
+  let h = host.trim();
+  if (h.startsWith('[')) {
+    const end = h.indexOf(']');
+    h = end >= 0 ? h.slice(1, end) : h;
+  } else {
+    h = h.split(':')[0];
+  }
+  return h === 'localhost' || h === '127.0.0.1' || h === '::1';
+}
+
+function getRepoRoot(): string {
+  const cwd = process.cwd();
+  return cwd.endsWith(path.sep + 'dashboard') || cwd.endsWith('/dashboard')
+    ? path.resolve(cwd, '..')
+    : cwd;
+}
+
+export async function GET(req: Request) {
+  if (!isLoopback(req.headers.get('host'))) {
+    return NextResponse.json(
+      { error: 'voice endpoints are localhost-only' },
+      { status: 403 },
+    );
+  }
+  const url = new URL(req.url);
+  const file = url.searchParams.get('file');
+  if (!file) {
+    return NextResponse.json({ error: 'file param required' }, { status: 400 });
+  }
+  const normalized = path.posix.normalize(file);
+  if (!normalized.startsWith('docs/superpowers/mockups/')) {
+    return NextResponse.json({ error: 'out of scope' }, { status: 403 });
+  }
+  const repoRoot = getRepoRoot();
+  try {
+    const abs = await resolveReadPath(repoRoot, normalized);
+    const content = await fs.readFile(abs, 'utf8');
+    const contentType = abs.endsWith('.html')
+      ? 'text/html; charset=utf-8'
+      : abs.endsWith('.md')
+        ? 'text/markdown; charset=utf-8'
+        : 'text/plain; charset=utf-8';
+    return new Response(content, { headers: { 'content-type': contentType } });
+  } catch {
+    return NextResponse.json({ error: 'not found or out of scope' }, { status: 404 });
+  }
+}

--- a/dashboard/src/app/voice/rates.ts
+++ b/dashboard/src/app/voice/rates.ts
@@ -1,0 +1,38 @@
+// Gemini 3.1 Flash Live pricing.
+// Source: https://ai.google.dev/gemini-api/docs/pricing
+// Retrieved: 2026-04-18
+// Update `asOf` and `version` when these change.
+
+export interface Rates {
+  textInPerM: number;
+  textOutPerM: number;
+  audioInPerM: number;
+  audioOutPerM: number;
+  asOf: string; // YYYY-MM-DD
+  version: string; // short tag used by voice_sessions.rates_version
+}
+
+export const RATES: Rates = {
+  textInPerM: 0.75,
+  textOutPerM: 4.5,
+  audioInPerM: 3.0,
+  audioOutPerM: 12.0,
+  asOf: '2026-04-18',
+  version: 'gemini-31-flash-live-2026-04',
+};
+
+export interface TokenUsage {
+  textIn: number;
+  textOut: number;
+  audioIn: number;
+  audioOut: number;
+}
+
+export function computeCostUsd(usage: TokenUsage, rates: Rates): number {
+  return (
+    (usage.textIn / 1_000_000) * rates.textInPerM +
+    (usage.textOut / 1_000_000) * rates.textOutPerM +
+    (usage.audioIn / 1_000_000) * rates.audioInPerM +
+    (usage.audioOut / 1_000_000) * rates.audioOutPerM
+  );
+}

--- a/dashboard/src/app/voice/voice-session.ts
+++ b/dashboard/src/app/voice/voice-session.ts
@@ -224,8 +224,8 @@ export class VoiceSession {
             ? ev.data
             : ev.data instanceof ArrayBuffer
               ? Buffer.from(new Uint8Array(ev.data)).toString('utf8')
-              : Buffer.isBuffer
-                ? Buffer.from(ev.data as unknown as ArrayBuffer).toString('utf8')
+              : Buffer.isBuffer(ev.data)
+                ? (ev.data as Buffer).toString('utf8')
                 : String(ev.data);
         this.onMessage(raw);
       },

--- a/dashboard/src/app/voice/voice-session.ts
+++ b/dashboard/src/app/voice/voice-session.ts
@@ -1,0 +1,435 @@
+import { CostTracker } from './cost-tracker';
+import { RATES, type TokenUsage } from './rates';
+import type { PersonaConfig } from './personas';
+
+export interface VoiceSessionEvents {
+  onInputTranscript: (text: string, partial: boolean) => void;
+  onOutputTranscript: (text: string, partial: boolean) => void;
+  onAudio: (pcm: Int16Array) => void;
+  onToolCall: (call: {
+    id: string;
+    name: string;
+    args: unknown;
+  }) => Promise<unknown>;
+  onCost: (costUsd: number) => void;
+  onEnd: (payload: SessionEndPayload) => void;
+}
+
+export interface TranscriptEntry {
+  role: 'user' | 'assistant';
+  text: string;
+  ts: string;
+}
+
+export interface SessionEndPayload {
+  transcript: TranscriptEntry[];
+  startedAt: string;
+  endedAt: string;
+  usage: TokenUsage;
+  endReason: 'user_stop' | 'tab_close' | 'soft_cap' | 'hard_cap' | 'ws_drop';
+  resumeHandle?: string;
+}
+
+export interface VoiceSessionOptions {
+  persona: PersonaConfig;
+  tokenEndpoint?: string;
+  contextEndpoint?: string;
+  toolEndpoint?: string;
+  closeEndpoint?: string;
+  liveApiUrl?: string;
+  softCapSeconds?: number;
+  events: VoiceSessionEvents;
+  wsFactory?: (url: string) => WebSocket;
+}
+
+type StopReason = SessionEndPayload['endReason'];
+
+interface ServerFrame {
+  type: string;
+  data?: string;
+  text?: string;
+  partial?: boolean;
+  id?: string;
+  name?: string;
+  args?: unknown;
+  textIn?: number;
+  textOut?: number;
+  audioIn?: number;
+  audioOut?: number;
+}
+
+const WS_OPEN = 1;
+
+function pcmToBase64(pcm: Int16Array): string {
+  const bytes = new Uint8Array(pcm.buffer, pcm.byteOffset, pcm.byteLength);
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(bytes).toString('base64');
+  }
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+
+function base64ToPcm(b64: string): Int16Array {
+  if (typeof Buffer !== 'undefined') {
+    const buf = Buffer.from(b64, 'base64');
+    // Copy into a standalone Int16Array so callers don't alias Buffer memory.
+    const pcm = new Int16Array(Math.floor(buf.length / 2));
+    const view = new DataView(
+      buf.buffer,
+      buf.byteOffset,
+      pcm.length * 2,
+    );
+    for (let i = 0; i < pcm.length; i++) {
+      pcm[i] = view.getInt16(i * 2, true);
+    }
+    return pcm;
+  }
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new Int16Array(
+    bytes.buffer,
+    bytes.byteOffset,
+    Math.floor(bytes.byteLength / 2),
+  );
+}
+
+function newSessionId(): string {
+  const g = globalThis as unknown as { crypto?: { randomUUID?: () => string } };
+  const uuid = g.crypto?.randomUUID?.();
+  if (uuid) return uuid;
+  return 'sid-' + Math.random().toString(36).slice(2);
+}
+
+export class VoiceSession {
+  private readonly events: VoiceSessionEvents;
+  private readonly persona: PersonaConfig;
+  private readonly tokenEndpoint: string;
+  private readonly contextEndpoint: string;
+  private readonly toolEndpoint: string;
+  private readonly closeEndpoint: string;
+  private readonly liveApiUrl: string | undefined;
+  private readonly softCapSeconds: number;
+  private readonly wsFactory: (url: string) => WebSocket;
+
+  private readonly costTracker: CostTracker;
+  private readonly costListener: (c: number) => void;
+  private readonly transcript: TranscriptEntry[] = [];
+
+  private ws: WebSocket | null = null;
+  private voiceSessionId = '';
+  private startedAt = '';
+  private muted = false;
+  private softCapTimer: ReturnType<typeof setTimeout> | null = null;
+  private stoppingPromise: Promise<void> | null = null;
+  private started = false;
+
+  constructor(opts: VoiceSessionOptions) {
+    this.events = opts.events;
+    this.persona = opts.persona;
+    this.tokenEndpoint = opts.tokenEndpoint ?? '/api/voice/token';
+    this.contextEndpoint = opts.contextEndpoint ?? opts.persona.contextPath;
+    this.toolEndpoint = opts.toolEndpoint ?? '/api/voice/tools/dev';
+    this.closeEndpoint = opts.closeEndpoint ?? '/api/voice/session-close';
+    this.liveApiUrl = opts.liveApiUrl;
+    this.softCapSeconds = opts.softCapSeconds ?? 600;
+    this.wsFactory =
+      opts.wsFactory ??
+      ((url: string) => new (globalThis as { WebSocket: typeof WebSocket }).WebSocket(url));
+
+    this.costTracker = new CostTracker(RATES);
+    this.costListener = (c) => {
+      this.events.onCost(c);
+    };
+    this.costTracker.onChange(this.costListener);
+  }
+
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    this.startedAt = new Date().toISOString();
+
+    let wsUrl: string;
+    if (this.liveApiUrl) {
+      this.voiceSessionId = newSessionId();
+      wsUrl = this.liveApiUrl;
+    } else {
+      const tokenRes = await fetch(this.tokenEndpoint, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ persona: this.persona.name }),
+      });
+      if (!tokenRes.ok) {
+        throw new Error(`Token mint failed: ${tokenRes.status}`);
+      }
+      const { token, voiceSessionId } = (await tokenRes.json()) as {
+        token: string;
+        voiceSessionId: string;
+      };
+      this.voiceSessionId = voiceSessionId;
+      // Raw URL placeholder for prod; production wiring is Task 19's concern.
+      wsUrl = `wss://generativelanguage.googleapis.com/?access_token=${encodeURIComponent(
+        token,
+      )}`;
+    }
+
+    // Fetch startup context BEFORE opening the WS; failure blocks session start.
+    const ctxRes = await fetch(this.contextEndpoint);
+    if (!ctxRes.ok) {
+      throw new Error(`Context fetch failed: ${ctxRes.status}`);
+    }
+    const contextPayload = await ctxRes.json();
+
+    const ws = this.wsFactory(wsUrl);
+    this.ws = ws;
+
+    await new Promise<void>((resolve, reject) => {
+      const onOpen = () => {
+        cleanup();
+        resolve();
+      };
+      const onError = (ev: unknown) => {
+        cleanup();
+        reject(new Error('ws open failed: ' + String(ev)));
+      };
+      const cleanup = () => {
+        (ws as unknown as { removeEventListener?: Function }).removeEventListener?.(
+          'open',
+          onOpen as EventListener,
+        );
+        (ws as unknown as { removeEventListener?: Function }).removeEventListener?.(
+          'error',
+          onError as EventListener,
+        );
+      };
+      (ws as unknown as { addEventListener: Function }).addEventListener(
+        'open',
+        onOpen as EventListener,
+        { once: true },
+      );
+      (ws as unknown as { addEventListener: Function }).addEventListener(
+        'error',
+        onError as EventListener,
+        { once: true },
+      );
+    });
+
+    // Wire ongoing handlers.
+    (ws as unknown as { addEventListener: Function }).addEventListener(
+      'message',
+      (ev: MessageEvent) => {
+        const raw =
+          typeof ev.data === 'string'
+            ? ev.data
+            : ev.data instanceof ArrayBuffer
+              ? Buffer.from(new Uint8Array(ev.data)).toString('utf8')
+              : Buffer.isBuffer
+                ? Buffer.from(ev.data as unknown as ArrayBuffer).toString('utf8')
+                : String(ev.data);
+        this.onMessage(raw);
+      },
+    );
+    (ws as unknown as { addEventListener: Function }).addEventListener(
+      'close',
+      () => {
+        if (!this.stoppingPromise) {
+          void this.stop('ws_drop');
+        }
+      },
+    );
+    (ws as unknown as { addEventListener: Function }).addEventListener(
+      'error',
+      () => {
+        // Swallow post-open errors; close handler will drive shutdown.
+      },
+    );
+
+    // Send the initial client_content with persona + context.
+    this.wsSend({
+      type: 'client_content',
+      content: {
+        systemInstruction: this.persona.systemInstruction,
+        context: contextPayload,
+        tools: this.persona.tools,
+        voice: this.persona.voice,
+      },
+    });
+
+    // Start soft-cap timer.
+    this.softCapTimer = setTimeout(() => {
+      void this.stop('soft_cap');
+    }, this.softCapSeconds * 1000);
+  }
+
+  sendAudio(pcm: Int16Array): void {
+    if (this.muted) return;
+    if (!this.ws || this.ws.readyState !== WS_OPEN) return;
+    this.wsSend({ type: 'client_audio', data: pcmToBase64(pcm) });
+  }
+
+  mute(): void {
+    this.muted = true;
+  }
+
+  unmute(): void {
+    this.muted = false;
+  }
+
+  stop(reason?: StopReason): Promise<void> {
+    if (this.stoppingPromise) return this.stoppingPromise;
+    this.stoppingPromise = this._doStop(reason ?? 'user_stop');
+    return this.stoppingPromise;
+  }
+
+  private async _doStop(reason: StopReason): Promise<void> {
+    if (this.softCapTimer) {
+      clearTimeout(this.softCapTimer);
+      this.softCapTimer = null;
+    }
+
+    // Best-effort farewell.
+    if (this.ws && this.ws.readyState === WS_OPEN) {
+      try {
+        this.wsSend({ type: 'bye' });
+      } catch {
+        /* ignore */
+      }
+      try {
+        this.ws.close();
+      } catch {
+        /* ignore */
+      }
+    }
+
+    const endedAt = new Date().toISOString();
+    const usage = this.costTracker.totals;
+    const payload: SessionEndPayload = {
+      transcript: this.transcript.slice(),
+      startedAt: this.startedAt,
+      endedAt,
+      usage,
+      endReason: reason,
+    };
+
+    try {
+      await fetch(this.closeEndpoint, {
+        method: 'POST',
+        // keepalive is relevant for beacon-style close in the browser; Node
+        // fetch ignores it silently.
+        keepalive: true,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          voiceSessionId: this.voiceSessionId,
+          persona: this.persona.name,
+          startedAt: this.startedAt,
+          endedAt,
+          transcript: payload.transcript,
+          usage,
+          artifacts: [],
+          endReason: reason,
+        }),
+      });
+    } catch (err) {
+      // Best-effort; don't throw.
+      console.error('session-close POST failed', err);
+    }
+
+    this.costTracker.offChange(this.costListener);
+    this.events.onEnd(payload);
+  }
+
+  private onMessage(raw: string): void {
+    let frame: ServerFrame;
+    try {
+      frame = JSON.parse(raw) as ServerFrame;
+    } catch {
+      return;
+    }
+
+    switch (frame.type) {
+      case 'audio': {
+        if (typeof frame.data !== 'string') return;
+        const pcm = base64ToPcm(frame.data);
+        this.events.onAudio(pcm);
+        return;
+      }
+      case 'input_transcription': {
+        if (typeof frame.text !== 'string') return;
+        const partial = frame.partial === true;
+        this.events.onInputTranscript(frame.text, partial);
+        if (!partial) {
+          this.transcript.push({
+            role: 'user',
+            text: frame.text,
+            ts: new Date().toISOString(),
+          });
+        }
+        return;
+      }
+      case 'output_transcription': {
+        if (typeof frame.text !== 'string') return;
+        const partial = frame.partial === true;
+        this.events.onOutputTranscript(frame.text, partial);
+        if (!partial) {
+          this.transcript.push({
+            role: 'assistant',
+            text: frame.text,
+            ts: new Date().toISOString(),
+          });
+        }
+        return;
+      }
+      case 'tool_call': {
+        if (typeof frame.id !== 'string' || typeof frame.name !== 'string') return;
+        void this.runToolCall({
+          id: frame.id,
+          name: frame.name,
+          args: frame.args,
+        });
+        return;
+      }
+      case 'usage': {
+        this.costTracker.addUsage({
+          textIn: frame.textIn ?? 0,
+          textOut: frame.textOut ?? 0,
+          audioIn: frame.audioIn ?? 0,
+          audioOut: frame.audioOut ?? 0,
+        });
+        return;
+      }
+      case 'server_end': {
+        if (!this.stoppingPromise) {
+          void this.stop('hard_cap');
+        }
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  private async runToolCall(call: {
+    id: string;
+    name: string;
+    args: unknown;
+  }): Promise<void> {
+    let response: unknown;
+    try {
+      response = await this.events.onToolCall(call);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      response = { error: message };
+    }
+    this.wsSend({ type: 'tool_response', id: call.id, response });
+  }
+
+  private wsSend(obj: unknown): void {
+    if (!this.ws || this.ws.readyState !== WS_OPEN) return;
+    try {
+      this.ws.send(JSON.stringify(obj));
+    } catch {
+      /* ignore; close handler drives shutdown */
+    }
+  }
+}

--- a/dashboard/src/app/voice/voice-session.ts
+++ b/dashboard/src/app/voice/voice-session.ts
@@ -60,6 +60,22 @@ interface ServerFrame {
 
 const WS_OPEN = 1;
 
+// Minimal typed surface the class needs from a WebSocket. Both the DOM
+// WebSocket and the `ws` package's client structurally satisfy this — it just
+// avoids the `Function` type for the listener casts.
+type WsEventName = 'open' | 'error' | 'message' | 'close';
+interface WsListenerTarget {
+  addEventListener(
+    ev: WsEventName,
+    cb: (e: Event) => void,
+    opts?: { once?: boolean },
+  ): void;
+  removeEventListener?(
+    ev: WsEventName,
+    cb: (e: Event) => void,
+  ): void;
+}
+
 function pcmToBase64(pcm: Int16Array): string {
   const bytes = new Uint8Array(pcm.buffer, pcm.byteOffset, pcm.byteLength);
   if (typeof Buffer !== 'undefined') {
@@ -194,21 +210,21 @@ export class VoiceSession {
         reject(new Error('ws open failed: ' + String(ev)));
       };
       const cleanup = () => {
-        (ws as unknown as { removeEventListener?: Function }).removeEventListener?.(
+        (ws as unknown as WsListenerTarget).removeEventListener?.(
           'open',
           onOpen as EventListener,
         );
-        (ws as unknown as { removeEventListener?: Function }).removeEventListener?.(
+        (ws as unknown as WsListenerTarget).removeEventListener?.(
           'error',
           onError as EventListener,
         );
       };
-      (ws as unknown as { addEventListener: Function }).addEventListener(
+      (ws as unknown as WsListenerTarget).addEventListener(
         'open',
         onOpen as EventListener,
         { once: true },
       );
-      (ws as unknown as { addEventListener: Function }).addEventListener(
+      (ws as unknown as WsListenerTarget).addEventListener(
         'error',
         onError as EventListener,
         { once: true },
@@ -216,9 +232,10 @@ export class VoiceSession {
     });
 
     // Wire ongoing handlers.
-    (ws as unknown as { addEventListener: Function }).addEventListener(
+    (ws as unknown as WsListenerTarget).addEventListener(
       'message',
-      (ev: MessageEvent) => {
+      (e) => {
+        const ev = e as MessageEvent;
         const raw =
           typeof ev.data === 'string'
             ? ev.data
@@ -230,7 +247,7 @@ export class VoiceSession {
         this.onMessage(raw);
       },
     );
-    (ws as unknown as { addEventListener: Function }).addEventListener(
+    (ws as unknown as WsListenerTarget).addEventListener(
       'close',
       () => {
         if (!this.stoppingPromise) {
@@ -238,7 +255,7 @@ export class VoiceSession {
         }
       },
     );
-    (ws as unknown as { addEventListener: Function }).addEventListener(
+    (ws as unknown as WsListenerTarget).addEventListener(
       'error',
       () => {
         // Swallow post-open errors; close handler will drive shutdown.

--- a/dashboard/src/lib/db/schema.ts
+++ b/dashboard/src/lib/db/schema.ts
@@ -144,3 +144,21 @@ export const activity_concepts = sqliteTable('activity_concepts', {
 }, (table) => [
   primaryKey({ columns: [table.activity_id, table.concept_id] }),
 ]);
+
+// Voice system tables (must match src/db/schema/voice.ts SQL columns exactly)
+
+export const voice_sessions = sqliteTable('voice_sessions', {
+  id: text('id').primaryKey(),
+  persona: text('persona').notNull(),
+  started_at: text('started_at').notNull(),
+  ended_at: text('ended_at').notNull(),
+  duration_seconds: integer('duration_seconds').notNull(),
+  text_tokens_in: integer('text_tokens_in').notNull().default(0),
+  text_tokens_out: integer('text_tokens_out').notNull().default(0),
+  audio_tokens_in: integer('audio_tokens_in').notNull().default(0),
+  audio_tokens_out: integer('audio_tokens_out').notNull().default(0),
+  cost_usd: real('cost_usd').notNull(),
+  rates_version: text('rates_version').notNull(),
+  transcript_path: text('transcript_path'),
+  artifacts: text('artifacts'),
+});

--- a/dashboard/src/lib/voice-logger.ts
+++ b/dashboard/src/lib/voice-logger.ts
@@ -1,0 +1,22 @@
+import path from 'node:path';
+import { createVoiceLogger } from '../../../src/voice/voice-log';
+
+type Logger = (record: Record<string, unknown>) => Promise<void>;
+
+let _logger: Logger | null = null;
+
+function getRepoRoot(): string {
+  const cwd = process.cwd();
+  return cwd.endsWith(path.sep + 'dashboard') || cwd.endsWith('/dashboard')
+    ? path.resolve(cwd, '..')
+    : cwd;
+}
+
+/** Append-only JSON-lines logger for voice events. Lazily created on first call.
+ *  Errors propagate — callers fire-and-forget with `.catch()` if they prefer. */
+export function voiceLog(record: Record<string, unknown>): Promise<void> {
+  if (!_logger) {
+    _logger = createVoiceLogger(path.join(getRepoRoot(), 'data', 'voice.log'));
+  }
+  return _logger(record);
+}

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -30,5 +30,8 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules",
+    "src/app/voice/audio-worklet-processor.ts"
+  ]
 }

--- a/docs/superpowers/plans/2026-04-18-live-voice-chat-v1.md
+++ b/docs/superpowers/plans/2026-04-18-live-voice-chat-v1.md
@@ -1,0 +1,1798 @@
+# Live Voice Chat (v1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a dashboard `/voice` page that hosts a real-time voice brainstorming session with a Gemini-powered Dev Assistant persona — with a live dollar tracker, captions, a preview pane for mockups and diagrams, durable transcripts, and strict read/write scoping.
+
+**Architecture:** Browser opens a WebSocket to Gemini Live using a short-lived ephemeral token minted by the dashboard backend. A `VoiceSession` abstraction owns the WS lifecycle and fires UI events. Server-side API routes execute tool calls (read from scoped roots, write to `docs/superpowers/`), persist transcripts to disk, and write session/cost records to a new `voice_sessions` SQLite table. No Claude container is in the loop — Gemini IS the Dev Assistant.
+
+**Tech Stack:** Next.js 16 (dashboard), React 19, `@google/genai`, `mermaid`, Drizzle ORM + `better-sqlite3`, Web Audio API (`AudioWorklet`), Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-live-voice-chat-design.md`.
+
+---
+
+## Prerequisites
+
+Work in the `feat/live-voice-chat` worktree at `/Users/simonkvalheim/Documents/01 - Projects/universityClaw-voice`. Do NOT modify anything on the `feat/gemini-tts-stt-migration` branch (separate parallel work).
+
+This plan assumes the parallel migration spec is either complete or running concurrently. `GEMINI_API_KEY` is the canonical env var name. If the migration hasn't yet renamed `google_api_key`, this plan adds a compatibility shim that reads both (preferring uppercase).
+
+## Essential Reading (coordinator only — do NOT dump into subagent prompts)
+
+If you're executing this plan yourself: read the full spec (`docs/superpowers/specs/2026-04-18-live-voice-chat-design.md`) and skim `src/db/schema/study.ts`, `src/db/migrate.ts`, `drizzle.config.ts`, `dashboard/src/lib/db/schema.ts`, `dashboard/src/app/api/chat/route.ts`, and `dashboard/src/lib/__tests__/analytics.test.ts` to internalize patterns.
+
+If you're dispatching subagents: inline the specific snippets each task needs (see Subagent Dispatch Guidance at the bottom).
+
+## Conventions (applies to all tasks)
+
+These are **hard constraints**, not suggestions. If your change appears to violate one, stop and ask.
+
+1. **Branch & worktree.** Work on `feat/live-voice-chat` in the `universityClaw-voice` worktree. Commit frequently. Never rebase published work. Never push to `main`.
+
+2. **DB schema: two schema files must stay in sync.**
+   - Canonical schema: `src/db/schema/*.ts` (consumed by `drizzle-kit generate`).
+   - Dashboard mirror: `dashboard/src/lib/db/schema.ts` (consumed by dashboard Drizzle queries).
+   - Both must describe the same SQL columns. The existing file `dashboard/src/lib/db/schema.ts` has a comment banner: "must match src/db/schema/*.ts SQL columns exactly" — preserve that invariant.
+
+3. **camelCase ↔ snake_case.**
+   - Request/response JSON keys in API routes: **camelCase** (`voiceSessionId`, not `voice_session_id`).
+   - Drizzle schema TS properties: **camelCase** mapped to snake_case DB columns (e.g. `voiceSessionId: text('voice_session_id')`).
+   - DB column names: **snake_case**.
+   - When a tool handler writes to a table, translate at the boundary.
+
+4. **Testing.**
+   - Run `npm test` from repo root (not from `dashboard/`). Tests live in `src/**/*.test.ts` or `dashboard/src/**/*.test.ts` and both are picked up by the root `vitest.config.ts`.
+   - Prefer one describe block per module; one `it` per behavior; short, named fixtures.
+   - TDD: write the failing test first, run it, watch it fail, then implement.
+
+5. **Path discipline.**
+   - All file paths in code: use `path.join`, never string concatenation.
+   - Repo root: resolve once via `process.cwd()` (from `npm test` this is repo root; from `next dev` this is `dashboard/`). Always derive: `const REPO_ROOT = path.resolve(process.cwd(), process.cwd().endsWith('/dashboard') ? '..' : '.');` OR use an env var `REPO_ROOT` set in `.env`. This plan uses the derivation approach — simpler.
+
+6. **Imports.**
+   - Use the project's existing module style (ESM with `.js` import extensions where the existing code does).
+   - No default exports for shared utilities; named exports only.
+
+7. **Env vars.** Read `process.env.X` only inside functions (NOT at module top level) so tests can set/unset without module-cache contamination. If caching is needed, cache inside the first call.
+
+8. **Logging.** Use the existing `logger` from `src/logger.ts` for backend code. For voice-specific structured logs, write JSON lines to `data/voice.log` using a tiny helper built in Task 7.
+
+9. **Secrets.** Never log `GEMINI_API_KEY` content. Never include it in error messages surfaced to the client.
+
+10. **Commit messages.** Follow the repo's conventional-commit style: `feat(voice): …`, `test(voice): …`, `chore(voice): …`. Include the `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer when committing.
+
+11. **YAGNI / DRY.** No premature abstractions. Share utilities only after the second caller exists.
+
+## File Structure (what gets created)
+
+```
+src/db/schema/voice.ts                                      NEW  canonical schema for voice_sessions
+src/db/schema/index.ts                                      MOD  export voice.ts
+src/voice/                                                  NEW  server-side voice helpers (non-dashboard)
+  path-scope.ts                                             NEW  read/write scope + realpath guards
+  voice-log.ts                                              NEW  JSON-line logger → data/voice.log
+dashboard/src/lib/db/schema.ts                              MOD  mirror voice_sessions schema
+dashboard/src/app/voice/page.tsx                            NEW  /voice page
+dashboard/src/app/voice/voice-session.ts                    NEW  WS lifecycle + event stream
+dashboard/src/app/voice/audio-io.ts                         NEW  mic capture + playback
+dashboard/src/app/voice/audio-worklet-processor.ts          NEW  16 kHz resampler (AudioWorklet)
+dashboard/src/app/voice/cost-tracker.ts                     NEW  token accumulator + $ conversion
+dashboard/src/app/voice/rates.ts                            NEW  Gemini pricing config
+dashboard/src/app/voice/personas.ts                         NEW  Dev Assistant persona config
+dashboard/src/app/voice/captions.tsx                        NEW  scrolling transcript
+dashboard/src/app/voice/preview-pane.tsx                    NEW  mockup iframe + mermaid tabs
+dashboard/src/app/voice/cost-panel.tsx                      NEW  live $ ticker + rollups
+dashboard/src/app/voice/__tests__/cost-tracker.test.ts      NEW
+dashboard/src/app/voice/__tests__/voice-session.test.ts     NEW
+dashboard/src/app/voice/__tests__/fake-gemini-server.ts     NEW  WS fixture
+dashboard/src/app/api/voice/token/route.ts                  NEW
+dashboard/src/app/api/voice/context/dev/route.ts            NEW
+dashboard/src/app/api/voice/tools/dev/[tool]/route.ts       NEW  single dynamic handler, dispatches by tool name
+dashboard/src/app/api/voice/session-close/route.ts          NEW
+dashboard/src/app/api/voice/__tests__/token.test.ts         NEW
+dashboard/src/app/api/voice/__tests__/context.test.ts       NEW
+dashboard/src/app/api/voice/__tests__/tools-read.test.ts    NEW
+dashboard/src/app/api/voice/__tests__/tools-write.test.ts   NEW
+dashboard/src/app/api/voice/__tests__/session-close.test.ts NEW
+dashboard/src/app/layout.tsx                                MOD  add nav link (dev-only)
+drizzle/migrations/000N_voice_sessions.sql                  NEW  generated by drizzle-kit
+docs/superpowers/mockups/                                   NEW  directory (.gitkeep)
+docs/superpowers/brainstorm-sessions/                       NEW  directory (.gitkeep)
+docs/superpowers/research/                                   NEW  directory (.gitkeep; reserved)
+.env.example                                                 MOD  add GEMINI_API_KEY + VOICE_MONTHLY_BUDGET_USD
+CLAUDE.md                                                    MOD  document the /voice surface
+```
+
+## Parallelism Guidance
+
+Tasks can be grouped into phases. Within a phase, tasks that touch disjoint files can run in parallel subagents.
+
+- **Phase A** (Foundation, sequential): Tasks 1 → 2 → 3 → 4
+- **Phase B** (Server, mostly parallel after 5): Task 5 first; then 6, 7, 8, 10, 11 in parallel (different files). Task 9 **must run after Task 8** because it extends the same dispatcher file.
+- **Phase C** (Client, parallel after 12): Task 12 first (cost tracker is a dep); then 13, 14, 15 in parallel (different files). Then 16, 17, 18 in parallel. Then 19 (page wiring; depends on all).
+- **Phase D** (Integration, sequential): 20 → 21 → 22 → 23.
+
+File scope per task is listed in each task's **Files** section. A parallel subagent must touch ONLY those files.
+
+---
+
+## Phase A — Foundation
+
+### Task 1: Install dependencies
+
+**Files:**
+- Modify: `dashboard/package.json`
+- Modify: `package-lock.json` (generated)
+- Do NOT touch: root `package.json` (backend doesn't need these)
+
+- [ ] **Step 1.1: Install `@google/genai`, `mermaid`, `uuid`, and dev dep `@types/uuid` in the dashboard.**
+
+Run from repo root:
+```bash
+cd dashboard && npm install @google/genai mermaid uuid && npm install --save-dev @types/uuid && cd ..
+```
+
+Pin nothing by hand; trust `^` ranges from npm install.
+
+- [ ] **Step 1.2: Sanity-check build.**
+
+Run: `cd dashboard && npx tsc --noEmit && cd ..`
+Expected: no errors. If there are pre-existing errors unrelated to this work, note them and proceed.
+
+- [ ] **Step 1.3: Commit.**
+
+```bash
+git add dashboard/package.json dashboard/package-lock.json
+git commit -m "chore(voice): add @google/genai, mermaid, uuid deps to dashboard"
+```
+
+### Task 2: Env var setup
+
+**Files:**
+- Modify: `.env.example`
+
+- [ ] **Step 2.1: Append voice env section to `.env.example`.**
+
+Add at the bottom:
+```
+# --- Voice (live Gemini chat at /voice) ---
+# GEMINI_API_KEY is set by the migration spec; if only lowercase google_api_key
+# is present, the voice feature falls back to it with a one-time warning.
+VOICE_MONTHLY_BUDGET_USD=
+```
+
+- [ ] **Step 2.2: Commit.**
+
+```bash
+git add .env.example
+git commit -m "chore(voice): document VOICE_MONTHLY_BUDGET_USD env var"
+```
+
+### Task 3: `voice_sessions` table — schema + migration
+
+**Files:**
+- Create: `src/db/schema/voice.ts`
+- Modify: `src/db/schema/index.ts`
+- Modify: `dashboard/src/lib/db/schema.ts`
+- Create: `drizzle/migrations/NNNN_voice_sessions.sql` (generated)
+
+Column list (SQL, **use these names exactly**, snake_case):
+
+```
+id               TEXT PRIMARY KEY       -- UUID
+persona          TEXT NOT NULL          -- 'dev' in v1
+started_at       TEXT NOT NULL          -- ISO 8601
+ended_at         TEXT NOT NULL          -- ISO 8601
+duration_seconds INTEGER NOT NULL
+text_tokens_in   INTEGER NOT NULL DEFAULT 0
+text_tokens_out  INTEGER NOT NULL DEFAULT 0
+audio_tokens_in  INTEGER NOT NULL DEFAULT 0
+audio_tokens_out INTEGER NOT NULL DEFAULT 0
+cost_usd         REAL    NOT NULL
+rates_version    TEXT    NOT NULL       -- sha256(rates.ts) short hash
+transcript_path  TEXT                   -- nullable (if beacon fails)
+artifacts        TEXT                   -- JSON array of file paths
+```
+
+Index: `CREATE INDEX idx_voice_sessions_started ON voice_sessions(started_at);`
+
+- [ ] **Step 3.1: Write the canonical Drizzle schema at `src/db/schema/voice.ts`.**
+
+Use the existing `src/db/schema/study.ts` as the pattern (import `sqliteTable`, `text`, `integer`, `real`, `index` from `drizzle-orm/sqlite-core`).
+
+Property names must be camelCase; DB column names must match the SQL list above exactly.
+
+Key exports:
+```ts
+export const voiceSessions = sqliteTable('voice_sessions', { ... },
+  (table) => ({ startedAtIdx: index('idx_voice_sessions_started').on(table.startedAt) })
+);
+export type VoiceSession = typeof voiceSessions.$inferSelect;
+export type NewVoiceSession = typeof voiceSessions.$inferInsert;
+```
+
+- [ ] **Step 3.2: Add voice export to `src/db/schema/index.ts`.**
+
+Append: `export * from './voice.js';` in the same style as the other re-exports.
+
+- [ ] **Step 3.3: Generate migration SQL.**
+
+Run from repo root:
+```bash
+npx drizzle-kit generate
+```
+
+Expected: a new file `drizzle/migrations/NNNN_<adjective>_<name>.sql` containing a `CREATE TABLE voice_sessions` plus the index.
+
+Inspect the generated file. Confirm columns match the list above. If drizzle-kit chose a weird adjective, that's fine.
+
+- [ ] **Step 3.4: Mirror schema in the dashboard.**
+
+Open `dashboard/src/lib/db/schema.ts`. At the bottom (respecting the comment banner), add a `voice_sessions` export that matches the canonical one.
+
+**The dashboard schema uses `snake_case` TypeScript property names** (read the nearby `ingestion_jobs`, `settings`, and `concepts` exports — they all use `source_path: text('source_path')`, `vault_note_path: text('vault_note_path')`, etc.). Match that convention exactly:
+
+```ts
+export const voice_sessions = sqliteTable('voice_sessions', {
+  id: text('id').primaryKey(),
+  persona: text('persona').notNull(),
+  started_at: text('started_at').notNull(),
+  ended_at: text('ended_at').notNull(),
+  duration_seconds: integer('duration_seconds').notNull(),
+  text_tokens_in: integer('text_tokens_in').notNull().default(0),
+  text_tokens_out: integer('text_tokens_out').notNull().default(0),
+  audio_tokens_in: integer('audio_tokens_in').notNull().default(0),
+  audio_tokens_out: integer('audio_tokens_out').notNull().default(0),
+  cost_usd: real('cost_usd').notNull(),
+  rates_version: text('rates_version').notNull(),
+  transcript_path: text('transcript_path'),
+  artifacts: text('artifacts'),
+});
+```
+
+**Consequence for Task 10:** Drizzle insert values use TS property names, so `db.insert(voice_sessions).values({...})` uses snake_case keys (`started_at:`, `duration_seconds:`, `cost_usd:`, etc.). Translation from camelCase request JSON to snake_case Drizzle values happens explicitly at the route-handler boundary.
+
+- [ ] **Step 3.5: Sanity-run migration.**
+
+Run the dashboard in a scratch terminal just to trigger migration (or run the migration script directly if one exists):
+```bash
+# Start nanoclaw to trigger migrations (it calls runMigrations in src/db/migrate.ts)
+# Or use drizzle-kit migrate if desired:
+npx drizzle-kit migrate
+```
+
+Expected: `store/messages.db` has the new table. Verify with:
+```bash
+sqlite3 store/messages.db ".schema voice_sessions"
+```
+Expected output: the CREATE TABLE matches step 3.3.
+
+- [ ] **Step 3.6: Commit.**
+
+```bash
+git add src/db/schema/voice.ts src/db/schema/index.ts dashboard/src/lib/db/schema.ts drizzle/migrations/
+git commit -m "feat(voice): add voice_sessions table for cost tracking"
+```
+
+### Task 4: Rates config (`rates.ts`)
+
+**Files:**
+- Create: `dashboard/src/app/voice/rates.ts`
+- Create: `dashboard/src/app/voice/__tests__/rates.test.ts`
+
+This is a pure-data module plus a `computeCostUsd(usage, rates)` function. Tests pin the math.
+
+- [ ] **Step 4.1: Write the failing test at `dashboard/src/app/voice/__tests__/rates.test.ts`.**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { computeCostUsd, RATES } from '../rates';
+
+describe('rates', () => {
+  it('computes zero cost for zero tokens', () => {
+    expect(computeCostUsd({ textIn: 0, textOut: 0, audioIn: 0, audioOut: 0 }, RATES)).toBe(0);
+  });
+
+  it('computes cost as the sum of per-modality rates (per million tokens)', () => {
+    const rates = { textInPerM: 1, textOutPerM: 2, audioInPerM: 4, audioOutPerM: 8, asOf: '2026-04-18', version: 'test' };
+    const usage = { textIn: 500_000, textOut: 1_000_000, audioIn: 2_000_000, audioOut: 500_000 };
+    // 0.5 * 1 + 1 * 2 + 2 * 4 + 0.5 * 8 = 0.5 + 2 + 8 + 4 = 14.5
+    expect(computeCostUsd(usage, rates)).toBeCloseTo(14.5, 6);
+  });
+
+  it('exposes a rates version string for persistence', () => {
+    expect(RATES.version).toMatch(/^[a-z0-9-]+$/);
+    expect(RATES.asOf).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+```
+
+- [ ] **Step 4.2: Run to confirm failure.**
+
+Run: `npm test -- dashboard/src/app/voice/__tests__/rates.test.ts`
+Expected: FAIL with "Cannot find module '../rates'".
+
+- [ ] **Step 4.3: Implement `rates.ts`.**
+
+Put actual Gemini 3.1 Flash Live values (look them up at https://ai.google.dev/gemini-api/docs/pricing when running this task; insert a clear comment with source URL and retrieval date).
+
+```ts
+// Gemini 3.1 Flash Live pricing. Source: https://ai.google.dev/gemini-api/docs/pricing
+// Retrieved: <YYYY-MM-DD>. Update the `asOf` field and `version` when these change.
+
+export interface Rates {
+  textInPerM: number;
+  textOutPerM: number;
+  audioInPerM: number;
+  audioOutPerM: number;
+  asOf: string;  // YYYY-MM-DD
+  version: string;  // short tag used by voice_sessions.rates_version
+}
+
+export const RATES: Rates = {
+  textInPerM:  /* look up */ 0,
+  textOutPerM: /* look up */ 0,
+  audioInPerM: /* look up */ 0,
+  audioOutPerM:/* look up */ 0,
+  asOf: '2026-04-18',
+  version: 'gemini-3.1-flash-live-2026-04',
+};
+
+export interface TokenUsage {
+  textIn: number;
+  textOut: number;
+  audioIn: number;
+  audioOut: number;
+}
+
+export function computeCostUsd(usage: TokenUsage, rates: Rates): number {
+  return (
+    (usage.textIn   / 1_000_000) * rates.textInPerM +
+    (usage.textOut  / 1_000_000) * rates.textOutPerM +
+    (usage.audioIn  / 1_000_000) * rates.audioInPerM +
+    (usage.audioOut / 1_000_000) * rates.audioOutPerM
+  );
+}
+```
+
+**Do NOT guess rates.** If Google's pricing page is unreachable, leave placeholders and flag to the coordinator; tests will still pass because they provide their own rates object.
+
+- [ ] **Step 4.4: Run tests.**
+
+Run: `npm test -- dashboard/src/app/voice/__tests__/rates.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 4.5: Commit.**
+
+```bash
+git add dashboard/src/app/voice/rates.ts dashboard/src/app/voice/__tests__/rates.test.ts
+git commit -m "feat(voice): rates config + cost math"
+```
+
+---
+
+## Phase B — Server
+
+### Task 5: Voice logger + path-scope utilities
+
+**Files:**
+- Create: `src/voice/path-scope.ts`
+- Create: `src/voice/voice-log.ts`
+- Create: `src/voice/__tests__/path-scope.test.ts`
+- Create: `src/voice/__tests__/voice-log.test.ts`
+
+These are shared server utilities. Building them first unblocks the tool handlers.
+
+- [ ] **Step 5.1: Write failing path-scope tests.**
+
+Create `src/voice/__tests__/path-scope.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, symlink, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { resolveReadPath, resolveWritePath, sanitizeSlug } from '../path-scope';
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(tmpdir(), 'voice-scope-'));
+  await mkdir(path.join(root, 'src'), { recursive: true });
+  await writeFile(path.join(root, 'src', 'a.ts'), 'x');
+  await writeFile(path.join(root, '.env'), 'SECRET=1');
+  await mkdir(path.join(root, 'docs', 'superpowers', 'specs'), { recursive: true });
+});
+
+describe('sanitizeSlug', () => {
+  it('accepts lowercase, digits, hyphen', () => {
+    expect(sanitizeSlug('voice-chat-v1')).toBe('voice-chat-v1');
+  });
+  it.each([
+    [''], ['a'.repeat(81)], ['has slash/bad'], ['UPPER'], ['dot.bad'], ['..'], [' pad '],
+  ])('rejects invalid slug %s', (bad) => {
+    expect(() => sanitizeSlug(bad)).toThrow();
+  });
+});
+
+describe('resolveReadPath', () => {
+  it('allows files under src/', async () => {
+    const p = await resolveReadPath(root, 'src/a.ts');
+    expect(p).toBe(path.join(root, 'src', 'a.ts'));
+  });
+
+  it('rejects .env', async () => {
+    await expect(resolveReadPath(root, '.env')).rejects.toThrow(/out of scope/);
+  });
+
+  it('rejects absolute path outside root', async () => {
+    await expect(resolveReadPath(root, '/etc/passwd')).rejects.toThrow(/out of scope/);
+  });
+
+  it('rejects parent traversal', async () => {
+    await expect(resolveReadPath(root, '../etc/passwd')).rejects.toThrow(/out of scope/);
+  });
+
+  it('rejects symlink escapes', async () => {
+    await symlink(path.join(root, '..'), path.join(root, 'src', 'escape'));
+    await expect(resolveReadPath(root, 'src/escape/secret')).rejects.toThrow();
+  });
+});
+
+describe('resolveWritePath', () => {
+  it('returns a path under the targeted docs dir with server-generated date prefix', async () => {
+    const p = await resolveWritePath(root, 'specs', 'my-slug', 'md');
+    expect(p).toMatch(/docs\/superpowers\/specs\/\d{4}-\d{2}-\d{2}-my-slug\.md$/);
+  });
+
+  it('rejects slug with path separator', async () => {
+    await expect(resolveWritePath(root, 'specs', '../escape', 'md')).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 5.2: Run to confirm failure.**
+
+Run: `npm test -- src/voice/__tests__/path-scope.test.ts`
+Expected: FAIL with "Cannot find module '../path-scope'".
+
+- [ ] **Step 5.3: Implement `src/voice/path-scope.ts`.**
+
+Export:
+- `sanitizeSlug(slug: string): string` — regex `^[a-z0-9-]{1,80}$`, throws on mismatch.
+- `resolveReadPath(repoRoot: string, requested: string): Promise<string>` — joins, resolves via `fs.realpath`, asserts resolved path starts with `repoRoot`, asserts first segment is in allow-list (`src`, `container`, `dashboard/src`, `docs`, `scripts`, `public`) OR the basename is in the root-config allowlist, asserts no denied substring (`.env`, `store`, `onecli`, `groups`, `data`, `node_modules`, `.venv`, `.git`).
+- `resolveWritePath(repoRoot: string, kind: 'specs'|'plans'|'mockups', slug: string, ext: string): Promise<string>` — calls `sanitizeSlug`, joins `docs/superpowers/<kind>/<YYYY-MM-DD>-<slug>.<ext>`, ensures parent dir exists (mkdir -p), resolves parent via realpath, asserts parent starts with `path.join(repoRoot, 'docs/superpowers', kind)`. Date = `new Date().toISOString().slice(0,10)`.
+
+Allow-list root config names (exact match against basename): `package.json`, `tsconfig.json`, `next.config.ts`, `vitest.config.ts`, `eslint.config.mjs`, `postcss.config.mjs`, `README.md`, `CLAUDE.md`, `CONTRIBUTING.md`.
+
+- [ ] **Step 5.4: Run tests.**
+
+Run: `npm test -- src/voice/__tests__/path-scope.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5.5: Write failing voice-log test.**
+
+Create `src/voice/__tests__/voice-log.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { createVoiceLogger } from '../voice-log';
+
+let dir: string;
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(os.tmpdir(), 'voice-log-'));
+});
+
+describe('voice-log', () => {
+  it('writes one JSON line per event', async () => {
+    const log = createVoiceLogger(path.join(dir, 'voice.log'));
+    await log({ event: 'session.start', voiceSessionId: 'abc', persona: 'dev' });
+    await log({ event: 'tool.call', voiceSessionId: 'abc', tool: 'read_file' });
+    const body = await readFile(path.join(dir, 'voice.log'), 'utf8');
+    const lines = body.trim().split('\n').map((l) => JSON.parse(l));
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatchObject({ event: 'session.start', voiceSessionId: 'abc' });
+    expect(lines[0].ts).toBeDefined();
+  });
+
+  it('includes a timestamp', async () => {
+    const log = createVoiceLogger(path.join(dir, 'voice.log'));
+    await log({ event: 'session.end', voiceSessionId: 'x' });
+    const body = await readFile(path.join(dir, 'voice.log'), 'utf8');
+    const line = JSON.parse(body.trim());
+    expect(line.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+```
+
+- [ ] **Step 5.6: Implement `src/voice/voice-log.ts`.**
+
+`createVoiceLogger(path: string) => (record: Record<string, unknown>) => Promise<void>` — opens the file in append mode, writes `{ ts: new Date().toISOString(), ...record }` as a single JSON line, flushes. Ensures parent directory exists.
+
+- [ ] **Step 5.7: Run tests.**
+
+Run: `npm test -- src/voice/__tests__/`
+Expected: PASS.
+
+- [ ] **Step 5.8: Commit.**
+
+```bash
+git add src/voice/
+git commit -m "feat(voice): path-scope guards + voice-log JSON writer"
+```
+
+### Task 6: Token endpoint (`POST /api/voice/token`) — parallel-safe
+
+**Files:**
+- Create: `dashboard/src/app/api/voice/token/route.ts`
+- Create: `dashboard/src/app/api/voice/__tests__/token.test.ts`
+
+This endpoint mints an ephemeral token using `@google/genai`. It accepts an optional `resumeHandle` (ignored) and a required `persona`.
+
+Spec requirement (security): reject if the `Host` header indicates the server is not on loopback.
+
+- [ ] **Step 6.1: Write failing test.**
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../../voice/token/route';
+
+// Mock @google/genai
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: class {
+    authTokens = {
+      create: vi.fn().mockResolvedValue({
+        name: 'tokens/fake',
+        // The real SDK returns an opaque token in authTokens.create; check the SDK docs at implementation time.
+      }),
+    };
+  },
+}));
+
+function makeReq(body: unknown, host = 'localhost:3100') {
+  return new Request('http://localhost:3100/api/voice/token', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', host },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/voice/token', () => {
+  beforeEach(() => {
+    process.env.GEMINI_API_KEY = 'test-key';
+  });
+
+  it('returns 400 when persona missing', async () => {
+    const res = await POST(makeReq({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 403 when host is not loopback', async () => {
+    const res = await POST(makeReq({ persona: 'dev' }, 'public.example.com'));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 500 when GEMINI_API_KEY is missing', async () => {
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.google_api_key;
+    const res = await POST(makeReq({ persona: 'dev' }));
+    expect(res.status).toBe(500);
+  });
+
+  it('returns an ephemeral token on success', async () => {
+    const res = await POST(makeReq({ persona: 'dev' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBeDefined();
+    expect(body.voiceSessionId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('accepts (and ignores) resumeHandle in v1', async () => {
+    const res = await POST(makeReq({ persona: 'dev', resumeHandle: 'abc' }));
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+- [ ] **Step 6.2: Run to confirm failure.**
+
+Run: `npm test -- dashboard/src/app/api/voice/__tests__/token.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 6.3: Implement token route.**
+
+`dashboard/src/app/api/voice/token/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from 'next/server';
+import { GoogleGenAI } from '@google/genai';
+import { randomUUID } from 'node:crypto';
+
+function isLoopback(host: string | null): boolean {
+  if (!host) return false;
+  const h = host.split(':')[0];
+  return h === 'localhost' || h === '127.0.0.1' || h === '[::1]' || h === '::1';
+}
+
+function getApiKey(): string | undefined {
+  return process.env.GEMINI_API_KEY || process.env.google_api_key;
+}
+
+export async function POST(req: NextRequest) {
+  if (!isLoopback(req.headers.get('host'))) {
+    return NextResponse.json({ error: 'voice endpoints are localhost-only' }, { status: 403 });
+  }
+  let body: { persona?: string; resumeHandle?: string };
+  try { body = await req.json(); } catch { return NextResponse.json({ error: 'invalid json' }, { status: 400 }); }
+  if (!body.persona || body.persona !== 'dev') {
+    return NextResponse.json({ error: 'persona required (only "dev" supported in v1)' }, { status: 400 });
+  }
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    return NextResponse.json({ error: 'GEMINI_API_KEY is not set' }, { status: 500 });
+  }
+  const voiceSessionId = randomUUID();
+  try {
+    const client = new GoogleGenAI({ apiKey });
+    // Exact SDK call: look up the current @google/genai API for ephemeral tokens.
+    // As of research date: client.authTokens.create({ config: { uses: 1, expireTime, liveConnectConstraints: { model: 'gemini-3.1-flash-live-preview' } } })
+    const token = await (client as any).authTokens.create({
+      config: {
+        uses: 1,
+        liveConnectConstraints: { model: 'gemini-3.1-flash-live-preview' },
+        // 30 min session lifetime after start; 1 min to start:
+        expireTime: new Date(Date.now() + 31 * 60 * 1000).toISOString(),
+        newSessionExpireTime: new Date(Date.now() + 60 * 1000).toISOString(),
+      },
+    });
+    return NextResponse.json({ token: token.name ?? token, voiceSessionId });
+  } catch (err) {
+    return NextResponse.json({ error: `token mint failed: ${(err as Error).message}` }, { status: 502 });
+  }
+}
+```
+
+**Note to the engineer**: the SDK method name and request shape MUST be verified against the latest `@google/genai` TypeScript types at implementation time. If the call signature differs, adjust to match the SDK. The important invariant is: we mint a single-use, short-lived token bound to `gemini-3.1-flash-live-preview` and return it to the client.
+
+- [ ] **Step 6.4: Run tests.**
+
+Run: `npm test -- dashboard/src/app/api/voice/__tests__/token.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6.5: Commit.**
+
+```bash
+git add dashboard/src/app/api/voice/token/ dashboard/src/app/api/voice/__tests__/token.test.ts
+git commit -m "feat(voice): ephemeral-token endpoint (/api/voice/token)"
+```
+
+### Task 7: Startup context endpoint (`GET /api/voice/context/dev`) — parallel-safe
+
+**Files:**
+- Create: `dashboard/src/app/api/voice/context/dev/route.ts`
+- Create: `dashboard/src/app/api/voice/__tests__/context.test.ts`
+- Create: `src/voice/subsystem-map.ts` (static data; exported so both the endpoint and tests can reference it)
+
+Context payload shape (JSON returned to the client, in camelCase):
+
+```ts
+interface DevStartupContext {
+  claudeMd: string;
+  architecture: string;
+  subsystemMap: Array<{ path: string; purpose: string }>;
+  scripts: { root: Record<string, string>; dashboard: Record<string, string> };
+  repoState: {
+    branch: string;
+    statusShort: string;   // `git status --short`
+    recentCommits: Array<{ sha: string; subject: string }>;
+    specNames: string[];
+    planNames: string[];
+  };
+  sessionMeta: { generatedAt: string };
+}
+```
+
+- [ ] **Step 7.1: Create `src/voice/subsystem-map.ts`.**
+
+Hand-curated list. Example seed:
+```ts
+export interface SubsystemEntry { path: string; purpose: string; }
+export const SUBSYSTEMS: SubsystemEntry[] = [
+  { path: 'src/ingestion/', purpose: 'File watcher → Docling extraction → Claude note generation → auto-promotion to vault.' },
+  { path: 'src/rag/', purpose: 'LightRAG hybrid retrieval with SQLite-tracked indexing; chokidar watcher with content-hash dedup.' },
+  { path: 'src/study/', purpose: 'Study engine, session builder, SM-2 spacing, scaffolding, audio pipeline.' },
+  { path: 'src/vault/', purpose: 'Direct Obsidian vault file I/O (gray-matter + wikilinks).' },
+  { path: 'src/channels/', purpose: 'Channel registry and per-channel adapters (telegram, web, slack, …).' },
+  { path: 'src/profile/', purpose: 'Student profile: progress tracking, knowledge map, study-log rotation.' },
+  { path: 'src/db/schema/', purpose: 'Canonical Drizzle schema (snake_case SQL columns, camelCase TS properties).' },
+  { path: 'dashboard/src/app/study/', purpose: 'Dashboard UI for study sessions, plans, analytics.' },
+  { path: 'dashboard/src/app/vault/', purpose: 'Dashboard UI for browsing and editing vault notes.' },
+  { path: 'dashboard/src/app/read/', purpose: 'Speed reader (RSVP) and book (EPUB) reading surfaces.' },
+  { path: 'dashboard/src/lib/', purpose: 'Dashboard-side DB helpers, study math, session builder.' },
+  { path: 'container/', purpose: 'Agent-runner container definition (Dockerfile + TS entrypoint + MCP tool surface).' },
+  { path: 'docs/superpowers/', purpose: 'Design specs and implementation plans for major features.' },
+];
+```
+
+Keep the list short and accurate. Update if you notice the repo has additional significant subsystems.
+
+- [ ] **Step 7.2: Write failing test.**
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GET } from '../../voice/context/dev/route';
+
+function makeReq(host = 'localhost:3100') {
+  return new Request('http://localhost:3100/api/voice/context/dev', { headers: { host } });
+}
+
+describe('GET /api/voice/context/dev', () => {
+  it('returns 403 off loopback', async () => {
+    const res = await GET(makeReq('public.example.com'));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns full context payload', async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(typeof body.claudeMd).toBe('string');
+    expect(body.claudeMd.length).toBeGreaterThan(100);
+    expect(Array.isArray(body.subsystemMap)).toBe(true);
+    expect(body.subsystemMap[0]).toHaveProperty('path');
+    expect(body.repoState.branch).toBeDefined();
+    expect(Array.isArray(body.repoState.recentCommits)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 7.3: Implement `dashboard/src/app/api/voice/context/dev/route.ts`.**
+
+Steps inside the handler:
+1. Loopback gate (same as token).
+2. Resolve repo root (see Conventions §5).
+3. Read `CLAUDE.md`, `docs/ARCHITECTURE.md` from repo root; tolerate missing with an empty-string fallback and a `warning` field.
+4. Load `SUBSYSTEMS` from `src/voice/subsystem-map.ts`.
+5. Read `package.json` scripts + `dashboard/package.json` scripts.
+6. Shell out to `git`:
+   - `git rev-parse --abbrev-ref HEAD`
+   - `git status --short`
+   - `git log -n 10 --pretty=format:%h%x09%s`
+7. `fs.readdir` `docs/superpowers/specs/` and `.../plans/` (names only).
+8. Return as `DevStartupContext`.
+
+Use `child_process.execFileSync` with array args (never template strings) and a working-dir set to repo root. Capture stderr; if any git call fails, populate fields with empty defaults.
+
+- [ ] **Step 7.4: Run tests.**
+
+Run: `npm test -- dashboard/src/app/api/voice/__tests__/context.test.ts`
+Expected: PASS. (Test runs against the real repo in the worktree.)
+
+- [ ] **Step 7.5: Commit.**
+
+```bash
+git add dashboard/src/app/api/voice/context/ dashboard/src/app/api/voice/__tests__/context.test.ts src/voice/subsystem-map.ts
+git commit -m "feat(voice): startup-context endpoint + subsystem map"
+```
+
+### Task 8: Read tools (`read_file`, `glob`, `grep`, `git_log`, `git_status`, `list_docs`, `read_doc`) — parallel-safe
+
+**Files:**
+- Create: `dashboard/src/app/api/voice/tools/dev/[tool]/route.ts` (single dynamic route; dispatches by tool name)
+- Create: `dashboard/src/app/api/voice/__tests__/tools-read.test.ts`
+
+The single route handler is a small dispatcher. Each tool lives as a named function. This avoids creating seven separate route files.
+
+- [ ] **Step 8.1: Write failing tests. For each read tool, one success case and one scope-denial case.**
+
+Skeleton (expand with a case per tool):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { POST } from '../../voice/tools/dev/[tool]/route';
+
+async function call(tool: string, args: unknown) {
+  const req = new Request(`http://localhost:3100/api/voice/tools/dev/${tool}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', host: 'localhost' },
+    body: JSON.stringify(args),
+  });
+  const res = await POST(req, { params: Promise.resolve({ tool }) } as any);
+  return { status: res.status, body: await res.json() };
+}
+
+describe('read tools', () => {
+  it('read_file: returns file contents for an allowed path', async () => {
+    const { status, body } = await call('read_file', { path: 'package.json' });
+    expect(status).toBe(200);
+    expect(body.content).toContain('"name"');
+  });
+
+  it('read_file: rejects .env with a clear error', async () => {
+    const { status, body } = await call('read_file', { path: '.env' });
+    expect(status).toBe(200);            // tool-level errors return 200 with { error }
+    expect(body.error).toMatch(/out of scope/);
+  });
+
+  it('read_file: truncates at 256 KB', async () => {
+    // arrange: use a known large file or create a temp fixture; assert marker in body
+  });
+
+  it('glob: returns matching paths', async () => {
+    const { body } = await call('glob', { pattern: 'src/**/*.test.ts' });
+    expect(body.paths.length).toBeGreaterThan(0);
+  });
+
+  it('grep: returns matches with path/line/text', async () => {
+    const { body } = await call('grep', { pattern: 'function', glob: 'src/**/*.ts' });
+    expect(body.matches[0]).toHaveProperty('path');
+    expect(body.matches[0]).toHaveProperty('line');
+  });
+
+  it('git_log: returns recent commits', async () => {
+    const { body } = await call('git_log', { limit: 3 });
+    expect(body.commits.length).toBeLessThanOrEqual(3);
+  });
+
+  it('git_status: returns branch and changes', async () => {
+    const { body } = await call('git_status', {});
+    expect(typeof body.branch).toBe('string');
+  });
+
+  it('list_docs: lists spec filenames', async () => {
+    const { body } = await call('list_docs', { kind: 'specs' });
+    expect(body.files.some((f: string) => f.endsWith('.md'))).toBe(true);
+  });
+
+  it('read_doc: returns a spec file', async () => {
+    const { body } = await call('read_doc', { kind: 'specs', name: '2026-04-18-live-voice-chat-design.md' });
+    expect(body.content.startsWith('# Live Voice Chat')).toBe(true);
+  });
+
+  it('unknown tool returns 404', async () => {
+    const res = await call('bogus', {});
+    expect(res.status).toBe(404);
+  });
+});
+```
+
+- [ ] **Step 8.2: Run to confirm failure.**
+
+Run: `npm test -- dashboard/src/app/api/voice/__tests__/tools-read.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 8.3: Implement the dispatcher and read-tool functions.**
+
+`route.ts` outline:
+
+```ts
+import { NextRequest, NextResponse } from 'next/server';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { resolveReadPath } from '../../../../../../../src/voice/path-scope';
+// Or via a tsconfig path; match the import style used in the rest of dashboard/.
+
+const READ_MAX = 256 * 1024;
+const TRUNC_MARKER = '\n\n[truncated at 256 KB — use grep/glob for larger files]';
+
+async function readFileTool(repoRoot: string, args: { path: string }) { /* … */ }
+async function globTool(repoRoot: string, args: { pattern: string }) { /* use `glob` npm package or fs-based walk; add dep if needed */ }
+async function grepTool(repoRoot: string, args: { pattern: string; glob?: string; path?: string }) { /* shell out to `rg` if available, else node-side; fail soft */ }
+async function gitLogTool(repoRoot: string, args: { limit?: number; path?: string }) { /* execFile git */ }
+async function gitStatusTool(repoRoot: string) { /* execFile git */ }
+async function listDocsTool(repoRoot: string, args: { kind: 'specs'|'plans'|'mockups'|'sessions' }) { /* fs.readdir */ }
+async function readDocTool(repoRoot: string, args: { kind: string; name: string }) { /* compose path, call readFileTool */ }
+
+const TOOLS: Record<string, (repoRoot: string, args: any) => Promise<unknown>> = {
+  read_file: readFileTool,
+  glob: globTool,
+  grep: grepTool,
+  git_log: gitLogTool,
+  git_status: gitStatusTool,
+  list_docs: listDocsTool,
+  read_doc: readDocTool,
+};
+
+export async function POST(req: NextRequest, ctx: { params: Promise<{ tool: string }> }) {
+  // loopback gate
+  const { tool } = await ctx.params;
+  if (!(tool in TOOLS)) return NextResponse.json({ error: 'unknown tool' }, { status: 404 });
+  const args = await req.json().catch(() => ({}));
+  const repoRoot = getRepoRoot(); // derived per Conventions §5
+  try {
+    const out = await TOOLS[tool](repoRoot, args);
+    return NextResponse.json(out);
+  } catch (err) {
+    // Distinguish scope errors (200 with body.error) from programmer errors (500).
+    if ((err as Error).message.includes('out of scope')) {
+      return NextResponse.json({ error: (err as Error).message });
+    }
+    return NextResponse.json({ error: 'tool execution failed' }, { status: 500 });
+  }
+}
+```
+
+Key correctness notes:
+- `glob` tool: use the `glob` npm package (`npm install glob @types/glob` in dashboard if needed). Reject patterns with `..` at the top level.
+- `grep` tool: shell out to `rg` via `execFile` if available (`rg --json`), otherwise fall back to the `glob` + `fs.readFile` walk with a simple regex. Cap results at 200 matches.
+- Every read path passes through `resolveReadPath`.
+- `read_file` truncation: if `content.length > READ_MAX`, slice to `READ_MAX` and append marker.
+
+- [ ] **Step 8.4: Run tests.**
+
+Run: `npm test -- dashboard/src/app/api/voice/__tests__/tools-read.test.ts`
+Expected: PASS. If `rg` isn't available on the test machine, the grep test may hit the fallback — that's fine, just verify it still returns matches.
+
+- [ ] **Step 8.5: Commit.**
+
+```bash
+git add dashboard/src/app/api/voice/tools/ dashboard/src/app/api/voice/__tests__/tools-read.test.ts
+git commit -m "feat(voice): read tools (read_file, glob, grep, git_log, git_status, list_docs, read_doc)"
+```
+
+### Task 9: Write tools (`write_spec`, `write_plan`, `write_mockup`, `write_diagram`) — **sequential after Task 8**
+
+**Files:**
+- Modify: `dashboard/src/app/api/voice/tools/dev/[tool]/route.ts` (add write handlers to the dispatcher)
+- Create: `dashboard/src/app/api/voice/__tests__/tools-write.test.ts`
+
+Write contract: server controls the final path. Slug is sanitized. Content size capped at 256 KB. Existing-file-with-different-content refused with `error`.
+
+- [ ] **Step 9.1: Write failing tests.**
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { POST } from '../../voice/tools/dev/[tool]/route';
+
+// The tests write to the actual repo's docs/superpowers/... — use a temp slug and clean up.
+
+async function call(tool: string, args: unknown) {
+  const req = new Request(`http://localhost:3100/api/voice/tools/dev/${tool}`, {
+    method: 'POST', headers: { 'content-type': 'application/json', host: 'localhost' }, body: JSON.stringify(args),
+  });
+  return POST(req, { params: Promise.resolve({ tool }) } as any);
+}
+
+const UNIQUE_SLUG = `test-${Date.now()}-${Math.random().toString(36).slice(2,6)}`;
+
+describe('write tools', () => {
+  afterEach(() => {
+    // Best-effort cleanup: rm any docs/superpowers/*/**-UNIQUE_SLUG.* files created.
+  });
+
+  it('write_spec: writes to docs/superpowers/specs/ with today\'s date', async () => {
+    const res = await call('write_spec', { slug: UNIQUE_SLUG, content: '# Hello' });
+    const body = await res.json();
+    expect(body.path).toMatch(new RegExp(`docs/superpowers/specs/\\d{4}-\\d{2}-\\d{2}-${UNIQUE_SLUG}\\.md$`));
+    expect(existsSync(body.path)).toBe(true);
+  });
+
+  it('write_plan: same pattern, plans dir', async () => { /* … */ });
+  it('write_mockup: writes .html with previewUrl', async () => { /* … */ });
+  it('write_diagram: wraps mermaid in a fenced block in .md', async () => {
+    const res = await call('write_diagram', { slug: UNIQUE_SLUG+'-d', mermaid: 'graph TD; A-->B;', title: 'x' });
+    const body = await res.json();
+    const contents = readFileSync(body.path, 'utf8');
+    expect(contents).toContain('```mermaid');
+    expect(contents).toContain('graph TD; A-->B;');
+  });
+
+  it('rejects slug with path separator', async () => {
+    const res = await call('write_spec', { slug: 'bad/slug', content: 'x' });
+    const body = await res.json();
+    expect(body.error).toBeDefined();
+  });
+
+  it('rejects oversized content (>256 KB)', async () => {
+    const res = await call('write_spec', { slug: UNIQUE_SLUG+'-big', content: 'x'.repeat(260 * 1024) });
+    const body = await res.json();
+    expect(body.error).toMatch(/too large/i);
+  });
+
+  it('refuses to overwrite existing file with different content', async () => {
+    const slug = UNIQUE_SLUG + '-dup';
+    const first = await (await call('write_spec', { slug, content: 'A' })).json();
+    const second = await (await call('write_spec', { slug, content: 'B' })).json();
+    expect(second.error).toMatch(/would overwrite/);
+    expect(second.existingContent).toBe('A');
+  });
+});
+```
+
+- [ ] **Step 9.2: Run to confirm failure.**
+
+Run: `npm test -- dashboard/src/app/api/voice/__tests__/tools-write.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 9.3: Implement write handlers.**
+
+Add to the dispatcher:
+
+```ts
+const WRITE_MAX = 256 * 1024;
+
+async function writeDoc(repoRoot: string, kind: 'specs'|'plans'|'mockups', slug: string, ext: string, body: string) {
+  if (body.length > WRITE_MAX) throw new Error(`content too large (${body.length} bytes, max ${WRITE_MAX})`);
+  const dest = await resolveWritePath(repoRoot, kind, slug, ext);
+  // If file exists, compare.
+  try {
+    const existing = await fs.readFile(dest, 'utf8');
+    if (existing !== body) {
+      // Return structured error; do NOT throw.
+      return { error: `would overwrite ${dest}`, existingContent: existing.slice(0, WRITE_MAX) };
+    }
+    // identical — no-op
+  } catch (e: any) {
+    if (e.code !== 'ENOENT') throw e;
+  }
+  await fs.writeFile(dest, body, 'utf8');
+  return { path: path.relative(repoRoot, dest) };
+}
+
+async function writeSpecTool(root: string, args: { slug: string; content: string }) {
+  return writeDoc(root, 'specs', args.slug, 'md', args.content);
+}
+async function writePlanTool(root: string, args: { slug: string; content: string }) {
+  return writeDoc(root, 'plans', args.slug, 'md', args.content);
+}
+async function writeMockupTool(root: string, args: { slug: string; html: string }) {
+  const result = await writeDoc(root, 'mockups', args.slug, 'html', args.html);
+  if ('path' in result) return { ...result, previewUrl: `/voice/preview?file=${encodeURIComponent(result.path)}` };
+  return result;
+}
+async function writeDiagramTool(root: string, args: { slug: string; mermaid: string; title?: string }) {
+  const md = (args.title ? `# ${args.title}\n\n` : '') + '```mermaid\n' + args.mermaid + '\n```\n';
+  const result = await writeDoc(root, 'mockups', args.slug, 'md', md);
+  if ('path' in result) return { ...result, previewUrl: `/voice/preview?file=${encodeURIComponent(result.path)}` };
+  return result;
+}
+
+// Register in TOOLS map:
+TOOLS.write_spec = writeSpecTool;
+TOOLS.write_plan = writePlanTool;
+TOOLS.write_mockup = writeMockupTool;
+TOOLS.write_diagram = writeDiagramTool;
+```
+
+- [ ] **Step 9.4: Run tests.**
+
+Run: `npm test -- dashboard/src/app/api/voice/__tests__/tools-write.test.ts`
+Expected: PASS.
+
+- [ ] **Step 9.5: Commit.**
+
+```bash
+git add dashboard/src/app/api/voice/tools/ dashboard/src/app/api/voice/__tests__/tools-write.test.ts
+git commit -m "feat(voice): write tools (spec/plan/mockup/diagram) with path+size guards"
+```
+
+### Task 10: Session-close endpoint — parallel-safe with 6-9
+
+**Files:**
+- Create: `dashboard/src/app/api/voice/session-close/route.ts`
+- Create: `dashboard/src/app/api/voice/__tests__/session-close.test.ts`
+
+Request body (camelCase):
+```ts
+{
+  voiceSessionId: string;
+  persona: 'dev';
+  startedAt: string;    // ISO
+  endedAt: string;      // ISO
+  transcript: Array<{ role: 'user'|'assistant'; text: string; ts: string }>;
+  usage: { textIn: number; textOut: number; audioIn: number; audioOut: number };
+  artifacts: string[];  // paths returned by write tools during session
+  endReason: 'user_stop'|'tab_close'|'soft_cap'|'hard_cap'|'ws_drop';
+}
+```
+
+Behavior:
+1. Loopback gate.
+2. Compute duration.
+3. Compute cost from `usage` using `rates.ts` on the server side too (import the same module).
+4. Write transcript markdown file to `docs/superpowers/brainstorm-sessions/YYYY-MM-DD-HHMM.md` with frontmatter; if `transcript` is empty, skip the file and leave `transcript_path` null.
+5. Insert row into `voice_sessions` via dashboard Drizzle client.
+6. Emit `voice-log.ts` `session.end` record.
+7. Respond `{ ok: true, transcriptPath, costUsd }`.
+
+Transcript markdown template:
+```
+---
+voiceSessionId: <id>
+persona: dev
+startedAt: <iso>
+endedAt: <iso>
+durationSeconds: <n>
+costUsd: <$...>
+artifacts:
+  - <path1>
+  - <path2>
+---
+
+## User
+
+> <user turn>
+
+## Assistant
+
+<assistant turn>
+
+…
+```
+
+- [ ] **Step 10.1: Write failing test.**
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { POST } from '../../voice/session-close/route';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import Database from 'better-sqlite3';
+
+// This test writes a real row to store/messages.db. Use a sentinel voiceSessionId
+// and clean up after.
+
+describe('POST /api/voice/session-close', () => {
+  const sid = 'test-' + Math.random().toString(36).slice(2, 10);
+
+  afterEach(() => {
+    // Remove the row
+    const db = new Database('store/messages.db');
+    db.prepare('DELETE FROM voice_sessions WHERE id = ?').run(sid);
+    db.close();
+    // Remove the transcript file(s) written with this sid if any — best effort
+  });
+
+  it('persists transcript file + session row', async () => {
+    const req = new Request('http://localhost:3100/api/voice/session-close', {
+      method: 'POST', headers: { 'content-type': 'application/json', host: 'localhost' },
+      body: JSON.stringify({
+        voiceSessionId: sid, persona: 'dev',
+        startedAt: new Date(Date.now() - 60_000).toISOString(),
+        endedAt: new Date().toISOString(),
+        transcript: [{ role: 'user', text: 'hi', ts: new Date().toISOString() }],
+        usage: { textIn: 1000, textOut: 2000, audioIn: 50_000, audioOut: 100_000 },
+        artifacts: [],
+        endReason: 'user_stop',
+      }),
+    });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.transcriptPath).toMatch(/brainstorm-sessions/);
+    expect(existsSync(body.transcriptPath)).toBe(true);
+
+    const db = new Database('store/messages.db');
+    const row = db.prepare('SELECT * FROM voice_sessions WHERE id = ?').get(sid) as any;
+    expect(row.persona).toBe('dev');
+    expect(row.duration_seconds).toBeGreaterThan(0);
+    expect(row.cost_usd).toBeGreaterThanOrEqual(0);
+  });
+
+  it('skips transcript file when transcript is empty', async () => {
+    // …
+  });
+});
+```
+
+- [ ] **Step 10.2: Run to confirm failure.**
+
+Run: `npm test -- dashboard/src/app/api/voice/__tests__/session-close.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 10.3: Implement the route.**
+
+Use `getDb()` from `dashboard/src/lib/db/index.ts` and import the `voice_sessions` table from `./schema` (note: dashboard schema uses snake_case TS property names — see Task 3.4). The Drizzle insert values object therefore uses snake_case keys matching the schema:
+
+```ts
+await db.insert(voice_sessions).values({
+  id: body.voiceSessionId,                      // camelCase request → snake_case value key
+  persona: body.persona,
+  started_at: body.startedAt,
+  ended_at: body.endedAt,
+  duration_seconds: durationSeconds,
+  text_tokens_in: body.usage.textIn,
+  text_tokens_out: body.usage.textOut,
+  audio_tokens_in: body.usage.audioIn,
+  audio_tokens_out: body.usage.audioOut,
+  cost_usd: costUsd,
+  rates_version: RATES.version,
+  transcript_path: transcriptPath,              // null if no transcript was written
+  artifacts: JSON.stringify(body.artifacts),
+});
+```
+
+API request JSON remains camelCase (`voiceSessionId`, `startedAt`, `usage.textIn`); translation to snake_case happens only at this boundary. The response JSON is also camelCase: `{ ok: true, transcriptPath, costUsd }`.
+
+- [ ] **Step 10.4: Run tests.**
+
+Run: `npm test -- dashboard/src/app/api/voice/__tests__/session-close.test.ts`
+Expected: PASS.
+
+- [ ] **Step 10.5: Commit.**
+
+```bash
+git add dashboard/src/app/api/voice/session-close/ dashboard/src/app/api/voice/__tests__/session-close.test.ts
+git commit -m "feat(voice): session-close endpoint (transcript + session row)"
+```
+
+### Task 11: Persona config — parallel-safe
+
+**Files:**
+- Create: `dashboard/src/app/voice/personas.ts`
+
+Pure-data module. Exports the Dev persona's system prompt, tool declarations (in `FunctionDeclaration` shape for Gemini), voice name, and startup-context path.
+
+- [ ] **Step 11.1: Implement `personas.ts`.**
+
+Approximate shape:
+
+```ts
+import type { FunctionDeclaration } from '@google/genai';
+
+export interface PersonaConfig {
+  name: 'dev';
+  voice: string;
+  systemInstruction: string;
+  tools: FunctionDeclaration[];
+  contextPath: string;  // '/api/voice/context/dev'
+}
+
+export const DEV_PERSONA: PersonaConfig = {
+  name: 'dev',
+  voice: 'Zephyr',
+  systemInstruction: `<paste final system prompt from spec §Persona: Dev Assistant>`,
+  contextPath: '/api/voice/context/dev',
+  tools: [
+    { name: 'read_file', description: '…', parameters: { type: 'OBJECT', properties: { path: { type: 'STRING' } }, required: ['path'] } },
+    // glob, grep, git_log, git_status, list_docs, read_doc, write_spec, write_plan, write_mockup, write_diagram
+  ],
+};
+```
+
+Use the exact tool names defined in the spec and Tasks 8 + 9. The full param schemas live with the implementation in this file.
+
+- [ ] **Step 11.2: Commit.**
+
+```bash
+git add dashboard/src/app/voice/personas.ts
+git commit -m "feat(voice): Dev Assistant persona config"
+```
+
+---
+
+## Phase C — Client
+
+### Task 12: Cost tracker
+
+**Files:**
+- Create: `dashboard/src/app/voice/cost-tracker.ts`
+- Create: `dashboard/src/app/voice/__tests__/cost-tracker.test.ts`
+
+- [ ] **Step 12.1: Write failing test.**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { CostTracker } from '../cost-tracker';
+import { RATES } from '../rates';
+
+describe('CostTracker', () => {
+  it('accumulates token counts across turns', () => {
+    const t = new CostTracker(RATES);
+    t.addUsage({ textIn: 10, textOut: 20, audioIn: 100, audioOut: 200 });
+    t.addUsage({ textIn: 5, textOut: 0, audioIn: 0, audioOut: 50 });
+    expect(t.totals).toEqual({ textIn: 15, textOut: 20, audioIn: 100, audioOut: 250 });
+  });
+
+  it('exposes a live cost figure', () => {
+    const t = new CostTracker({ textInPerM: 1_000_000, textOutPerM: 0, audioInPerM: 0, audioOutPerM: 0, asOf: 'x', version: 'x' });
+    t.addUsage({ textIn: 1, textOut: 0, audioIn: 0, audioOut: 0 });
+    expect(t.costUsd).toBeCloseTo(1, 6);
+  });
+
+  it('emits change events', () => {
+    const t = new CostTracker(RATES);
+    const seen: number[] = [];
+    t.onChange((c) => seen.push(c));
+    t.addUsage({ textIn: 100, textOut: 0, audioIn: 0, audioOut: 0 });
+    expect(seen.length).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 12.2: Run to confirm failure.**
+
+Run: `npm test -- dashboard/src/app/voice/__tests__/cost-tracker.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 12.3: Implement `CostTracker`.**
+
+Plain TS class, no framework deps. Holds an internal `TokenUsage` total, exposes `totals`, `costUsd` getter, `addUsage(u)`, `reset()`, and `onChange(cb)`/`offChange(cb)`.
+
+- [ ] **Step 12.4: Run tests.**
+
+Run: `npm test -- dashboard/src/app/voice/__tests__/cost-tracker.test.ts`
+Expected: PASS.
+
+- [ ] **Step 12.5: Commit.**
+
+```bash
+git add dashboard/src/app/voice/cost-tracker.ts dashboard/src/app/voice/__tests__/cost-tracker.test.ts
+git commit -m "feat(voice): cost tracker with live change events"
+```
+
+### Task 13: Audio I/O — parallel-safe with 14, 15
+
+**Files:**
+- Create: `dashboard/src/app/voice/audio-io.ts`
+- Create: `dashboard/src/app/voice/audio-worklet-processor.ts`
+
+This is browser-only code. Tests would need jsdom + a Web Audio shim (which jsdom lacks); skip unit tests for these two files and cover behavior via the integration test in Task 20.
+
+- [ ] **Step 13.1: Implement the worklet processor.**
+
+`audio-worklet-processor.ts` is loaded by the browser via `audioContext.audioWorklet.addModule(url)`. Contents (plain JS worklet):
+
+```ts
+class PcmCaptureProcessor extends AudioWorkletProcessor {
+  // Downsample from audioContext.sampleRate (likely 48000) to 16000 and post Int16 frames.
+  process(inputs: Float32Array[][]) {
+    const ch = inputs[0]?.[0];
+    if (!ch) return true;
+    // resample + Int16 convert + postMessage(buffer)
+    return true;
+  }
+}
+registerProcessor('pcm-capture', PcmCaptureProcessor);
+```
+
+Ship as a `.ts` that Next.js can serve (or a `.js` placed in `public/`). Next.js 16 can import workers via `new Worker(new URL(...), import.meta.url)` but AudioWorkletModules need a URL path. Simplest: put a compiled `pcm-capture.js` in `dashboard/public/voice/` and `addModule('/voice/pcm-capture.js')`.
+
+- [ ] **Step 13.2: Implement `audio-io.ts`.**
+
+Two exports:
+
+- `startMicCapture(): Promise<{ stream: MediaStream; onFrame: (cb: (pcm: Int16Array) => void) => void; stop: () => void }>`
+- `createPlayback(): { enqueue: (pcm24: Int16Array) => void; stop: () => void }`
+
+Playback uses `AudioBufferSourceNode` with a minimal buffer queue that schedules each chunk right after the previous one (`startTime = Math.max(ctx.currentTime, lastEndTime)`). No worklet needed for output.
+
+- [ ] **Step 13.3: Commit.**
+
+```bash
+git add dashboard/src/app/voice/audio-io.ts dashboard/src/app/voice/audio-worklet-processor.ts dashboard/public/voice/
+git commit -m "feat(voice): mic capture (worklet) + PCM playback"
+```
+
+### Task 14: Fake Gemini server — parallel-safe with 13, 15
+
+**Files:**
+- Create: `dashboard/src/app/voice/__tests__/fake-gemini-server.ts`
+
+Standalone module used by `voice-session.test.ts`. Uses the `ws` package (add as a dev dep in dashboard if not present).
+
+- [ ] **Step 14.1: Add `ws` dep.**
+
+```bash
+cd dashboard && npm install --save-dev ws @types/ws && cd ..
+```
+
+- [ ] **Step 14.2: Implement the fake server.**
+
+Minimal API:
+
+```ts
+import { WebSocketServer, WebSocket } from 'ws';
+
+export interface FakeGemini {
+  url: string;
+  close: () => Promise<void>;
+  // Scripted behaviors:
+  sendAssistantAudio: (chunkBase64: string) => void;
+  sendInputTranscription: (text: string, partial?: boolean) => void;
+  sendOutputTranscription: (text: string, partial?: boolean) => void;
+  sendToolCall: (call: { id: string; name: string; args: unknown }) => void;
+  sendUsage: (usage: { textIn: number; textOut: number; audioIn: number; audioOut: number }) => void;
+  terminate: () => void;  // server-initiated close (simulates 15-min cap)
+  waitForClientAudio: () => Promise<Buffer>;
+  waitForToolResponse: (toolCallId: string) => Promise<unknown>;
+}
+
+export async function startFakeGemini(): Promise<FakeGemini>;
+```
+
+Implement only the framing needed for tests — opaque frames are fine as long as they match the shape `VoiceSession` expects.
+
+- [ ] **Step 14.3: Commit.**
+
+```bash
+git add dashboard/src/app/voice/__tests__/fake-gemini-server.ts dashboard/package.json dashboard/package-lock.json
+git commit -m "test(voice): fake Gemini Live WS server for integration tests"
+```
+
+### Task 15: `VoiceSession` class — parallel-safe with 13, 14
+
+**Files:**
+- Create: `dashboard/src/app/voice/voice-session.ts`
+- Create: `dashboard/src/app/voice/__tests__/voice-session.test.ts`
+
+Public surface:
+
+```ts
+export interface VoiceSessionEvents {
+  onInputTranscript: (text: string, partial: boolean) => void;
+  onOutputTranscript: (text: string, partial: boolean) => void;
+  onAudio: (pcm: Int16Array) => void;
+  onToolCall: (call: { id: string; name: string; args: unknown }) => Promise<unknown>;
+  onCost: (costUsd: number) => void;
+  onEnd: (payload: SessionEndPayload) => void;
+}
+
+export interface SessionEndPayload {
+  transcript: Array<{ role: 'user'|'assistant'; text: string; ts: string }>;
+  startedAt: string;
+  endedAt: string;
+  usage: TokenUsage;
+  endReason: 'user_stop'|'tab_close'|'soft_cap'|'hard_cap'|'ws_drop';
+  resumeHandle?: string;
+}
+
+export class VoiceSession {
+  constructor(opts: {
+    persona: PersonaConfig;
+    tokenEndpoint?: string;     // defaults '/api/voice/token'
+    contextEndpoint?: string;   // derived from persona
+    toolEndpoint?: string;
+    closeEndpoint?: string;
+    liveApiUrl?: string;        // injectable for tests
+    softCapSeconds?: number;    // default 10 * 60
+    events: VoiceSessionEvents;
+  });
+  start(): Promise<void>;  // mints token, fetches context, opens WS, sends first clientContent
+  sendAudio(pcm: Int16Array): void;
+  mute(): void;
+  unmute(): void;
+  stop(reason?: SessionEndPayload['endReason']): Promise<void>;
+}
+```
+
+Responsibilities:
+- Own a `CostTracker` instance and forward `onChange` to `onCost`.
+- Buffer the transcript from `onInput/OutputTranscript` final events only (drop partials from the buffer).
+- Track `startedAt`. When `stop()` is called, compose `SessionEndPayload`, `fetch(closeEndpoint, { method: 'POST', keepalive: true, body: JSON.stringify(...) })`, then fire `onEnd`.
+- Tool-call dispatch: on `onToolCall`, await the caller's response, send back as `toolResponse` over the WS.
+- Soft-cap: `setTimeout(softCapSeconds * 1000, () => stop('soft_cap'))`.
+
+- [ ] **Step 15.1: Write failing test using the fake server.**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { startFakeGemini } from './fake-gemini-server';
+import { VoiceSession } from '../voice-session';
+import { DEV_PERSONA } from '../personas';
+
+describe('VoiceSession', () => {
+  it('connects, receives audio, and accumulates cost on usage events', async () => {
+    const fake = await startFakeGemini();
+    const audio: Int16Array[] = [];
+    let lastCost = 0;
+    const session = new VoiceSession({
+      persona: DEV_PERSONA,
+      liveApiUrl: fake.url,
+      tokenEndpoint: '/test/token',   // stubbed via vi.fetch mock
+      contextEndpoint: '/test/ctx',
+      toolEndpoint: '/test/tool',
+      closeEndpoint: '/test/close',
+      events: {
+        onAudio: (pcm) => audio.push(pcm),
+        onCost: (c) => { lastCost = c; },
+        onInputTranscript: () => {}, onOutputTranscript: () => {},
+        onToolCall: async () => ({}), onEnd: () => {},
+      },
+    });
+    // mock global fetch for the endpoints used above
+    // start, feed a usage event + audio frame, assert receipt
+    await session.start();
+    fake.sendUsage({ textIn: 100_000, textOut: 200_000, audioIn: 1_000_000, audioOut: 1_000_000 });
+    fake.sendAssistantAudio(/* tiny base64 PCM */ 'AAAA');
+    await new Promise((r) => setTimeout(r, 50));
+    expect(audio.length).toBeGreaterThan(0);
+    expect(lastCost).toBeGreaterThan(0);
+    await session.stop('user_stop');
+    await fake.close();
+  });
+
+  it('round-trips a tool call', async () => { /* … */ });
+  it('auto-stops at soft cap', async () => { /* using fake timers */ });
+});
+```
+
+- [ ] **Step 15.2: Run to confirm failure.**
+
+Run: `npm test -- dashboard/src/app/voice/__tests__/voice-session.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 15.3: Implement `VoiceSession`.**
+
+Decide per the latest `@google/genai` browser API: whether to use `client.live.connect()` (SDK-wrapped) or the raw WebSocket. For testability against the fake server, prefer the raw WebSocket approach and keep the frame shape minimal. Document the choice in a code comment.
+
+- [ ] **Step 15.4: Run tests.**
+
+Run: `npm test -- dashboard/src/app/voice/__tests__/voice-session.test.ts`
+Expected: PASS.
+
+- [ ] **Step 15.5: Commit.**
+
+```bash
+git add dashboard/src/app/voice/voice-session.ts dashboard/src/app/voice/__tests__/voice-session.test.ts
+git commit -m "feat(voice): VoiceSession owns WS lifecycle + cost + transcript buffer"
+```
+
+### Task 16: Captions component
+
+**Files:**
+- Create: `dashboard/src/app/voice/captions.tsx`
+
+Simple React component. No unit test required; exercised by Task 20 / manual dogfood.
+
+- [ ] **Step 16.1: Implement.**
+
+Props: `{ lines: Array<{ role: 'user'|'assistant'; text: string; ts: string; partial?: boolean }> }`. Renders a scrolling list. User lines left-aligned muted; assistant lines right-aligned normal. Pin to bottom unless user has scrolled up. Include a "Copy session" button.
+
+- [ ] **Step 16.2: Commit.**
+
+```bash
+git add dashboard/src/app/voice/captions.tsx
+git commit -m "feat(voice): Captions component"
+```
+
+### Task 17: Preview pane
+
+**Files:**
+- Create: `dashboard/src/app/voice/preview-pane.tsx`
+
+- [ ] **Step 17.1: Implement.**
+
+Props: `{ artifacts: Array<{ type: 'mockup'|'diagram'; path: string }> }`. Two tabs: Mockup and Diagram. Selected tab renders the latest artifact of that type. Mockup via `<iframe sandbox="allow-scripts" src={`/voice/preview?file=${encodeURIComponent(path)}`} />`. Diagram via `mermaid.initialize({ startOnLoad: false })` and `mermaid.render()`.
+
+To serve the mockup file from its location on disk, add a helper route `dashboard/src/app/voice/preview/route.ts` (GET) that reads the file from the mockups dir (path-scoped to `docs/superpowers/mockups/`) and returns its bytes as text/html or text/markdown. Reuse `resolveReadPath`-style guards.
+
+- [ ] **Step 17.2: Commit.**
+
+```bash
+git add dashboard/src/app/voice/preview-pane.tsx dashboard/src/app/voice/preview/
+git commit -m "feat(voice): preview pane (mockup iframe + mermaid)"
+```
+
+### Task 18: Cost panel
+
+**Files:**
+- Create: `dashboard/src/app/voice/cost-panel.tsx`
+- Create: `dashboard/src/app/api/voice/stats/route.ts`
+- Create: `dashboard/src/app/api/voice/__tests__/stats.test.ts`
+
+Cost panel shows: current session $ (from `CostTracker`), today total, month-to-date total. The rollups come from `/api/voice/stats`.
+
+- [ ] **Step 18.1: Write failing test for stats endpoint.**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { GET } from '../../voice/stats/route';
+
+describe('GET /api/voice/stats', () => {
+  it('returns today and month totals + warning threshold', async () => {
+    const req = new Request('http://localhost:3100/api/voice/stats', { headers: { host: 'localhost' } });
+    const res = await GET(req);
+    const body = await res.json();
+    expect(typeof body.todayUsd).toBe('number');
+    expect(typeof body.monthUsd).toBe('number');
+    expect(body.budgetUsd === null || typeof body.budgetUsd === 'number').toBe(true);
+  });
+});
+```
+
+- [ ] **Step 18.2: Implement stats endpoint.**
+
+SQL (inline to avoid hallucination — verified against Task 3 schema):
+
+```ts
+const todayRow = db.all(sql`SELECT COALESCE(SUM(cost_usd), 0) AS total FROM voice_sessions WHERE date(started_at) = date('now','localtime')`);
+const monthRow = db.all(sql`SELECT COALESCE(SUM(cost_usd), 0) AS total FROM voice_sessions WHERE strftime('%Y-%m', started_at) = strftime('%Y-%m', 'now','localtime')`);
+```
+
+Return `{ todayUsd, monthUsd, budgetUsd: process.env.VOICE_MONTHLY_BUDGET_USD ? Number(...) : null }`.
+
+- [ ] **Step 18.3: Implement cost panel UI.**
+
+Shows three figures; tooltip on session $ shows token breakdown from `CostTracker.totals`. If `monthUsd > budgetUsd`, render a non-blocking amber banner.
+
+- [ ] **Step 18.4: Run tests.**
+
+Run: `npm test -- dashboard/src/app/api/voice/__tests__/stats.test.ts`
+Expected: PASS.
+
+- [ ] **Step 18.5: Commit.**
+
+```bash
+git add dashboard/src/app/voice/cost-panel.tsx dashboard/src/app/api/voice/stats/ dashboard/src/app/api/voice/__tests__/stats.test.ts
+git commit -m "feat(voice): cost panel + /api/voice/stats rollups"
+```
+
+### Task 19: `/voice` page
+
+**Files:**
+- Create: `dashboard/src/app/voice/page.tsx`
+
+- [ ] **Step 19.1: Implement page.**
+
+Use a top-level client component (`'use client'`). Responsibilities:
+
+1. Mount: fetch `/api/voice/stats` for rollups; subscribe to `CostTracker` updates.
+2. Top bar: persona name (Dev Assistant), localhost-only banner.
+3. Controls: Start / Stop button; mute; session timer.
+4. Main layout: three-pane CSS grid — captions (left, ~40%), preview pane (right, ~60%), cost panel (bottom, fixed height).
+5. Start button: constructs `VoiceSession` with `DEV_PERSONA` and event callbacks wired to React state. Catches errors and shows inline messages.
+6. On `onEnd`: show "Session ended — cost $X. Transcript saved to [path]." with a "Start new session" button.
+
+Keep CSS Tailwind-only, no custom stylesheet.
+
+- [ ] **Step 19.2: Manually smoke-test.**
+
+Start services per `CLAUDE.md`. Open `http://localhost:3100/voice` in Chrome (Gemini Live requires a Chromium-based browser for Web Audio + Worklets). Click Start. Verify: mic permission, banner visible, stop works, session-end writes a row and a file.
+
+- [ ] **Step 19.3: Commit.**
+
+```bash
+git add dashboard/src/app/voice/page.tsx
+git commit -m "feat(voice): /voice page wiring"
+```
+
+---
+
+## Phase D — Integration
+
+### Task 20: End-to-end test via fake Gemini server
+
+**Files:**
+- Create: `dashboard/src/app/voice/__tests__/e2e.test.ts`
+
+Drives `VoiceSession` against the fake server + hits the real backend API routes via Next.js request helpers. Confirms: session-close is called, DB row written, transcript file created, tool calls round-trip.
+
+- [ ] **Step 20.1: Write the e2e test.**
+
+Integrate the fake server with spies on `fetch` routed to real route handlers. Cleanup after.
+
+- [ ] **Step 20.2: Run.**
+
+Run: `npm test -- dashboard/src/app/voice/__tests__/e2e.test.ts`
+Expected: PASS.
+
+- [ ] **Step 20.3: Commit.**
+
+```bash
+git add dashboard/src/app/voice/__tests__/e2e.test.ts
+git commit -m "test(voice): end-to-end against fake Gemini server"
+```
+
+### Task 21: Dashboard nav (dev-only)
+
+**Files:**
+- Modify: `dashboard/src/app/layout.tsx` (or wherever the nav lives)
+
+- [ ] **Step 21.1: Add conditional link.**
+
+`{process.env.NODE_ENV === 'development' && <Link href="/voice">Voice</Link>}`
+
+- [ ] **Step 21.2: Commit.**
+
+```bash
+git add dashboard/src/app/layout.tsx
+git commit -m "feat(voice): add /voice nav link (dev-only)"
+```
+
+### Task 22: Dogfood checklist + CLAUDE.md update
+
+**Files:**
+- Create: `docs/superpowers/brainstorm-sessions/.gitkeep`
+- Create: `docs/superpowers/mockups/.gitkeep`
+- Create: `docs/superpowers/research/.gitkeep`
+- Create: `docs/voice-dogfood-checklist.md`
+- Modify: `CLAUDE.md` (add `/voice` row to the dashboard section)
+
+- [ ] **Step 22.1: Create gitkeep files.**
+
+- [ ] **Step 22.2: Verify RAG indexer does NOT watch `docs/superpowers/`.**
+
+Run:
+```bash
+grep -n "superpowers\|brainstorm-sessions" src/rag/indexer.ts
+```
+
+Expected: no matches. The indexer's watch roots should be vault-only (likely `VAULT_DIR` from env). If `docs/superpowers/` is in the watch scope, STOP — the spec's privacy guarantee is violated and the plan must add an exclusion before shipping. Report the finding to the coordinator rather than silently editing `src/rag/indexer.ts` (that module is outside this plan's write scope).
+
+Document the verification in the commit message for Step 22.5.
+
+- [ ] **Step 22.3: Write `docs/voice-dogfood-checklist.md`.**
+
+A concise manual-test list — mirror the spec's "Manual dogfood checklist" bullets.
+
+- [ ] **Step 22.4: Update `CLAUDE.md`.**
+
+In the universityClaw Extensions section, add:
+- A row in the Subsystems table: `Live Voice (/voice) | dashboard/src/app/voice/ | Gemini Live brainstorm partner`
+- A row in the Key Paths section pointing to the new dirs under `docs/superpowers/`
+- A row in the Services table for the voice feature if that pattern fits; otherwise a dedicated short section is fine.
+
+- [ ] **Step 22.5: Commit.**
+
+```bash
+git add docs/ CLAUDE.md
+git commit -m "docs(voice): dogfood checklist + CLAUDE.md entry + RAG-scope verification"
+```
+
+### Task 23: Final verification + open PR
+
+- [ ] **Step 23.1: Run all tests.**
+
+Run from repo root: `npm test`
+Expected: all green (including pre-existing tests).
+
+- [ ] **Step 23.2: TypeScript + lint.**
+
+```bash
+npm run typecheck && npm run lint
+cd dashboard && npx tsc --noEmit && cd ..
+```
+
+Expected: no new errors. (Pre-existing ones unrelated to voice can be noted.)
+
+- [ ] **Step 23.3: Manual smoke test.**
+
+Full manual pass per `docs/voice-dogfood-checklist.md`. Capture any issues as GitHub issues or follow-up tasks; do NOT fix scope-creep items in this PR.
+
+- [ ] **Step 23.4: Push + PR.**
+
+```bash
+git push -u origin feat/live-voice-chat
+gh pr create --title "Live Voice Chat v1 — Dev Assistant (/voice)" --body "<summary of what's in the spec + link to it>"
+```
+
+Target base: `main`. Repo: `SimonKvalheim/universityClaw` (never upstream).
+
+---
+
+## Self-Review (coordinator, before dispatch)
+
+- [ ] Every spec section has at least one task implementing it.
+- [ ] No placeholders remain (grep the plan for "TBD", "TODO", "fill in").
+- [ ] Function/method names are consistent across tasks.
+- [ ] Every write tool has a corresponding test case.
+- [ ] `voice_sessions` column names match between Task 3 SQL, Drizzle schemas, Task 10 insert, and Task 18 SELECT.
+- [ ] camelCase vs snake_case: request/response JSON is camelCase; DB columns are snake_case; Drizzle TS properties are camelCase with explicit column name in `text('snake_case')`.
+
+---
+
+## Subagent Dispatch Guidance (coordinator-only)
+
+If using superpowers:subagent-driven-development, for each task include in the subagent prompt:
+
+1. The exact content of the task (from above), verbatim.
+2. The "Conventions" section, verbatim.
+3. The relevant code snippet(s) from the surrounding context the subagent would otherwise grep for — NEVER trust the subagent to find them. Specifically:
+   - For Task 3: the canonical schema SQL column list (as shown in the task).
+   - For Task 10 / 18: the `voice_sessions` column list and sample SQL inline.
+   - For Tasks 6, 7, 10, 18: the loopback-gate pattern (copy from Task 6 implementation).
+   - For Tasks 8, 9: the `resolveReadPath`/`resolveWritePath` signatures from Task 5.
+   - For Task 15: a copy of the `VoiceSessionEvents` interface.
+4. Explicit file scope: the `Files` section of the task, and an instruction: "Do NOT modify any files outside the listed set without pausing to ask the coordinator."
+5. Explicit "what not to skip": tests before implementation; run the failing test and paste the output before writing any implementation code; commit at each step boundary; do not invent DB column names — use the ones inlined in this prompt.
+
+End of plan.

--- a/docs/superpowers/specs/2026-04-18-live-voice-chat-design.md
+++ b/docs/superpowers/specs/2026-04-18-live-voice-chat-design.md
@@ -1,327 +1,433 @@
-# Live Voice Chat — Design Spec
+# Live Voice Chat (v1) — Design Spec
 
 ## Overview
 
-A new dashboard surface at `/voice` that enables real-time spoken conversation with two distinct personas:
+A new dashboard surface at `/voice` that enables real-time spoken conversation with a **Dev Assistant** persona — a brainstorming and spec-writing partner for uniClaw feature work. The session is native-audio end-to-end: Gemini 3.1 Flash Live hears the developer's voice, reasons, speaks back, and calls read/write tools on the codebase and docs directory.
 
-- **Mr. Rogers Live** — the existing teaching assistant, reachable by voice from the desk. Shares state with the Telegram Mr. Rogers so a concept discussed by voice is remembered when the next text exchange happens.
-- **Dev Assistant** — a new brainstorming partner for uniClaw feature work. Read-only on the codebase, can draft specs, plans, and HTML/mermaid mockups. Not a replacement for Claude Code; a complement for thinking out loud.
+This v1 intentionally delivers the **voice infrastructure** and the **Dev Assistant persona** together. Mr. Rogers Live (the teaching-assistant persona that routes reasoning through the existing Claude container) is a separate, deferred design — see `2026-04-18-mr-rogers-live-design.md`. The Dev Assistant exercises the full Gemini Live stack without the hybrid-transport complexity, making it the safer first persona to ship and dogfood.
 
-Both personas share one infrastructure — a Gemini 3.1 Flash Live session opened from the browser — and differ only in system prompt, tool surface, startup context, and default voice.
-
-Separate from existing async voice flow on Telegram (voice note → transcription → agent → voice note). That flow keeps its own provider migration path and is out of scope here.
+This feature is distinct from the existing async voice-note flow on Telegram, which is being migrated from Mistral to Gemini in a parallel spec (`2026-04-18-gemini-tts-stt-migration-design.md`). Both specs share a single `GEMINI_API_KEY` env var; otherwise they do not overlap.
 
 ## Goals
 
-- **Zero to talking in <5 seconds** — click mic, start speaking.
-- **Captions always visible** — you can reread what was just said.
-- **Preview pane** — HTML mockups and mermaid diagrams render as they are written.
-- **Transcripts preserved** — every session leaves durable artifacts.
-- **Future-friendly boundaries** — adding session resumption, phone delivery, or more personas later is additive, not a rewrite.
+- **Zero to talking in under 5 seconds.** Click mic → Gemini is listening.
+- **Gemini has enough project context from the first second** to talk about uniClaw specifically (subsystems, file layout, recent work) without reactive grepping.
+- **Captions always visible.** Live transcription of both sides.
+- **Preview pane.** Mockups and diagrams render as they are written.
+- **Dollar tracker.** You see how much each session costs, in real time and cumulatively.
+- **Durable artifacts.** Every session leaves transcripts, specs, plans, mockups, and diagrams on disk.
+- **Future-friendly boundaries.** Adding session resumption, Mr. Rogers Live, a phone delivery path, or more personas later is additive, not a rewrite.
 
 ## Non-Goals (v1)
 
-- Session resumption beyond the 15-minute Live API cap. Sessions end; you start a fresh one. The frontend abstraction leaves room for adding resumption later.
-- Phone / Twilio / mobile apps. Dashboard-only.
-- Multi-user. Single-user, localhost. No auth beyond whatever gates the dashboard itself (none today — see Security).
-- Voice cloning or custom voices. Use prebuilt Gemini voices only.
-- Tool-use approval UI for Dev writes. Mockups and specs are cheap to revert via git; an approval step adds friction without much safety gain.
-- Barge-in tuning. Use Gemini's default VAD.
+- **Mr. Rogers Live persona.** Deferred to its own spec; hybrid transport (Gemini Live ↔ Claude container) is a non-trivial new IPC primitive.
+- **Subagent spawning** (e.g. "Gemini, research X in the background"). Discussed and deferred — rich tool surface + project context do the equivalent work more cheaply. If we add it later, the clean shape is an async task queue (research file dropped into `docs/superpowers/research/pending/`, picked up by a background worker, result written to `.../completed/`), not an in-session subagent call.
+- **Session resumption** beyond the 15-minute Live API cap. Sessions end; you start a fresh one. The `VoiceSession` abstraction reserves the slot for adding resumption without breaking the UI contract.
+- **Phone / Twilio / mobile apps.** Dashboard only.
+- **Multi-user.** Single-user, localhost.
+- **Voice cloning or custom voices.** Prebuilt Gemini voices only.
+- **Tool-use approval UI.** Mockups and specs are cheap to revert via git; an approval step adds friction without proportionate safety gain.
+- **Barge-in tuning.** Use Gemini's default VAD.
+- **Hard dollar cap per session.** v1 uses a 10-minute soft session limit and visible cost tracker; the user can stop early. If dogfood shows runaway costs, add a cap in v2.
 
 ## Route & File Structure
 
 ```
-dashboard/src/app/voice/page.tsx                           — The page (persona toggle, mic, captions, preview)
+dashboard/src/app/voice/page.tsx                           — The page
 dashboard/src/app/voice/voice-session.ts                   — VoiceSession class: WS lifecycle, audio I/O, event stream
-dashboard/src/app/voice/audio-io.ts                        — Mic capture + playback helpers (Web Audio API)
-dashboard/src/app/voice/personas.ts                        — Persona configs (system prompts, tool declarations, voice, context loader)
-dashboard/src/app/voice/preview-pane.tsx                   — Renders latest mockup (iframe) or diagram (mermaid)
+dashboard/src/app/voice/audio-io.ts                        — Mic capture (AudioWorklet) + playback helpers
+dashboard/src/app/voice/cost-tracker.ts                    — Token accumulator + dollar conversion
+dashboard/src/app/voice/preview-pane.tsx                   — Mockup iframe / mermaid renderer / history
 dashboard/src/app/voice/captions.tsx                       — Scrolling transcript view
+dashboard/src/app/voice/personas.ts                        — Persona config (v1: dev)
+dashboard/src/app/voice/rates.ts                           — Gemini pricing config (per-1M tokens, by modality)
+dashboard/src/app/voice/tests/voice-session.test.ts        — Unit tests against a fake WS server
+dashboard/src/app/voice/tests/fake-gemini-server.ts        — Minimal WS fixture for tests
 dashboard/src/app/api/voice/token/route.ts                 — Mints ephemeral token for Live API
-dashboard/src/app/api/voice/context/[persona]/route.ts     — Returns startup context payload per persona
-dashboard/src/app/api/voice/tools/[persona]/[tool]/route.ts — Executes a tool call forwarded from the browser
-dashboard/src/app/api/voice/session-close/route.ts         — Persists transcript per persona rules
+dashboard/src/app/api/voice/context/dev/route.ts           — Dev Assistant startup context
+dashboard/src/app/api/voice/tools/dev/[tool]/route.ts      — Executes a Dev tool call
+dashboard/src/app/api/voice/session-close/route.ts         — Persists transcript + session record
 docs/superpowers/mockups/YYYY-MM-DD-<slug>.html            — Dev-written HTML+Tailwind mockups (new dir)
-docs/superpowers/mockups/YYYY-MM-DD-<slug>.md              — Dev-written mermaid diagrams (same dir, .md)
+docs/superpowers/mockups/YYYY-MM-DD-<slug>.md              — Dev-written mermaid diagrams (same dir)
 docs/superpowers/brainstorm-sessions/YYYY-MM-DD-HHMM.md    — Dev session transcripts (new dir)
+docs/superpowers/research/                                 — Reserved dir for future subagent results (empty in v1)
 ```
+
+Schema change: a new `voice_sessions` table in `store/messages.db` (see Cost Tracking).
 
 ## Dependencies
 
-- `@google/genai` — Google Gen AI SDK (TypeScript). Used server-side for ephemeral token minting; browser uses the SDK's WebSocket client for the Live session.
+- `@google/genai` — TypeScript SDK. Used server-side for ephemeral-token minting; browser uses the SDK's WebSocket client.
 - `mermaid` — client-side diagram rendering in the preview pane.
-- No new backend services. Everything runs in the existing Next.js dashboard process.
-- `GEMINI_API_KEY` environment variable (rename of current `google_api_key`; see Environment below).
+- No new backend services.
+- `GEMINI_API_KEY` env var. Current lowercase `google_api_key` is standardized to `GEMINI_API_KEY` in the parallel migration spec; this feature requires that rename to be done (or reads both, with the uppercase taking precedence).
 
 ## Architecture
 
-```
-┌───────────────────────────────────────────────────────────────┐
-│ Browser (dashboard/src/app/voice/page.tsx)                    │
-│                                                                │
-│  Mic ─► PCM encode ─┐                          ┌─► Audio out  │
-│                     ▼                          │               │
-│           ┌──────────────────┐                 │               │
-│           │  VoiceSession    │────── WS ───────┼──► Gemini     │
-│           │  (voice-session) │                 │    Live API   │
-│           └─┬────────────────┘                 │    (v1alpha)  │
-│             │ onToolCall    onTranscript       │               │
-│             ▼               ▼                  │               │
-│   ┌──────────────┐    ┌──────────────┐         │               │
-│   │ Tool bridge  │    │ Captions +   │         │               │
-│   │ (fetch)      │    │ Preview pane │         │               │
-│   └──────┬───────┘    └──────────────┘         │               │
-└──────────┼─────────────────────────────────────────────────────┘
-           │
-           ▼
-┌─────────────────────────────────────────────────────────────────┐
-│ Dashboard Next.js API routes                                     │
-│                                                                  │
-│   /api/voice/token          mint ephemeral token from GEMINI_API_KEY │
-│   /api/voice/context/:p     session startup context              │
-│   /api/voice/tools/:p/:tool execute a tool call                  │
-│   /api/voice/session-close  flush transcript per persona         │
-└──────────┬──────────────────────────────────────────────────────┘
-           │
-   ┌───────┴───────────────┐
-   │                       │
-   ▼                       ▼
-┌─────────────────┐   ┌────────────────────────────┐
-│ Filesystem      │   │ NanoClaw IPC queue          │
-│ (vault, docs,   │   │ (for ask_mr_rogers only)    │
-│  git, specs)    │   │ → main Telegram group's     │
-└─────────────────┘   │   Claude container          │
-                      └────────────────────────────┘
+```mermaid
+flowchart LR
+  subgraph Browser["Browser · /voice page"]
+    Mic["Mic → PCM 16 kHz"]
+    VS["VoiceSession<br/>(WS lifecycle,<br/>event stream,<br/>cost tracker)"]
+    Spk["Audio out ← PCM 24 kHz"]
+    UI["Captions · Preview · $ tracker"]
+  end
+
+  subgraph Backend["Dashboard Next.js API"]
+    Token["/api/voice/token<br/>(mint ephemeral token)"]
+    Ctx["/api/voice/context/dev<br/>(startup context)"]
+    Tools["/api/voice/tools/dev/[tool]<br/>(tool executor)"]
+    Close["/api/voice/session-close<br/>(transcript + record)"]
+  end
+
+  subgraph Gemini["Gemini Live v1alpha"]
+    GLive["gemini-3.1-flash-live-preview"]
+  end
+
+  subgraph Storage["Filesystem"]
+    Repo["Repo (read)<br/>src · container · dashboard · docs"]
+    Docs["docs/superpowers/ (write)<br/>specs · plans · mockups · sessions"]
+    DB["store/messages.db<br/>voice_sessions table"]
+  end
+
+  Mic --> VS
+  VS -- PCM in --> GLive
+  GLive -- PCM out --> Spk
+  GLive -- transcripts + tool calls --> VS
+  VS --> UI
+  UI -- start session --> Token
+  Token -- ephemeral token --> VS
+  UI -- load ctx --> Ctx
+  Ctx --> Repo
+  VS -- tool call --> Tools
+  Tools -- read --> Repo
+  Tools -- write --> Docs
+  VS -- on end --> Close
+  Close --> Docs
+  Close --> DB
 ```
 
 ## Data Flow
 
 ### Session start
 
-1. User opens `/voice`, picks persona, clicks **Start**.
-2. Frontend calls `POST /api/voice/token` with `{ persona }`. Optional `resumeHandle` is accepted but ignored in v1.
-3. Backend uses `GEMINI_API_KEY` and `@google/genai` to request an ephemeral token bound to the persona's model config. Returns `{ token, expiresAt }`.
-4. Frontend calls `GET /api/voice/context/:persona` to fetch startup context (see Personas below).
-5. `VoiceSession` opens a WebSocket to Gemini at the `v1alpha` endpoint using the ephemeral token. Session config includes:
+1. User opens `/voice`, clicks **Start**.
+2. Frontend calls `POST /api/voice/token`. Optional `resumeHandle` accepted but ignored in v1.
+3. Backend uses `GEMINI_API_KEY` and `@google/genai` to mint an ephemeral token bound to `gemini-3.1-flash-live-preview`. Returns `{ token, expiresAt }`.
+4. Frontend calls `GET /api/voice/context/dev` for startup context (see Persona).
+5. `VoiceSession` opens a WebSocket to Gemini at the `v1alpha` endpoint using the token. Session config:
    - Model: `gemini-3.1-flash-live-preview`
    - Response modalities: `["AUDIO"]`
-   - System instruction (persona-specific)
-   - Tool declarations (persona-specific)
-   - `inputAudioTranscription: {}`, `outputAudioTranscription: {}` (for captions)
-   - Voice config (persona-specific)
-6. Immediately after connecting, `VoiceSession` sends a `clientContent` turn containing the fetched startup context, then unmutes the mic.
+   - System instruction: Dev Assistant persona prompt
+   - Tools: Dev Assistant tool declarations
+   - `inputAudioTranscription: {}` and `outputAudioTranscription: {}`
+   - Voice: `Zephyr`
+6. Immediately after connecting, `VoiceSession` sends a `clientContent` turn with the startup context, then unmutes the mic.
 
 ### Talking
 
-1. Browser captures mic audio, resamples/encodes to **16-bit PCM, 16 kHz, little-endian**, mono.
-2. `VoiceSession.sendRealtimeInput({ audio: { mimeType: 'audio/pcm;rate=16000', data: base64Chunk } })` streams chunks to Gemini.
-3. Gemini streams back `serverContent` events with 24 kHz PCM audio data + transcription events.
-4. `audio-io.ts` buffers and plays incoming PCM via a Web Audio `AudioWorklet`.
-5. Transcription events update the captions component.
-6. When Gemini emits a `toolCall`, `VoiceSession` forwards it to `POST /api/voice/tools/:persona/:tool` with the tool's args. The backend executes the tool and returns JSON. `VoiceSession` replies to Gemini with `toolResponse`.
-7. Mockup/diagram tool calls return a file path; the preview pane reloads to display it.
+1. `audio-io.ts` uses a `MediaStream` → `AudioWorklet` pipeline to resample mic input to **16-bit PCM, 16 kHz, little-endian, mono**, emitting ~20 ms frames.
+2. `VoiceSession.sendRealtimeInput({ audio: { mimeType: 'audio/pcm;rate=16000', data: base64Chunk } })` streams frames.
+3. Gemini returns `serverContent` events carrying 24 kHz PCM audio + transcription deltas + (optionally) tool calls.
+4. An `AudioWorklet`-based playback path buffers and plays incoming PCM.
+5. `cost-tracker.ts` listens for `usageMetadata` on each server turn, multiplies by rates from `rates.ts`, exposes a live dollar figure to the UI.
+6. Transcription events update the captions component.
+7. When Gemini emits a `toolCall`, `VoiceSession` `POST`s to `/api/voice/tools/dev/[tool]` with the args. The backend executes, returns JSON. `VoiceSession` replies to Gemini with `toolResponse`.
+8. Mockup/diagram tool calls return `{ path, previewUrl }`; the preview pane reloads to show the file.
 
 ### Session end
 
-Triggered by: user click **Stop**, tab close, 15-minute cap, or WebSocket disconnect.
+Triggered by: user **Stop**, tab close, 10-minute soft cap (with warnings), 15-minute Gemini hard cap, or WebSocket disconnect.
 
-1. `VoiceSession` emits `onSessionEnd({ transcript, persona, startedAt, endedAt })`.
-2. Frontend `POST /api/voice/session-close` with the payload.
-3. Server-side persistence branches by persona (see Transcript Handling).
+1. `VoiceSession` emits `onSessionEnd({ transcript, startedAt, endedAt, usage, resumeHandle? })`.
+2. Frontend `POST /api/voice/session-close` with the payload. Uses `fetch(..., { keepalive: true })`; `navigator.sendBeacon` is only a fallback (its ~64 KB body cap will truncate long transcripts).
+3. Server persists: verbatim transcript to `docs/superpowers/brainstorm-sessions/YYYY-MM-DD-HHMM.md` (with frontmatter cross-referencing any files written); a session record to `voice_sessions` table (see Cost Tracking).
+4. No summarization step. Raw brainstorms are more valuable than summaries for dev work.
 
-## Personas
+## Persona: Dev Assistant
 
-### Mr. Rogers Live
-
-**Backend**: Hybrid. Gemini handles conversation; the `ask_mr_rogers` tool delegates to the existing Claude container for anything that needs memory or vault writes.
-
-**Scope**: Shared with the main Telegram group. Context flows both ways (voice → Telegram memory → voice).
-
-**Default voice**: `Aoede` (warm, conversational).
-
-**System prompt (sketch)**:
-> You are Mr. Rogers, the student's personal teaching assistant, speaking with them by voice at their desk. You already know them well from prior exchanges — the context block below contains their current study state. Speak naturally and conversationally, as in a tutoring session. Keep turns short. Ask what they want to work on before explaining. When they ask about a concept, check the vault first (`search_vault`, `read_note`). Use `search_rag` for synthesis across sources. For anything that needs durable memory, planning, or vault writes, call `ask_mr_rogers` — that reaches your "slower self" which maintains the student profile.
-
-**Startup context**:
-
-Fetched by `/api/voice/context/mr-rogers`. Contains:
-- Today's study plan entries (from the plan DB)
-- Last 10 concepts practiced (from study log)
-- Open questions / gaps flagged in the student profile
-- Timestamp
-
-Delivered as a `clientContent` turn: `Here's where you left off: [context JSON]`. Not read aloud; Gemini keeps it in context.
-
-**Tool surface**:
-
-| Tool | Args | Returns | Scope |
-|---|---|---|---|
-| `search_vault` | `{ query: string, limit?: number }` | `{ matches: Array<{path, snippet}> }` | Read |
-| `read_note` | `{ path: string }` | `{ content: string, frontmatter: object }` | Read |
-| `search_rag` | `{ query: string, mode?: 'hybrid'\|'local'\|'global' }` | `{ answer: string, sources: string[] }` | Read |
-| `get_study_state` | `{}` | `{ plan, recentConcepts, openQuestions }` | Read (same as startup context, on-demand) |
-| `ask_mr_rogers` | `{ question: string, context?: string }` | `{ answer: string }` | Delegate to Claude container |
-
-The `ask_mr_rogers` tool posts a synthetic message into the main group's IPC queue with a `[voice-session]` tag, then polls / awaits the container's response. Implementation detail to be worked out in the plan: either reuse the existing message-response flow with a dedicated correlation ID, or add a direct blocking IPC path keyed on a request ID. The correlation-ID approach fits the existing IPC model; the plan should prefer it unless there's a reason not to.
-
-### Dev Assistant
-
-**Backend**: Gemini direct. No Claude container.
-
-**Scope**: Isolated. No access to `groups/`, vault, RAG, study system, or `src/`/`container/`/`dashboard/` for writes.
+**Backend**: Gemini direct. No Claude container in the loop.
 
 **Default voice**: `Zephyr` (clear, neutral).
 
-**System prompt (sketch)**:
-> You are a design and brainstorming partner for uniClaw (a personal Claude assistant / teaching platform fork of NanoClaw). The developer you're speaking with is building features for it. You have read access to the codebase and docs, and write access scoped to `docs/superpowers/specs/`, `docs/superpowers/plans/`, and `docs/superpowers/mockups/` only. You do NOT touch source code. When drafting specs or plans, follow the structure of existing files in those directories. For mockups, produce single-file HTML with Tailwind via CDN. For architecture or flow questions, prefer mermaid diagrams over prose. Keep spoken turns short. Think out loud. Ask about constraints before writing.
+### System prompt (sketch — final wording during implementation)
 
-**Startup context**:
+> You are the uniClaw Dev Assistant — a design and brainstorming partner speaking with the developer by voice. uniClaw is their personal Claude assistant / teaching platform, forked from NanoClaw.
+>
+> You have read-only access to the codebase and docs, plus write access to `docs/superpowers/specs/`, `docs/superpowers/plans/`, and `docs/superpowers/mockups/`. You do NOT edit source code, configs, or tests — Claude Code handles implementation; your job is to help the developer think, then capture the result as a written artifact.
+>
+> Use the context block below. It contains the project's CLAUDE.md, architecture overview, a subsystem map, available npm scripts, and current repo state. Use it to speak specifically about their codebase, not generically.
+>
+> Keep spoken turns short (aim ≤ 15 seconds). Think out loud. Ask about constraints before drafting. When writing specs or plans, match the structure of existing files in those directories. For mockups, produce single-file HTML with Tailwind via CDN. For architecture or flow questions, prefer mermaid diagrams over prose.
 
-Fetched by `/api/voice/context/dev`. Contains:
-- Current git branch
-- `git status` (short form)
-- Last 10 commits (subject line only)
-- List of spec filenames in `docs/superpowers/specs/`
-- List of plan filenames in `docs/superpowers/plans/`
-- Timestamp
+### Startup context
 
-**Tool surface**:
+Fetched by `GET /api/voice/context/dev`. Composed on the server at request time; delivered as a single `clientContent` turn after WS connect. Components:
+
+1. **`CLAUDE.md`** — full file (~188 lines, ~2 KB).
+2. **`docs/ARCHITECTURE.md`** — full file (~302 lines, ~4 KB).
+3. **Subsystem map** — generated: top-level dirs under `src/` and `dashboard/src/` with a one-liner each. Derived from a static map in `src/voice-context.ts` (list maintained by hand; cheap to update, avoids runtime guessing).
+4. **`package.json` scripts** — names + descriptions, both root and `dashboard/`.
+5. **Repo state** — current branch, `git status --short`, last 10 commit subjects, filenames (not contents) in `docs/superpowers/specs/` and `docs/superpowers/plans/`.
+6. **Session meta** — timestamp, `voice_session_id` (UUID, used for correlated logging).
+
+Estimated total: 6–9 K tokens. Re-tokenized on each fresh session. At Flash Live rates this is a few cents per start — acceptable given it eliminates most reactive grepping. The plan measures actual size against a real payload and revises the context if it exceeds 12 K tokens.
+
+### Tool surface
 
 | Tool | Args | Returns | Scope |
 |---|---|---|---|
-| `read_file` | `{ path: string }` | `{ content: string }` | Read; path must be within repo |
+| `read_file` | `{ path: string }` | `{ content: string }` | Read; see Read Scope below |
 | `glob` | `{ pattern: string }` | `{ paths: string[] }` | Read |
 | `grep` | `{ pattern: string, path?: string, glob?: string }` | `{ matches: Array<{path, line, text}> }` | Read |
 | `git_log` | `{ limit?: number, path?: string }` | `{ commits: Array<{sha, subject, date, author}> }` | Read |
 | `git_status` | `{}` | `{ branch, staged, modified, untracked }` | Read |
-| `list_specs` | `{}` | `{ specs: string[], plans: string[] }` | Read |
+| `list_docs` | `{ kind: 'specs' \| 'plans' \| 'mockups' \| 'sessions' }` | `{ files: string[] }` | Read |
+| `read_doc` | `{ kind: 'specs' \| 'plans' \| 'mockups' \| 'sessions', name: string }` | `{ content: string }` | Read (convenience over `read_file` for the docs dir) |
 | `write_spec` | `{ slug: string, content: string }` | `{ path: string }` | Write to `docs/superpowers/specs/YYYY-MM-DD-<slug>.md` |
 | `write_plan` | `{ slug: string, content: string }` | `{ path: string }` | Write to `docs/superpowers/plans/YYYY-MM-DD-<slug>.md` |
 | `write_mockup` | `{ slug: string, html: string }` | `{ path: string, previewUrl: string }` | Write to `docs/superpowers/mockups/YYYY-MM-DD-<slug>.html` |
-| `write_diagram` | `{ slug: string, mermaid: string, title?: string }` | `{ path: string, previewUrl: string }` | Write to `docs/superpowers/mockups/YYYY-MM-DD-<slug>.md` with mermaid block |
+| `write_diagram` | `{ slug: string, mermaid: string, title?: string }` | `{ path: string, previewUrl: string }` | Write to `docs/superpowers/mockups/YYYY-MM-DD-<slug>.md` with a mermaid code block |
 
-**Path guards** on all write tools:
-- Slug sanitized to `[a-z0-9-]+`, trimmed, max 80 chars.
-- Generated filename is fully controlled by the server; Gemini's `slug` arg never contains a path separator or parent traversal.
-- Refuse if the resulting file already exists and contents differ (don't overwrite silently). Provide a `replace: true` flag only if we later decide to support iteration on the same slug.
+### Read scope
+
+Allowed read roots: `src/`, `container/`, `dashboard/src/`, `docs/`, `scripts/`, `public/`, and root config files by explicit name (`package.json`, `tsconfig.json`, `next.config.ts`, `vitest.config.ts`, `eslint.config.mjs`, `postcss.config.mjs`, `README.md`, `CLAUDE.md`, `CONTRIBUTING.md`).
+
+Denied (reject with clear error): `.env*`, `store/`, `onecli/`, `groups/`, `data/`, `node_modules/`, `.venv/`, `dashboard/node_modules/`, `.git/`, anything outside the repo root.
+
+The backend tool handler enforces scope by:
+
+1. Resolving the requested path with `fs.realpath` (follows symlinks, rejects on broken link).
+2. Asserting the resolved path has the repo root as a prefix (no escape via symlink).
+3. Asserting the resolved path has one of the allowed roots as a prefix AND none of the denied substrings.
+4. Returning a size-bounded response: `read_file` truncates at 256 KB with a clear `[truncated at 256 KB — use grep/glob for larger files]` marker appended.
+
+### Write scope and guards
+
+All write tools apply these guards (server-owned, not trusted to the model):
+
+1. **Slug sanitization**: regex `^[a-z0-9-]{1,80}$`. No slashes, no dots, no parent traversal. Reject otherwise.
+2. **Date prefix is server-generated**, not passed by Gemini. Format: `YYYY-MM-DD`. The model's `slug` argument never sees the date.
+3. **Final path construction**: `path.join(repoRoot, targetDir, today + '-' + slug + '.' + ext)`. After construction, resolve with `fs.realpath` and assert prefix match against `targetDir` (symlink-escape guard).
+4. **Content size cap**: 256 KB per write (`content`, `html`, or `mermaid`). Reject oversized with a clear error.
+5. **Existing-file behavior**: if the resolved path exists and content differs, return `{ error: "would overwrite <path>", existingContent: "…" }` and refuse. Gemini can choose a different slug. An explicit `replace: true` flag is NOT added in v1.
+6. **Iframe sandbox for mockups**: rendered with `<iframe sandbox="allow-scripts" srcDoc={html}>` (no `allow-same-origin`). This intentionally blocks `localStorage`, `fetch` to the origin, and cookie access. The Dev Assistant is told to produce self-contained mockups; document this constraint in the system prompt.
 
 ## Preview Pane
 
 A tabbed side panel within `/voice`:
 
-- **Mockup tab** — renders latest `write_mockup` in a sandboxed `<iframe srcDoc={html}>`. Sandboxed with `allow-scripts` so Tailwind CDN works, no `allow-same-origin`.
-- **Diagram tab** — renders latest `write_diagram` using client-side `mermaid.js` initialized on mount.
-- **History** — a dropdown listing all files written during this session. Selecting one swaps the tab content.
+- **Mockup tab** — latest `write_mockup` rendered in a sandboxed `<iframe sandbox="allow-scripts" srcDoc={html}>`. Viewport sized to match a typical dashboard frame (~1280×720); zoom controls optional in v2.
+- **Diagram tab** — latest `write_diagram` rendered with client-side `mermaid.js` initialized on mount.
+- **History dropdown** — lists every mockup/diagram written during the current session. Swap by selecting.
 
-Files persist on disk; history is session-scoped only (resets when you leave the page). Grepping `docs/superpowers/mockups/` recovers anything you produced in prior sessions.
+Files persist on disk at `docs/superpowers/mockups/`; session history is page-scoped and resets on nav. Prior sessions' artifacts are reached by grepping the mockups dir.
 
 ## Captions
 
 Scrolling transcript pane beneath the mic controls:
 
-- Input transcription (what the user said) — left-aligned, muted text.
-- Output transcription (what Gemini said) — left-aligned, normal text, prefixed with the persona name.
-- Auto-scroll to bottom on new content; pin-to-bottom toggle if user scrolls up.
-- Copy-session button copies the full transcript to clipboard.
+- Input transcription (user) — **left-aligned, muted color**.
+- Output transcription (Gemini) — **right-aligned, normal color**, prefixed with the persona name.
+- Auto-scroll to bottom on new content; manual scroll-up pins the view until user returns to bottom.
+- **Copy session** button copies the full transcript to clipboard.
 
 Captions update in real time as transcription events arrive over the WebSocket.
 
-## Transcript Handling (session close)
+## Cost Tracking
 
-### Mr. Rogers
+### Data sources
 
-1. Session-close handler calls `ask_mr_rogers` one more time with the full transcript and a prompt like: *"Summarize this voice tutoring session into 2–5 bullet points for your long-term log. Focus on: concepts practiced, what the student struggled with, what to revisit next."*
-2. Writes the summary as a single message into the main group's conversation log with metadata: `{ origin: 'voice-session', startedAt, endedAt, transcriptPath? }`.
-3. Optionally also writes the full transcript to a side file (e.g., `groups/{main}/voice-archive/YYYY-MM-DD-HHMM.md`) so it's available for manual review but doesn't flood the agent's context. Default: yes. Storage cost is negligible.
+Gemini Live streams `usageMetadata` with each server turn. Known axes:
 
-### Dev Assistant
+- Text tokens in
+- Text tokens out
+- Audio tokens in
+- Audio tokens out
+- Tool-call tokens (folded into text if not separately reported)
 
-1. Session-close handler writes the full verbatim transcript to `docs/superpowers/brainstorm-sessions/YYYY-MM-DD-HHMM.md`.
-2. The file's frontmatter lists any spec/plan/mockup/diagram files written during the session so they're cross-referenced.
-3. No summarization step. Raw brainstorms are more valuable than summaries for dev work.
+Pricing lives in `dashboard/src/app/voice/rates.ts` as a hand-maintained config (values pulled from Google's pricing page at implementation time; marked with an `# as of YYYY-MM-DD` comment so staleness is visible). A single source of truth used by both the live ticker and the session-close persistence.
+
+### Live UI
+
+Next to the mic controls in `/voice`:
+
+- **Session cost** (formatted as `$0.0842`, 4 decimal precision) updating every time a new `usageMetadata` event arrives.
+- Breakdown tooltip on hover: text in / audio in / text out / audio out (tokens and $).
+- **Today** and **This month** rollups pulled from the `voice_sessions` table on page load and incremented live.
+
+### Persistence
+
+New SQLite table:
+
+```sql
+CREATE TABLE voice_sessions (
+  id TEXT PRIMARY KEY,                 -- voice_session_id (UUID)
+  persona TEXT NOT NULL,               -- 'dev' in v1
+  started_at TEXT NOT NULL,            -- ISO timestamp
+  ended_at TEXT NOT NULL,              -- ISO timestamp
+  duration_seconds INTEGER NOT NULL,
+  text_tokens_in INTEGER NOT NULL DEFAULT 0,
+  text_tokens_out INTEGER NOT NULL DEFAULT 0,
+  audio_tokens_in INTEGER NOT NULL DEFAULT 0,
+  audio_tokens_out INTEGER NOT NULL DEFAULT 0,
+  cost_usd REAL NOT NULL,              -- computed at close using rates.ts
+  rates_version TEXT NOT NULL,         -- a hash/version string of rates.ts so old rows are explainable
+  transcript_path TEXT,                -- docs/superpowers/brainstorm-sessions/...
+  artifacts TEXT                       -- JSON array of files written during session
+);
+CREATE INDEX idx_voice_sessions_started ON voice_sessions(started_at);
+```
+
+### Reporting
+
+- Session-close writes one row.
+- Dashboard exposes a simple `/voice/history` view (stretch goal — not required for MVP): list of sessions with cost and artifacts. v1 just shows daily/monthly rollups inline on `/voice`.
+
+### Budget guardrails
+
+- **Today** and **This month** totals are shown; if the month passes a user-configurable threshold (env var `VOICE_MONTHLY_BUDGET_USD`, default unset), a non-blocking banner warns on session start.
+- No hard cutoff in v1. A runaway session is bounded by the 10-minute soft limit and the 15-minute Gemini hard cap.
 
 ## Session Lifecycle Edge Cases
 
-- **User closes the tab mid-session**: browser unload handler does a best-effort `sendBeacon` to `/api/voice/session-close` with the buffered transcript. If it fails, the transcript is lost — acceptable for v1.
-- **WebSocket drops unexpectedly**: show a "connection lost, reconnect?" button. No auto-reconnect in v1 (that's B territory). Transcript up to the drop is preserved and can be saved.
-- **15-minute cap approaches**: show a countdown at 2:00 remaining; at 0:15 auto-flush transcript and show "session ended — start a new one?".
-- **Tool call fails**: return a structured error to Gemini (`{ error: "..." }`). Gemini decides how to relay it verbally. Server also logs for diagnostics.
-- **Tool call times out (default 10s)**: return `{ error: "timeout" }`. `ask_mr_rogers` gets a longer budget (60s) because the Claude container may need to search, read, reason.
-- **`ask_mr_rogers` queue is busy** (e.g. a Telegram exchange in flight): queue behind it. The IPC model already serializes per-container. This means voice may pause while a text exchange completes — acceptable.
+- **Tab closes mid-session**: `beforeunload` triggers `fetch('/api/voice/session-close', { keepalive: true, body: JSON })`. Falls back to `sendBeacon` only for small payloads (≤ 48 KB). If both fail, transcript is lost; a partial session record is still written (with `transcript_path: null`) so the cost is tracked.
+- **WebSocket drops unexpectedly**: UI shows "connection lost — reconnect?" button. No auto-reconnect in v1. Transcript up to the drop is preserved and flushed to disk via `session-close` as if the user stopped.
+- **10-minute soft cap approaches**: show countdown at 2:00 remaining; at 0:30, a spoken prompt from Gemini ("we have thirty seconds left in this session") plus visual warning. At 10:00, session ends gracefully.
+- **15-minute Gemini hard cap**: Gemini closes the WS. Treated same as a user-triggered end.
+- **Tool call fails**: return `{ error: string }`. Gemini decides how to verbalize. Server logs under `voice_session_id`.
+- **Tool call times out (10 s)**: return `{ error: "timeout" }`. Server logs. No retry.
+- **Write tool conflict** (file exists, differs): return `{ error: "would overwrite <path>", existingContent: "…" }`. Gemini picks a new slug.
+- **Startup-context fetch fails**: show a prominent error and block session start. Without context the Dev Assistant provides much less value; better to fail loudly.
 
-## Environment
+## Observability
 
-Standardize on **`GEMINI_API_KEY`** for all Google AI access in universityClaw.
+A single `voice_session_id` (UUID) is generated on session start and propagated through every log line and database row for correlation.
 
-- `.env.example`: add `GEMINI_API_KEY=` under a new `# --- Google Gemini API ---` section.
-- `.env` migration: the current lowercase `google_api_key` should be renamed to `GEMINI_API_KEY` during implementation (documented in the plan).
-- Dashboard API routes read from `process.env.GEMINI_API_KEY`.
-- No container-side env changes in this spec (the container's Gemini usage, if any, is out of scope and handled by the parallel Mistral → Gemini migration).
+### Logs (structured JSON, written to `data/voice.log`)
+
+- `session.start` — persona, model, context size (bytes, tokens estimate)
+- `session.end` — reason (user_stop / tab_close / soft_cap / hard_cap / ws_drop), duration, cost
+- `tool.call` — tool name, args (summarized; no file contents), duration
+- `tool.error` — tool name, args (summarized), error
+- `usage.turn` — incremental token counts (sampled, not every turn — e.g. one log per 30 s)
+- `error.*` — any exception thrown in backend handlers
+
+### Metrics (manual for v1, prometheus-friendly names chosen for later)
+
+- `voice_sessions_total{persona, end_reason}`
+- `voice_session_duration_seconds` (histogram)
+- `voice_session_cost_usd` (histogram)
+- `voice_tool_calls_total{tool, outcome}`
+- `voice_tool_duration_seconds{tool}` (histogram)
+
+v1 does not export these to a metrics backend; the `voice_sessions` table and the log file carry the data. Adding a Prometheus endpoint is v2 if needed.
+
+## Privacy & Retention
+
+- **Brainstorm transcripts** live at `docs/superpowers/brainstorm-sessions/`. This directory is **outside the RAG indexer's watch scope** (`src/rag/indexer.ts` watches vault only; verify during implementation). They are committed to git along with other spec work; be aware when sharing a repo publicly.
+- **`voice_sessions` table** lives in `store/messages.db`. Cost and duration data only — no transcript content duplicated there.
+- **No automatic deletion** of transcripts or session records. If you want to redact a session, delete the transcript file and the row manually.
+- **Nothing leaves localhost.** Gemini's server-side retention is governed by Google's API terms; no additional copies are stored beyond what's listed here.
 
 ## Security
 
-**Current state**: dashboard has no auth (per existing deferred-auth note). Voice routes inherit that.
+**Current state**: dashboard has no auth. Voice routes inherit that.
 
 **Implications**:
 
-- `/api/voice/token` issues ephemeral tokens with minimal scope, but **anyone who reaches `localhost:3100` can mint one**. On localhost this is fine; on a LAN or public network, it leaks Gemini billing to anyone who finds the dashboard.
-- Tool routes execute real operations (vault reads, git reads, file writes) — unauthenticated access means someone on the LAN could, for example, make the Dev Assistant write a mockup that exfiltrates secrets via tailwind image URLs. Low risk on localhost; meaningful risk otherwise.
+- `/api/voice/token` will mint ephemeral tokens for anyone who can reach `localhost:3100`.
+- Tool routes execute real reads and writes to `docs/superpowers/`.
 
 **Enforcement for v1**:
 
-- Dashboard server binds to `127.0.0.1` only (verify / enforce in the plan if not already).
-- No voice features used outside localhost until dashboard auth ships.
-- A banner on `/voice` says "Localhost only — do not expose without auth" so the constraint is visible.
+- Dashboard must bind to `127.0.0.1` only. If Next.js is ever started with `-H 0.0.0.0` during development, the voice feature must refuse to serve. Implement a startup check in `token/route.ts` that reads `process.env.HOSTNAME` and the request `Host` header; return 403 if the host is not a loopback address.
+- A banner on `/voice` states: "Localhost only — do not expose without auth." The banner includes a link to the deferred dashboard-auth work.
+- Write tools already enforce path scoping and symlink escape protection (see Write scope and guards).
+- Read tools enforce their allow-list and realpath check.
 
-**Future hardening (out of scope for v1)**:
-
-- Dashboard auth (covered by the existing deferred work). Once it ships, voice routes sit behind it automatically.
-- Per-tool rate limiting on `/api/voice/tools/*`.
-- Content-Security-Policy for the mockup iframe (beyond `sandbox` attribute).
-
-## Error Handling
-
-- **Missing `GEMINI_API_KEY`**: `/api/voice/token` returns 500 with a clear error; frontend shows "Voice requires `GEMINI_API_KEY` in .env."
-- **Token mint failure** (network, quota): surface the Google error message to the user. Don't retry silently.
-- **Mic permission denied**: show inline instructions to enable it.
-- **Audio worklet fails to load**: fall back to `AudioBufferSourceNode`-based playback. Degraded but functional.
-- **Unknown tool call**: server returns `{ error: "unknown tool" }`; Gemini apologizes verbally. Logged for review.
-- **Write tool conflict** (file exists, differs): return `{ error: "would overwrite <path>", existingContent: "..." }`. Gemini can offer a new slug.
+**Out of scope for v1**: dashboard auth itself; per-tool rate limiting; CSP headers beyond the iframe sandbox attribute.
 
 ## Testing
 
-Given the real-time, audio-centric nature of this feature, test coverage focuses on the deterministic parts:
+### Unit tests (Vitest)
 
-- Unit tests (Vitest) for:
-  - Token endpoint response shape
-  - Context endpoints (with mocked file/git reads)
-  - Tool handlers with fixture vaults and temp dirs
-  - Path-guard regressions for write tools (reject slashes, traversal, bad chars, existing-file conflicts)
-  - Session-close handler for each persona (summarization mocked for Mr. Rogers)
-- Frontend unit tests for `VoiceSession` event stream (with a mocked WebSocket).
-- Integration test: manually verified — end-to-end voice loop against real Gemini with a fresh `GEMINI_API_KEY`. Not automated in v1.
+- Token endpoint response shape (mock `@google/genai`).
+- Context endpoint: mock fs + git; assert payload structure and size bounds.
+- Each tool handler: fixture repo with both allowed and denied paths; assert success, scope rejection, size cap, symlink escape rejection.
+- Path sanitization: slug regex tests (empty, too long, slashes, dots, unicode, parent traversal, trailing whitespace).
+- Session-close: assert transcript file, session row, and cost math.
+- `cost-tracker.ts`: feed recorded `usageMetadata` sequences, assert totals.
+
+### Integration test via fake WS server
+
+`dashboard/src/app/voice/tests/fake-gemini-server.ts` implements just enough of the Live protocol (config handshake, client/server content frames, tool-call/tool-response, usage metadata) for end-to-end tests. Exercise:
+
+- Connect, send a fake user turn, receive a fake assistant turn, assert captions render.
+- Tool call: fake server emits a `tool_call`, session forwards to `/api/voice/tools/dev/*`, session replies with tool response, fake server emits final assistant turn.
+- Session end: close from server side, assert `/api/voice/session-close` called with full transcript.
+- Cost tracking: fake server emits `usageMetadata`; assert live UI value updates.
+
+Replay-based tests keep the real Gemini off the hook during CI. A manual smoke test against the real service is the only step requiring a key.
+
+### Manual dogfood checklist
+
+A short checklist (committed alongside the spec) that exercises: first start from scratch, second start in same day (rollups work), tab close mid-session, hitting the soft cap, a denied read, a denied write (existing file conflict), a mockup, a diagram.
 
 ## Rollout
 
-1. Build behind a dev-only link on the dashboard nav (e.g. visible only when `NODE_ENV=development`).
-2. Dogfood for a week. Log every tool call, every transcript, every failure mode to `store/messages.db` or a voice-specific log file.
-3. Based on dogfood findings, decide which v2 items to pull forward: session resumption, tool approval UI, different default voices, captions toggle, etc.
+1. Ship behind a conditional nav link in the dashboard (`NODE_ENV=development`). No public surface.
+2. Dogfood for at least one week. Track per-session via the `voice_sessions` table.
+3. **Success criteria** for v2 planning (each measured over dogfood window):
+   - **Time-to-first-audio** ≤ 5 s in ≥ 95% of starts.
+   - **Tool error rate** ≤ 2% of tool calls (excludes user-caused denials).
+   - **Zero write-scope escapes** (no file written outside `docs/superpowers/*`).
+   - **p50 session cost** ≤ $0.50; **p95** ≤ $1.50. If these blow out, revisit context size and output modality.
+   - **Subjective usefulness**: the developer writes ≥ 3 specs/plans/mockups through the Dev Assistant and judges them worth keeping.
+4. On the basis of dogfood findings, decide the order of v2 items: Mr. Rogers Live, session resumption, cost caps, `/voice/history` page, subagent research queue.
 
-## Open Questions
+## Environment
 
-Items deliberately deferred into the implementation plan:
+- `GEMINI_API_KEY` — required. Set by the migration spec; this feature fails loudly if absent.
+- `VOICE_MONTHLY_BUDGET_USD` — optional; when set, the monthly rollup shows a warning banner above this threshold.
+- No container-side env changes.
 
-1. **`ask_mr_rogers` transport** — correlation-ID inside existing IPC vs a new dedicated channel. Plan should pick and justify.
-2. **Context injection as a `clientContent` turn vs part of the system instruction** — either works; the former lets us refresh mid-session via a new turn, the latter is simpler. Plan decides.
-3. **Audio worklet processor** — write one or use an existing open-source 16 kHz resampler. Plan surveys options.
-4. **Mockup tab iframe sandbox policy** — exact flags. Needs CSP sanity check.
-5. **Voice selection UX** — can user override the default per session, or is it hardcoded in `personas.ts`? Default: hardcoded; swap by editing config. Plan confirms.
+## Error Handling (summary)
 
-## Future Work (out of scope, noted for architecture clarity)
+| Scenario | Behavior |
+|---|---|
+| Missing `GEMINI_API_KEY` | `/api/voice/token` returns 500 with a clear message; UI shows setup hint. |
+| Token mint failure (network, quota) | Surface Google's error verbatim; do not retry silently. |
+| Mic permission denied | Inline instructions to enable; no session starts. |
+| Audio worklet fails to load | Fall back to `AudioBufferSourceNode`-based playback (degraded but functional). Log. |
+| Unknown tool | Server returns `{ error: "unknown tool" }`; Gemini apologizes verbally. Log. |
+| Denied read/write path | Server returns `{ error: "path out of scope: <path>" }`. Log. Gemini adjusts. |
+| Write file exists with diff content | Return `{ error: "would overwrite <path>" }`. Gemini picks new slug. |
+| Tab close mid-session | `fetch({ keepalive: true })` flushes transcript + record. Best effort. |
 
-- **Session resumption** — reconnect with a handle to span multiple 15-min windows. Token endpoint already reserves the param.
-- **More personas** — e.g. "Research Reader" for speed-reading sessions with Mr. Rogers, "Code Reviewer" that has write access to PR descriptions.
-- **Phone delivery** — Twilio bridge, reuse backend tool surface.
-- **Dashboard auth** — blocks network exposure of this feature.
-- **Tool approval UI** — if the Dev Assistant grows write access beyond `docs/superpowers/`.
-- **Real-time interruption tuning** — expose VAD sensitivity as a setting.
+## Open Questions (decided — no plan deferrals)
+
+The previous draft left several items as plan-deferred; they're resolved here so the plan is not blocked:
+
+- **Voice selection**: Hardcoded `Zephyr` in `personas.ts`. Reviewer can edit the file to try alternatives. Not exposed in UI.
+- **Context injection mechanism**: First `clientContent` turn after WS connect. Not part of system instruction (keeps it refreshable if we ever want to send updates mid-session).
+- **Audio worklet processor**: Custom-written 16 kHz resampler in v1 (<100 lines, no native dependency). Small enough to review and audit.
+- **Mockup iframe sandbox flags**: `allow-scripts` only (no `allow-same-origin`). Documented to the Dev Assistant via system prompt.
+
+## Future Work (out of scope)
+
+- **Mr. Rogers Live** (separate spec).
+- **Session resumption** — reconnect with a handle across multiple 15-min windows.
+- **Subagent research queue** — async task queue under `docs/superpowers/research/{pending,completed}/`.
+- **`/voice/history` page** — per-session cost, transcript, artifacts list.
+- **More personas** — e.g. a "Read-aloud" persona for listening to specs.
+- **Phone delivery** — Twilio bridge reusing the backend tool surface.
+- **Dashboard auth** — required before any network exposure.
+- **Prometheus metrics exporter** — currently `voice_sessions` table + logs.
+- **Tool approval UI** — only relevant if Dev Assistant later gains write access outside `docs/superpowers/`.
+- **VAD sensitivity controls** — expose Gemini's tuning knobs.
+
+## Relationship to Other Specs
+
+- `2026-04-18-gemini-tts-stt-migration-design.md` — parallel work renaming `google_api_key` → `GEMINI_API_KEY` and removing Mistral from the async voice-note flow. This feature requires the rename.
+- `2026-04-18-mr-rogers-live-design.md` (deferred stub) — the teaching-assistant voice persona; hybrid Gemini Live ↔ Claude container architecture. Blocked on designing a request/response IPC primitive.

--- a/docs/superpowers/specs/2026-04-18-live-voice-chat-design.md
+++ b/docs/superpowers/specs/2026-04-18-live-voice-chat-design.md
@@ -1,0 +1,327 @@
+# Live Voice Chat — Design Spec
+
+## Overview
+
+A new dashboard surface at `/voice` that enables real-time spoken conversation with two distinct personas:
+
+- **Mr. Rogers Live** — the existing teaching assistant, reachable by voice from the desk. Shares state with the Telegram Mr. Rogers so a concept discussed by voice is remembered when the next text exchange happens.
+- **Dev Assistant** — a new brainstorming partner for uniClaw feature work. Read-only on the codebase, can draft specs, plans, and HTML/mermaid mockups. Not a replacement for Claude Code; a complement for thinking out loud.
+
+Both personas share one infrastructure — a Gemini 3.1 Flash Live session opened from the browser — and differ only in system prompt, tool surface, startup context, and default voice.
+
+Separate from existing async voice flow on Telegram (voice note → transcription → agent → voice note). That flow keeps its own provider migration path and is out of scope here.
+
+## Goals
+
+- **Zero to talking in <5 seconds** — click mic, start speaking.
+- **Captions always visible** — you can reread what was just said.
+- **Preview pane** — HTML mockups and mermaid diagrams render as they are written.
+- **Transcripts preserved** — every session leaves durable artifacts.
+- **Future-friendly boundaries** — adding session resumption, phone delivery, or more personas later is additive, not a rewrite.
+
+## Non-Goals (v1)
+
+- Session resumption beyond the 15-minute Live API cap. Sessions end; you start a fresh one. The frontend abstraction leaves room for adding resumption later.
+- Phone / Twilio / mobile apps. Dashboard-only.
+- Multi-user. Single-user, localhost. No auth beyond whatever gates the dashboard itself (none today — see Security).
+- Voice cloning or custom voices. Use prebuilt Gemini voices only.
+- Tool-use approval UI for Dev writes. Mockups and specs are cheap to revert via git; an approval step adds friction without much safety gain.
+- Barge-in tuning. Use Gemini's default VAD.
+
+## Route & File Structure
+
+```
+dashboard/src/app/voice/page.tsx                           — The page (persona toggle, mic, captions, preview)
+dashboard/src/app/voice/voice-session.ts                   — VoiceSession class: WS lifecycle, audio I/O, event stream
+dashboard/src/app/voice/audio-io.ts                        — Mic capture + playback helpers (Web Audio API)
+dashboard/src/app/voice/personas.ts                        — Persona configs (system prompts, tool declarations, voice, context loader)
+dashboard/src/app/voice/preview-pane.tsx                   — Renders latest mockup (iframe) or diagram (mermaid)
+dashboard/src/app/voice/captions.tsx                       — Scrolling transcript view
+dashboard/src/app/api/voice/token/route.ts                 — Mints ephemeral token for Live API
+dashboard/src/app/api/voice/context/[persona]/route.ts     — Returns startup context payload per persona
+dashboard/src/app/api/voice/tools/[persona]/[tool]/route.ts — Executes a tool call forwarded from the browser
+dashboard/src/app/api/voice/session-close/route.ts         — Persists transcript per persona rules
+docs/superpowers/mockups/YYYY-MM-DD-<slug>.html            — Dev-written HTML+Tailwind mockups (new dir)
+docs/superpowers/mockups/YYYY-MM-DD-<slug>.md              — Dev-written mermaid diagrams (same dir, .md)
+docs/superpowers/brainstorm-sessions/YYYY-MM-DD-HHMM.md    — Dev session transcripts (new dir)
+```
+
+## Dependencies
+
+- `@google/genai` — Google Gen AI SDK (TypeScript). Used server-side for ephemeral token minting; browser uses the SDK's WebSocket client for the Live session.
+- `mermaid` — client-side diagram rendering in the preview pane.
+- No new backend services. Everything runs in the existing Next.js dashboard process.
+- `GEMINI_API_KEY` environment variable (rename of current `google_api_key`; see Environment below).
+
+## Architecture
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│ Browser (dashboard/src/app/voice/page.tsx)                    │
+│                                                                │
+│  Mic ─► PCM encode ─┐                          ┌─► Audio out  │
+│                     ▼                          │               │
+│           ┌──────────────────┐                 │               │
+│           │  VoiceSession    │────── WS ───────┼──► Gemini     │
+│           │  (voice-session) │                 │    Live API   │
+│           └─┬────────────────┘                 │    (v1alpha)  │
+│             │ onToolCall    onTranscript       │               │
+│             ▼               ▼                  │               │
+│   ┌──────────────┐    ┌──────────────┐         │               │
+│   │ Tool bridge  │    │ Captions +   │         │               │
+│   │ (fetch)      │    │ Preview pane │         │               │
+│   └──────┬───────┘    └──────────────┘         │               │
+└──────────┼─────────────────────────────────────────────────────┘
+           │
+           ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Dashboard Next.js API routes                                     │
+│                                                                  │
+│   /api/voice/token          mint ephemeral token from GEMINI_API_KEY │
+│   /api/voice/context/:p     session startup context              │
+│   /api/voice/tools/:p/:tool execute a tool call                  │
+│   /api/voice/session-close  flush transcript per persona         │
+└──────────┬──────────────────────────────────────────────────────┘
+           │
+   ┌───────┴───────────────┐
+   │                       │
+   ▼                       ▼
+┌─────────────────┐   ┌────────────────────────────┐
+│ Filesystem      │   │ NanoClaw IPC queue          │
+│ (vault, docs,   │   │ (for ask_mr_rogers only)    │
+│  git, specs)    │   │ → main Telegram group's     │
+└─────────────────┘   │   Claude container          │
+                      └────────────────────────────┘
+```
+
+## Data Flow
+
+### Session start
+
+1. User opens `/voice`, picks persona, clicks **Start**.
+2. Frontend calls `POST /api/voice/token` with `{ persona }`. Optional `resumeHandle` is accepted but ignored in v1.
+3. Backend uses `GEMINI_API_KEY` and `@google/genai` to request an ephemeral token bound to the persona's model config. Returns `{ token, expiresAt }`.
+4. Frontend calls `GET /api/voice/context/:persona` to fetch startup context (see Personas below).
+5. `VoiceSession` opens a WebSocket to Gemini at the `v1alpha` endpoint using the ephemeral token. Session config includes:
+   - Model: `gemini-3.1-flash-live-preview`
+   - Response modalities: `["AUDIO"]`
+   - System instruction (persona-specific)
+   - Tool declarations (persona-specific)
+   - `inputAudioTranscription: {}`, `outputAudioTranscription: {}` (for captions)
+   - Voice config (persona-specific)
+6. Immediately after connecting, `VoiceSession` sends a `clientContent` turn containing the fetched startup context, then unmutes the mic.
+
+### Talking
+
+1. Browser captures mic audio, resamples/encodes to **16-bit PCM, 16 kHz, little-endian**, mono.
+2. `VoiceSession.sendRealtimeInput({ audio: { mimeType: 'audio/pcm;rate=16000', data: base64Chunk } })` streams chunks to Gemini.
+3. Gemini streams back `serverContent` events with 24 kHz PCM audio data + transcription events.
+4. `audio-io.ts` buffers and plays incoming PCM via a Web Audio `AudioWorklet`.
+5. Transcription events update the captions component.
+6. When Gemini emits a `toolCall`, `VoiceSession` forwards it to `POST /api/voice/tools/:persona/:tool` with the tool's args. The backend executes the tool and returns JSON. `VoiceSession` replies to Gemini with `toolResponse`.
+7. Mockup/diagram tool calls return a file path; the preview pane reloads to display it.
+
+### Session end
+
+Triggered by: user click **Stop**, tab close, 15-minute cap, or WebSocket disconnect.
+
+1. `VoiceSession` emits `onSessionEnd({ transcript, persona, startedAt, endedAt })`.
+2. Frontend `POST /api/voice/session-close` with the payload.
+3. Server-side persistence branches by persona (see Transcript Handling).
+
+## Personas
+
+### Mr. Rogers Live
+
+**Backend**: Hybrid. Gemini handles conversation; the `ask_mr_rogers` tool delegates to the existing Claude container for anything that needs memory or vault writes.
+
+**Scope**: Shared with the main Telegram group. Context flows both ways (voice → Telegram memory → voice).
+
+**Default voice**: `Aoede` (warm, conversational).
+
+**System prompt (sketch)**:
+> You are Mr. Rogers, the student's personal teaching assistant, speaking with them by voice at their desk. You already know them well from prior exchanges — the context block below contains their current study state. Speak naturally and conversationally, as in a tutoring session. Keep turns short. Ask what they want to work on before explaining. When they ask about a concept, check the vault first (`search_vault`, `read_note`). Use `search_rag` for synthesis across sources. For anything that needs durable memory, planning, or vault writes, call `ask_mr_rogers` — that reaches your "slower self" which maintains the student profile.
+
+**Startup context**:
+
+Fetched by `/api/voice/context/mr-rogers`. Contains:
+- Today's study plan entries (from the plan DB)
+- Last 10 concepts practiced (from study log)
+- Open questions / gaps flagged in the student profile
+- Timestamp
+
+Delivered as a `clientContent` turn: `Here's where you left off: [context JSON]`. Not read aloud; Gemini keeps it in context.
+
+**Tool surface**:
+
+| Tool | Args | Returns | Scope |
+|---|---|---|---|
+| `search_vault` | `{ query: string, limit?: number }` | `{ matches: Array<{path, snippet}> }` | Read |
+| `read_note` | `{ path: string }` | `{ content: string, frontmatter: object }` | Read |
+| `search_rag` | `{ query: string, mode?: 'hybrid'\|'local'\|'global' }` | `{ answer: string, sources: string[] }` | Read |
+| `get_study_state` | `{}` | `{ plan, recentConcepts, openQuestions }` | Read (same as startup context, on-demand) |
+| `ask_mr_rogers` | `{ question: string, context?: string }` | `{ answer: string }` | Delegate to Claude container |
+
+The `ask_mr_rogers` tool posts a synthetic message into the main group's IPC queue with a `[voice-session]` tag, then polls / awaits the container's response. Implementation detail to be worked out in the plan: either reuse the existing message-response flow with a dedicated correlation ID, or add a direct blocking IPC path keyed on a request ID. The correlation-ID approach fits the existing IPC model; the plan should prefer it unless there's a reason not to.
+
+### Dev Assistant
+
+**Backend**: Gemini direct. No Claude container.
+
+**Scope**: Isolated. No access to `groups/`, vault, RAG, study system, or `src/`/`container/`/`dashboard/` for writes.
+
+**Default voice**: `Zephyr` (clear, neutral).
+
+**System prompt (sketch)**:
+> You are a design and brainstorming partner for uniClaw (a personal Claude assistant / teaching platform fork of NanoClaw). The developer you're speaking with is building features for it. You have read access to the codebase and docs, and write access scoped to `docs/superpowers/specs/`, `docs/superpowers/plans/`, and `docs/superpowers/mockups/` only. You do NOT touch source code. When drafting specs or plans, follow the structure of existing files in those directories. For mockups, produce single-file HTML with Tailwind via CDN. For architecture or flow questions, prefer mermaid diagrams over prose. Keep spoken turns short. Think out loud. Ask about constraints before writing.
+
+**Startup context**:
+
+Fetched by `/api/voice/context/dev`. Contains:
+- Current git branch
+- `git status` (short form)
+- Last 10 commits (subject line only)
+- List of spec filenames in `docs/superpowers/specs/`
+- List of plan filenames in `docs/superpowers/plans/`
+- Timestamp
+
+**Tool surface**:
+
+| Tool | Args | Returns | Scope |
+|---|---|---|---|
+| `read_file` | `{ path: string }` | `{ content: string }` | Read; path must be within repo |
+| `glob` | `{ pattern: string }` | `{ paths: string[] }` | Read |
+| `grep` | `{ pattern: string, path?: string, glob?: string }` | `{ matches: Array<{path, line, text}> }` | Read |
+| `git_log` | `{ limit?: number, path?: string }` | `{ commits: Array<{sha, subject, date, author}> }` | Read |
+| `git_status` | `{}` | `{ branch, staged, modified, untracked }` | Read |
+| `list_specs` | `{}` | `{ specs: string[], plans: string[] }` | Read |
+| `write_spec` | `{ slug: string, content: string }` | `{ path: string }` | Write to `docs/superpowers/specs/YYYY-MM-DD-<slug>.md` |
+| `write_plan` | `{ slug: string, content: string }` | `{ path: string }` | Write to `docs/superpowers/plans/YYYY-MM-DD-<slug>.md` |
+| `write_mockup` | `{ slug: string, html: string }` | `{ path: string, previewUrl: string }` | Write to `docs/superpowers/mockups/YYYY-MM-DD-<slug>.html` |
+| `write_diagram` | `{ slug: string, mermaid: string, title?: string }` | `{ path: string, previewUrl: string }` | Write to `docs/superpowers/mockups/YYYY-MM-DD-<slug>.md` with mermaid block |
+
+**Path guards** on all write tools:
+- Slug sanitized to `[a-z0-9-]+`, trimmed, max 80 chars.
+- Generated filename is fully controlled by the server; Gemini's `slug` arg never contains a path separator or parent traversal.
+- Refuse if the resulting file already exists and contents differ (don't overwrite silently). Provide a `replace: true` flag only if we later decide to support iteration on the same slug.
+
+## Preview Pane
+
+A tabbed side panel within `/voice`:
+
+- **Mockup tab** — renders latest `write_mockup` in a sandboxed `<iframe srcDoc={html}>`. Sandboxed with `allow-scripts` so Tailwind CDN works, no `allow-same-origin`.
+- **Diagram tab** — renders latest `write_diagram` using client-side `mermaid.js` initialized on mount.
+- **History** — a dropdown listing all files written during this session. Selecting one swaps the tab content.
+
+Files persist on disk; history is session-scoped only (resets when you leave the page). Grepping `docs/superpowers/mockups/` recovers anything you produced in prior sessions.
+
+## Captions
+
+Scrolling transcript pane beneath the mic controls:
+
+- Input transcription (what the user said) — left-aligned, muted text.
+- Output transcription (what Gemini said) — left-aligned, normal text, prefixed with the persona name.
+- Auto-scroll to bottom on new content; pin-to-bottom toggle if user scrolls up.
+- Copy-session button copies the full transcript to clipboard.
+
+Captions update in real time as transcription events arrive over the WebSocket.
+
+## Transcript Handling (session close)
+
+### Mr. Rogers
+
+1. Session-close handler calls `ask_mr_rogers` one more time with the full transcript and a prompt like: *"Summarize this voice tutoring session into 2–5 bullet points for your long-term log. Focus on: concepts practiced, what the student struggled with, what to revisit next."*
+2. Writes the summary as a single message into the main group's conversation log with metadata: `{ origin: 'voice-session', startedAt, endedAt, transcriptPath? }`.
+3. Optionally also writes the full transcript to a side file (e.g., `groups/{main}/voice-archive/YYYY-MM-DD-HHMM.md`) so it's available for manual review but doesn't flood the agent's context. Default: yes. Storage cost is negligible.
+
+### Dev Assistant
+
+1. Session-close handler writes the full verbatim transcript to `docs/superpowers/brainstorm-sessions/YYYY-MM-DD-HHMM.md`.
+2. The file's frontmatter lists any spec/plan/mockup/diagram files written during the session so they're cross-referenced.
+3. No summarization step. Raw brainstorms are more valuable than summaries for dev work.
+
+## Session Lifecycle Edge Cases
+
+- **User closes the tab mid-session**: browser unload handler does a best-effort `sendBeacon` to `/api/voice/session-close` with the buffered transcript. If it fails, the transcript is lost — acceptable for v1.
+- **WebSocket drops unexpectedly**: show a "connection lost, reconnect?" button. No auto-reconnect in v1 (that's B territory). Transcript up to the drop is preserved and can be saved.
+- **15-minute cap approaches**: show a countdown at 2:00 remaining; at 0:15 auto-flush transcript and show "session ended — start a new one?".
+- **Tool call fails**: return a structured error to Gemini (`{ error: "..." }`). Gemini decides how to relay it verbally. Server also logs for diagnostics.
+- **Tool call times out (default 10s)**: return `{ error: "timeout" }`. `ask_mr_rogers` gets a longer budget (60s) because the Claude container may need to search, read, reason.
+- **`ask_mr_rogers` queue is busy** (e.g. a Telegram exchange in flight): queue behind it. The IPC model already serializes per-container. This means voice may pause while a text exchange completes — acceptable.
+
+## Environment
+
+Standardize on **`GEMINI_API_KEY`** for all Google AI access in universityClaw.
+
+- `.env.example`: add `GEMINI_API_KEY=` under a new `# --- Google Gemini API ---` section.
+- `.env` migration: the current lowercase `google_api_key` should be renamed to `GEMINI_API_KEY` during implementation (documented in the plan).
+- Dashboard API routes read from `process.env.GEMINI_API_KEY`.
+- No container-side env changes in this spec (the container's Gemini usage, if any, is out of scope and handled by the parallel Mistral → Gemini migration).
+
+## Security
+
+**Current state**: dashboard has no auth (per existing deferred-auth note). Voice routes inherit that.
+
+**Implications**:
+
+- `/api/voice/token` issues ephemeral tokens with minimal scope, but **anyone who reaches `localhost:3100` can mint one**. On localhost this is fine; on a LAN or public network, it leaks Gemini billing to anyone who finds the dashboard.
+- Tool routes execute real operations (vault reads, git reads, file writes) — unauthenticated access means someone on the LAN could, for example, make the Dev Assistant write a mockup that exfiltrates secrets via tailwind image URLs. Low risk on localhost; meaningful risk otherwise.
+
+**Enforcement for v1**:
+
+- Dashboard server binds to `127.0.0.1` only (verify / enforce in the plan if not already).
+- No voice features used outside localhost until dashboard auth ships.
+- A banner on `/voice` says "Localhost only — do not expose without auth" so the constraint is visible.
+
+**Future hardening (out of scope for v1)**:
+
+- Dashboard auth (covered by the existing deferred work). Once it ships, voice routes sit behind it automatically.
+- Per-tool rate limiting on `/api/voice/tools/*`.
+- Content-Security-Policy for the mockup iframe (beyond `sandbox` attribute).
+
+## Error Handling
+
+- **Missing `GEMINI_API_KEY`**: `/api/voice/token` returns 500 with a clear error; frontend shows "Voice requires `GEMINI_API_KEY` in .env."
+- **Token mint failure** (network, quota): surface the Google error message to the user. Don't retry silently.
+- **Mic permission denied**: show inline instructions to enable it.
+- **Audio worklet fails to load**: fall back to `AudioBufferSourceNode`-based playback. Degraded but functional.
+- **Unknown tool call**: server returns `{ error: "unknown tool" }`; Gemini apologizes verbally. Logged for review.
+- **Write tool conflict** (file exists, differs): return `{ error: "would overwrite <path>", existingContent: "..." }`. Gemini can offer a new slug.
+
+## Testing
+
+Given the real-time, audio-centric nature of this feature, test coverage focuses on the deterministic parts:
+
+- Unit tests (Vitest) for:
+  - Token endpoint response shape
+  - Context endpoints (with mocked file/git reads)
+  - Tool handlers with fixture vaults and temp dirs
+  - Path-guard regressions for write tools (reject slashes, traversal, bad chars, existing-file conflicts)
+  - Session-close handler for each persona (summarization mocked for Mr. Rogers)
+- Frontend unit tests for `VoiceSession` event stream (with a mocked WebSocket).
+- Integration test: manually verified — end-to-end voice loop against real Gemini with a fresh `GEMINI_API_KEY`. Not automated in v1.
+
+## Rollout
+
+1. Build behind a dev-only link on the dashboard nav (e.g. visible only when `NODE_ENV=development`).
+2. Dogfood for a week. Log every tool call, every transcript, every failure mode to `store/messages.db` or a voice-specific log file.
+3. Based on dogfood findings, decide which v2 items to pull forward: session resumption, tool approval UI, different default voices, captions toggle, etc.
+
+## Open Questions
+
+Items deliberately deferred into the implementation plan:
+
+1. **`ask_mr_rogers` transport** — correlation-ID inside existing IPC vs a new dedicated channel. Plan should pick and justify.
+2. **Context injection as a `clientContent` turn vs part of the system instruction** — either works; the former lets us refresh mid-session via a new turn, the latter is simpler. Plan decides.
+3. **Audio worklet processor** — write one or use an existing open-source 16 kHz resampler. Plan surveys options.
+4. **Mockup tab iframe sandbox policy** — exact flags. Needs CSP sanity check.
+5. **Voice selection UX** — can user override the default per session, or is it hardcoded in `personas.ts`? Default: hardcoded; swap by editing config. Plan confirms.
+
+## Future Work (out of scope, noted for architecture clarity)
+
+- **Session resumption** — reconnect with a handle to span multiple 15-min windows. Token endpoint already reserves the param.
+- **More personas** — e.g. "Research Reader" for speed-reading sessions with Mr. Rogers, "Code Reviewer" that has write access to PR descriptions.
+- **Phone delivery** — Twilio bridge, reuse backend tool surface.
+- **Dashboard auth** — blocks network exposure of this feature.
+- **Tool approval UI** — if the Dev Assistant grows write access beyond `docs/superpowers/`.
+- **Real-time interruption tuning** — expose VAD sensitivity as a setting.

--- a/docs/superpowers/specs/2026-04-18-mr-rogers-live-design.md
+++ b/docs/superpowers/specs/2026-04-18-mr-rogers-live-design.md
@@ -1,0 +1,79 @@
+# Mr. Rogers Live — Design Spec (Deferred Stub)
+
+**Status**: deferred. Blocked on designing a request/response IPC primitive between the dashboard and the per-group Claude Agent SDK container. This document captures the intended architecture and the open problem so we can return to it later without re-deriving the context.
+
+## Why deferred
+
+A subagent review of the initial combined voice-chat spec identified the `ask_mr_rogers` transport as a load-bearing unknown:
+
+1. Existing IPC (`src/ipc.ts`) is a one-way filesystem-drop protocol. The container writes JSON files; the host picks them up and applies them. **There is no existing request/response correlation primitive.** `study_concept_status` writes to `ipc/{group}/responses/` but nothing reads those back for a waiting caller.
+2. The main-group Claude container is already shared with Telegram. `GroupQueue.enqueueMessageCheck` uses a boolean `pendingMessages` flag to signal "more work to do," not a FIFO of distinct prompts. Injecting a voice-originated tool call while a Telegram turn is in flight does not give back a typed response; it's absorbed into the next Telegram-shaped reply.
+3. Gemini's tool-call timeout is ~60 s. A Claude container vault search + reasoning turn can take 30–120 s. Without a dedicated blocking RPC path, `ask_mr_rogers` tool calls will time out and the "real" answer will appear in the Telegram chat minutes later — not the intended UX.
+4. Runaway-loop risk: Gemini Live audio output is expensive; `ask_mr_rogers` → Claude → vault + RAG → text → Gemini narrates → user asks follow-up creates a multiplicative cost path. No cap, no budget estimate, no loop guard in the current design.
+
+Addressing these requires a new IPC primitive, not a small reuse. That design work is deliberately **separated from** the v1 voice feature (`2026-04-18-live-voice-chat-design.md`), which ships the Dev Assistant persona using Gemini Live alone.
+
+## Intended architecture (sketch, unchanged from earlier brainstorm)
+
+- **Voice face**: the same `VoiceSession` + `/voice` page infrastructure shipped in v1. Gemini 3.1 Flash Live is the conversational agent.
+- **Hybrid tool**: a new tool `ask_mr_rogers(question)` added to the Mr. Rogers persona config. Gemini Live handles natural back-and-forth natively; the tool is the escape hatch for anything that needs memory, vault writes, study-system state, or planning.
+- **Backend of the tool**: posts the question into the main Telegram group's Claude container, awaits the container's response, returns it to Gemini.
+- **Shared state**: by design, voice turns flow into the main group's conversation log (scope A from the earlier brainstorm). A voice session ends with a summary written via `ask_mr_rogers` → a single log entry tagged `[voice-session]` with metadata, plus a full archive at `groups/{main}/voice-archive/YYYY-MM-DD-HHMM.md`.
+- **Startup context**: today's plan, recent concepts, open questions from the student profile. Injected via the same `clientContent` first-turn mechanism as the Dev Assistant.
+- **Default voice**: `Aoede` (warmer) vs Dev's `Zephyr`.
+
+## Open problems (must be resolved before a real plan)
+
+### 1. Request/response IPC primitive
+
+The central design problem. Candidate approaches:
+
+- **Correlation-ID over existing IPC**: caller drops a `requests/<id>.json`; container picks it up, produces `responses/<id>.json`; host polls. Matches the existing model but requires a **new host-side poller** that correlates, times out, and resolves a promise. Not free, but fits the pattern.
+- **Direct HTTP surface from the container**: the agent-runner exposes a small HTTP endpoint (inside the container) that the dashboard calls with a correlation ID, and the container answers synchronously. Requires plumbing the container's port out to the host, which is a larger architectural change.
+- **Dedicated voice-tool container**: spin up a second container per voice session that only handles `ask_mr_rogers` calls, with its own short-lived IPC. Isolates voice from the main-group's Telegram turns at the cost of doubled container spawn latency and separate memory state.
+
+The choice has implications for reliability, latency, cost, and whether voice and Telegram can run in parallel. Worth an agent-run design exploration before committing.
+
+### 2. Container contention with Telegram
+
+Even with a blocking RPC, two agents sharing the same container state (voice and Telegram) may race. Options:
+
+- Serialize via the existing `GroupQueue` and accept voice-pauses-Telegram and vice versa. Document the UX consequence ("if a Telegram message is mid-flight, voice tool calls queue behind it and may time out").
+- Use a separate container for voice tool calls (see option 3 above), at the cost of fragmented conversation memory.
+- Add a priority lane to `GroupQueue` so interactive voice preempts background Telegram work. Introduces fairness concerns.
+
+### 3. Cost and runaway-loop guards
+
+- Per-session `ask_mr_rogers` invocation cap (e.g. 10 per session).
+- Per-session token/dollar cap driven by the `voice_sessions` cost tracker built in v1.
+- Hard end-of-session trigger if cumulative cost crosses a configurable threshold (auto-stop with a spoken notice).
+
+### 4. Log-pollution vs continuity tradeoff
+
+Voice turns landing in the Telegram log is the whole point of "shared scope," but it also means that opening Telegram will show a summary of a voice session the user might have forgotten. Needs an explicit UX decision: summary only? Full transcript linked? Neither, and voice stays out of the group log by default?
+
+### 5. Voice + Telegram collision UX
+
+User types on Telegram while a voice session is running. What happens?
+
+- Both go to the same container (serialized), so one blocks the other.
+- Voice transcribed captions could echo in Telegram or vice versa.
+- Or: block text input on Telegram while a voice session is active.
+
+All of these are product decisions, not engineering ones, and should be answered before the plan.
+
+## Prerequisites
+
+1. Voice infrastructure shipped (v1 `2026-04-18-live-voice-chat-design.md`).
+2. Gemini TTS/STT migration shipped (`2026-04-18-gemini-tts-stt-migration-design.md`) — specifically the `GEMINI_API_KEY` rename.
+3. IPC request/response primitive designed, built, and tested in isolation (likely its own spec under a name like `2026-xx-xx-container-rpc-design.md`).
+4. Product answers to the five open problems above.
+
+## When to revive
+
+After v1 dogfood delivers clear signal that the Dev Assistant is useful, AND an IPC primitive has been designed. Not before.
+
+## Relationship to Other Specs
+
+- `2026-04-18-live-voice-chat-design.md` — v1 voice infrastructure and Dev Assistant persona. Provides `/voice`, `VoiceSession`, cost tracking, preview pane, transcript handling — all reusable.
+- `2026-04-18-gemini-tts-stt-migration-design.md` — `GEMINI_API_KEY` env var required.

--- a/docs/voice-dogfood-checklist.md
+++ b/docs/voice-dogfood-checklist.md
@@ -4,6 +4,21 @@ Manual exercise of the `/voice` Dev Assistant. Tick each item once per dogfood
 pass. If any row fails, open a GitHub issue rather than patching scope-creep
 items into the current PR.
 
+> ⚠️ **v1 status — fake server only.** The browser WebSocket client speaks
+> an opaque-JSON frame format (`{type: 'audio'|'usage'|'tool_call'|…}`) that
+> matches the in-repo fake Gemini server, not the real Gemini Live
+> `BidiGenerateContent` wire protocol. The `VoiceSession.start()` path that
+> builds `wss://generativelanguage.googleapis.com/?access_token=…` is a
+> placeholder. **A real GEMINI_API_KEY will not make a working session
+> until the v1.1 real-Gemini adapter lands** (uses `@google/genai`'s
+> `ai.live.connect()` and mirrors the real `serverContent` / `toolCall` /
+> `usageMetadata` frame shapes).
+>
+> Everything except the live-audio path is usable today: token minting, the
+> tool dispatcher + scope guards, session-close persistence, cost rollups,
+> fake-server e2e. Dogfooding the UI, tools, and cost plumbing is valuable
+> groundwork before the adapter lands.
+
 ## Environment
 
 - [ ] `GEMINI_API_KEY` is set in `.env` (or falls back to legacy `google_api_key`).

--- a/docs/voice-dogfood-checklist.md
+++ b/docs/voice-dogfood-checklist.md
@@ -1,0 +1,54 @@
+# Voice Dogfood Checklist
+
+Manual exercise of the `/voice` Dev Assistant. Tick each item once per dogfood
+pass. If any row fails, open a GitHub issue rather than patching scope-creep
+items into the current PR.
+
+## Environment
+
+- [ ] `GEMINI_API_KEY` is set in `.env` (or falls back to legacy `google_api_key`).
+- [ ] Dashboard is running at `http://localhost:3100`.
+- [ ] Browser is Chromium-based (Chrome, Edge, Arc) — Gemini Live needs Web Audio + AudioWorklet.
+
+## Golden path (first start)
+
+- [ ] Click **Start** — browser prompts for microphone permission.
+- [ ] Localhost-only amber banner is visible in the page header.
+- [ ] Session timer starts counting up.
+- [ ] Speak; my words appear in the transcript as the assistant listens.
+- [ ] Assistant replies; audio plays; caption shows assistant turn.
+- [ ] Cost panel (session) ticks up as usage metadata arrives.
+- [ ] Today and This month rollups show non-zero after my first turn.
+
+## Tools
+
+- [ ] Ask the assistant to read a file (e.g. `src/config.ts`); response references concrete lines.
+- [ ] Ask for a `grep` — response cites `path:line` rows.
+- [ ] Ask for a `git_status` — response mentions the current branch.
+- [ ] Ask to write a mockup (`write_mockup`). Preview pane loads it in the iframe.
+- [ ] Ask to write a mermaid diagram (`write_diagram`). Diagram tab renders it.
+- [ ] Ask to write a spec (`write_spec`). File appears under `docs/superpowers/specs/YYYY-MM-DD-<slug>.md`.
+
+## Denials (security sanity)
+
+- [ ] Ask it to `read_file .env` — assistant verbalises a polite "out of scope" (server returns `{ error }`).
+- [ ] Ask it to write a spec with an uppercase slug (e.g. `BadSlug`) — assistant acknowledges slug rejection.
+- [ ] Ask it to overwrite an existing spec with different content — server returns `would overwrite`, assistant picks a new slug.
+
+## Session lifecycle
+
+- [ ] Click **Mute** — assistant stops hearing you mid-sentence.
+- [ ] Click **Unmute** — continues naturally.
+- [ ] Click **Stop** — session ends cleanly; transcript is saved to `docs/superpowers/brainstorm-sessions/`.
+- [ ] Row appears in `store/messages.db` `voice_sessions` table with matching `id`.
+- [ ] Open a new tab and start a second session — Today rollup includes both.
+
+## Edge cases
+
+- [ ] Close the browser tab mid-session — `voice_sessions` row still lands (best-effort flush via `fetch({keepalive:true})`).
+- [ ] Approach the 10-minute soft cap — session auto-ends with `endReason: 'soft_cap'`.
+- [ ] Set `VOICE_MONTHLY_BUDGET_USD` below the current monthly total — amber banner surfaces on next reload.
+
+## Privacy
+
+- [ ] Confirm `docs/superpowers/brainstorm-sessions/` is NOT indexed by RAG (`grep -n superpowers src/rag/indexer.ts` returns nothing).

--- a/drizzle/migrations/0003_dry_caretaker.sql
+++ b/drizzle/migrations/0003_dry_caretaker.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `voice_sessions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`persona` text NOT NULL,
+	`started_at` text NOT NULL,
+	`ended_at` text NOT NULL,
+	`duration_seconds` integer NOT NULL,
+	`text_tokens_in` integer DEFAULT 0 NOT NULL,
+	`text_tokens_out` integer DEFAULT 0 NOT NULL,
+	`audio_tokens_in` integer DEFAULT 0 NOT NULL,
+	`audio_tokens_out` integer DEFAULT 0 NOT NULL,
+	`cost_usd` real NOT NULL,
+	`rates_version` text NOT NULL,
+	`transcript_path` text,
+	`artifacts` text
+);
+--> statement-breakpoint
+CREATE INDEX `idx_voice_sessions_started` ON `voice_sessions` (`started_at`);

--- a/drizzle/migrations/meta/0003_snapshot.json
+++ b/drizzle/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1855 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ee250c6d-b8e8-4177-99eb-fcbcee3d1954",
+  "prevId": "31c93c9f-559e-495e-9e04-4afd795fe790",
+  "tables": {
+    "chats": {
+      "name": "chats",
+      "columns": {
+        "jid": {
+          "name": "jid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_message_time": {
+          "name": "last_message_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_group": {
+          "name": "is_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_jid": {
+          "name": "chat_jid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender": {
+          "name": "sender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sender_name": {
+          "name": "sender_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_from_me": {
+          "name": "is_from_me",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_bot_message": {
+          "name": "is_bot_message",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_timestamp": {
+          "name": "idx_timestamp",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_chat_jid_chats_jid_fk": {
+          "name": "messages_chat_jid_chats_jid_fk",
+          "tableFrom": "messages",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_jid"
+          ],
+          "columnsTo": [
+            "jid"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "messages_id_chat_jid_pk": {
+          "columns": [
+            "id",
+            "chat_jid"
+          ],
+          "name": "messages_id_chat_jid_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "citation_edges": {
+      "name": "citation_edges",
+      "columns": {
+        "source_slug": {
+          "name": "source_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_slug": {
+          "name": "target_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_citation_target": {
+          "name": "idx_citation_target",
+          "columns": [
+            "target_slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "citation_edges_source_slug_target_slug_pk": {
+          "columns": [
+            "source_slug",
+            "target_slug"
+          ],
+          "name": "citation_edges_source_slug_target_slug_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "registered_groups": {
+      "name": "registered_groups",
+      "columns": {
+        "jid": {
+          "name": "jid",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder": {
+          "name": "folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trigger_pattern": {
+          "name": "trigger_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "container_config": {
+          "name": "container_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requires_trigger": {
+          "name": "requires_trigger",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "registered_groups_folder_unique": {
+          "name": "registered_groups_folder_unique",
+          "columns": [
+            "folder"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "group_folder": {
+          "name": "group_folder",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ingestion_jobs": {
+      "name": "ingestion_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_filename": {
+          "name": "source_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "extraction_path": {
+          "name": "extraction_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'upload'"
+        },
+        "zotero_key": {
+          "name": "zotero_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "zotero_metadata": {
+          "name": "zotero_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_after": {
+          "name": "retry_after",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "promoted_paths": {
+          "name": "promoted_paths",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_ingestion_jobs_status": {
+          "name": "idx_ingestion_jobs_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_ingestion_jobs_source_path": {
+          "name": "idx_ingestion_jobs_source_path",
+          "columns": [
+            "source_path"
+          ],
+          "isUnique": false
+        },
+        "idx_ingestion_jobs_hash": {
+          "name": "idx_ingestion_jobs_hash",
+          "columns": [
+            "content_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rag_index_tracker": {
+      "name": "rag_index_tracker",
+      "columns": {
+        "vault_path": {
+          "name": "vault_path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "indexed_at": {
+          "name": "indexed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_rag_tracker_doc_id": {
+          "name": "idx_rag_tracker_doc_id",
+          "columns": [
+            "doc_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "router_state": {
+      "name": "router_state",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "zotero_sync": {
+      "name": "zotero_sync",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity_concepts": {
+      "name": "activity_concepts",
+      "columns": {
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'related'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "activity_concepts_activity_id_learning_activities_id_fk": {
+          "name": "activity_concepts_activity_id_learning_activities_id_fk",
+          "tableFrom": "activity_concepts",
+          "tableTo": "learning_activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_concepts_concept_id_concepts_id_fk": {
+          "name": "activity_concepts_concept_id_concepts_id_fk",
+          "tableFrom": "activity_concepts",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "activity_concepts_activity_id_concept_id_pk": {
+          "columns": [
+            "activity_id",
+            "concept_id"
+          ],
+          "name": "activity_concepts_activity_id_concept_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "activity_log": {
+      "name": "activity_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bloom_level": {
+          "name": "bloom_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response_text": {
+          "name": "response_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_time_ms": {
+          "name": "response_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence_rating": {
+          "name": "confidence_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scaffolding_level": {
+          "name": "scaffolding_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "evaluation_method": {
+          "name": "evaluation_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'self_rated'"
+        },
+        "ai_quality": {
+          "name": "ai_quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_feedback": {
+          "name": "ai_feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "method_used": {
+          "name": "method_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_log_concept": {
+          "name": "idx_log_concept",
+          "columns": [
+            "concept_id"
+          ],
+          "isUnique": false
+        },
+        "idx_log_session": {
+          "name": "idx_log_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_log_bloom": {
+          "name": "idx_log_bloom",
+          "columns": [
+            "bloom_level"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "activity_log_activity_id_learning_activities_id_fk": {
+          "name": "activity_log_activity_id_learning_activities_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "learning_activities",
+          "columnsFrom": [
+            "activity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_log_concept_id_concepts_id_fk": {
+          "name": "activity_log_concept_id_concepts_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "activity_log_session_id_study_sessions_id_fk": {
+          "name": "activity_log_session_id_study_sessions_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "study_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "concept_prerequisites": {
+      "name": "concept_prerequisites",
+      "columns": {
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prerequisite_id": {
+          "name": "prerequisite_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "concept_prerequisites_concept_id_concepts_id_fk": {
+          "name": "concept_prerequisites_concept_id_concepts_id_fk",
+          "tableFrom": "concept_prerequisites",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "concept_prerequisites_prerequisite_id_concepts_id_fk": {
+          "name": "concept_prerequisites_prerequisite_id_concepts_id_fk",
+          "tableFrom": "concept_prerequisites",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "prerequisite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "concept_prerequisites_concept_id_prerequisite_id_pk": {
+          "columns": [
+            "concept_id",
+            "prerequisite_id"
+          ],
+          "name": "concept_prerequisites_concept_id_prerequisite_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "concepts": {
+      "name": "concepts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subdomain": {
+          "name": "subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course": {
+          "name": "course",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vault_note_path": {
+          "name": "vault_note_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "mastery_L1": {
+          "name": "mastery_L1",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "mastery_L2": {
+          "name": "mastery_L2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "mastery_L3": {
+          "name": "mastery_L3",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "mastery_L4": {
+          "name": "mastery_L4",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "mastery_L5": {
+          "name": "mastery_L5",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "mastery_L6": {
+          "name": "mastery_L6",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "mastery_overall": {
+          "name": "mastery_overall",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bloom_ceiling": {
+          "name": "bloom_ceiling",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_concepts_domain": {
+          "name": "idx_concepts_domain",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": false
+        },
+        "idx_concepts_status": {
+          "name": "idx_concepts_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "learning_activities": {
+      "name": "learning_activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_answer": {
+          "name": "reference_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bloom_level": {
+          "name": "bloom_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "difficulty_estimate": {
+          "name": "difficulty_estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "card_type": {
+          "name": "card_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "source_note_path": {
+          "name": "source_note_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_chunk_hash": {
+          "name": "source_chunk_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ease_factor": {
+          "name": "ease_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 2.5
+        },
+        "interval_days": {
+          "name": "interval_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_reviewed": {
+          "name": "last_reviewed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_quality": {
+          "name": "last_quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mastery_state": {
+          "name": "mastery_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'new'"
+        }
+      },
+      "indexes": {
+        "idx_activities_due": {
+          "name": "idx_activities_due",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "idx_activities_concept": {
+          "name": "idx_activities_concept",
+          "columns": [
+            "concept_id"
+          ],
+          "isUnique": false
+        },
+        "idx_activities_type": {
+          "name": "idx_activities_type",
+          "columns": [
+            "activity_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "learning_activities_concept_id_concepts_id_fk": {
+          "name": "learning_activities_concept_id_concepts_id_fk",
+          "tableFrom": "learning_activities",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "study_plan_concepts": {
+      "name": "study_plan_concepts",
+      "columns": {
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "concept_id": {
+          "name": "concept_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_bloom": {
+          "name": "target_bloom",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 6
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "study_plan_concepts_plan_id_study_plans_id_fk": {
+          "name": "study_plan_concepts_plan_id_study_plans_id_fk",
+          "tableFrom": "study_plan_concepts",
+          "tableTo": "study_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "study_plan_concepts_concept_id_concepts_id_fk": {
+          "name": "study_plan_concepts_concept_id_concepts_id_fk",
+          "tableFrom": "study_plan_concepts",
+          "tableTo": "concepts",
+          "columnsFrom": [
+            "concept_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "study_plan_concepts_plan_id_concept_id_pk": {
+          "columns": [
+            "plan_id",
+            "concept_id"
+          ],
+          "name": "study_plan_concepts_plan_id_concept_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "study_plans": {
+      "name": "study_plans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "course": {
+          "name": "course",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "learning_objectives": {
+          "name": "learning_objectives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "desired_outcomes": {
+          "name": "desired_outcomes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "implementation_intention": {
+          "name": "implementation_intention",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "obstacle": {
+          "name": "obstacle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "study_schedule": {
+          "name": "study_schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checkpoint_interval_days": {
+          "name": "checkpoint_interval_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 14
+        },
+        "next_checkpoint_at": {
+          "name": "next_checkpoint_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "study_sessions": {
+      "name": "study_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_type": {
+          "name": "session_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pre_confidence": {
+          "name": "pre_confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_reflection": {
+          "name": "post_reflection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "calibration_score": {
+          "name": "calibration_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "activities_completed": {
+          "name": "activities_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_time_ms": {
+          "name": "total_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "study_sessions_plan_id_study_plans_id_fk": {
+          "name": "study_sessions_plan_id_study_plans_id_fk",
+          "tableFrom": "study_sessions",
+          "tableTo": "study_plans",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_folder": {
+          "name": "group_folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_jid": {
+          "name": "chat_jid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_type": {
+          "name": "schedule_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_value": {
+          "name": "schedule_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_run": {
+          "name": "next_run",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_result": {
+          "name": "last_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_mode": {
+          "name": "context_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'isolated'"
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_next_run": {
+          "name": "idx_next_run",
+          "columns": [
+            "next_run"
+          ],
+          "isUnique": false
+        },
+        "idx_status": {
+          "name": "idx_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_run_logs": {
+      "name": "task_run_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_at": {
+          "name": "run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_task_run_logs": {
+          "name": "idx_task_run_logs",
+          "columns": [
+            "task_id",
+            "run_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "task_run_logs_task_id_scheduled_tasks_id_fk": {
+          "name": "task_run_logs_task_id_scheduled_tasks_id_fk",
+          "tableFrom": "task_run_logs",
+          "tableTo": "scheduled_tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "voice_sessions": {
+      "name": "voice_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_tokens_in": {
+          "name": "text_tokens_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "text_tokens_out": {
+          "name": "text_tokens_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "audio_tokens_in": {
+          "name": "audio_tokens_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "audio_tokens_out": {
+          "name": "audio_tokens_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rates_version": {
+          "name": "rates_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transcript_path": {
+          "name": "transcript_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_voice_sessions_started": {
+          "name": "idx_voice_sessions_started",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1776245600959,
       "tag": "0002_vengeful_kat_farrell",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1776530493928,
+      "tag": "0003_dry_caretaker",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5137,7 +5137,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -6,3 +6,4 @@ export * from './rag.js';
 export * from './state.js';
 export * from './study.js';
 export * from './tasks.js';
+export * from './voice.js';

--- a/src/db/schema/voice.ts
+++ b/src/db/schema/voice.ts
@@ -1,0 +1,30 @@
+import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+// ====================================================================
+// Voice Sessions — live voice chat cost tracking
+// ====================================================================
+
+export const voiceSessions = sqliteTable(
+  'voice_sessions',
+  {
+    id: text('id').primaryKey(),
+    persona: text('persona').notNull(),
+    startedAt: text('started_at').notNull(),
+    endedAt: text('ended_at').notNull(),
+    durationSeconds: integer('duration_seconds').notNull(),
+    textTokensIn: integer('text_tokens_in').notNull().default(0),
+    textTokensOut: integer('text_tokens_out').notNull().default(0),
+    audioTokensIn: integer('audio_tokens_in').notNull().default(0),
+    audioTokensOut: integer('audio_tokens_out').notNull().default(0),
+    costUsd: real('cost_usd').notNull(),
+    ratesVersion: text('rates_version').notNull(),
+    transcriptPath: text('transcript_path'),
+    artifacts: text('artifacts'),
+  },
+  (table) => ({
+    startedAtIdx: index('idx_voice_sessions_started').on(table.startedAt),
+  }),
+);
+
+export type VoiceSession = typeof voiceSessions.$inferSelect;
+export type NewVoiceSession = typeof voiceSessions.$inferInsert;

--- a/src/db/schema/voice.ts
+++ b/src/db/schema/voice.ts
@@ -1,4 +1,10 @@
-import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import {
+  index,
+  integer,
+  real,
+  sqliteTable,
+  text,
+} from 'drizzle-orm/sqlite-core';
 
 // ====================================================================
 // Voice Sessions — live voice chat cost tracking

--- a/src/voice/__tests__/path-scope.test.ts
+++ b/src/voice/__tests__/path-scope.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { mkdtemp, mkdir, writeFile, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { resolveReadPath, resolveWritePath, sanitizeSlug } from '../path-scope.js';
+import {
+  resolveReadPath,
+  resolveWritePath,
+  sanitizeSlug,
+} from '../path-scope.js';
 
 let root: string;
 

--- a/src/voice/__tests__/path-scope.test.ts
+++ b/src/voice/__tests__/path-scope.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, symlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { resolveReadPath, resolveWritePath, sanitizeSlug } from '../path-scope';
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(tmpdir(), 'voice-scope-'));
+  await mkdir(path.join(root, 'src'), { recursive: true });
+  await writeFile(path.join(root, 'src', 'a.ts'), 'x');
+  await writeFile(path.join(root, '.env'), 'SECRET=1');
+  await mkdir(path.join(root, 'docs', 'superpowers', 'specs'), { recursive: true });
+});
+
+describe('sanitizeSlug', () => {
+  it('accepts lowercase, digits, hyphen', () => {
+    expect(sanitizeSlug('voice-chat-v1')).toBe('voice-chat-v1');
+  });
+  it.each([
+    [''], ['a'.repeat(81)], ['has slash/bad'], ['UPPER'], ['dot.bad'], ['..'], [' pad '],
+  ])('rejects invalid slug %s', (bad) => {
+    expect(() => sanitizeSlug(bad)).toThrow();
+  });
+});
+
+describe('resolveReadPath', () => {
+  it('allows files under src/', async () => {
+    const p = await resolveReadPath(root, 'src/a.ts');
+    expect(p).toBe(path.join(root, 'src', 'a.ts'));
+  });
+
+  it('rejects .env', async () => {
+    await expect(resolveReadPath(root, '.env')).rejects.toThrow(/out of scope/);
+  });
+
+  it('rejects absolute path outside root', async () => {
+    await expect(resolveReadPath(root, '/etc/passwd')).rejects.toThrow(/out of scope/);
+  });
+
+  it('rejects parent traversal', async () => {
+    await expect(resolveReadPath(root, '../etc/passwd')).rejects.toThrow(/out of scope/);
+  });
+
+  it('rejects symlink escapes', async () => {
+    await symlink(path.join(root, '..'), path.join(root, 'src', 'escape'));
+    await expect(resolveReadPath(root, 'src/escape/secret')).rejects.toThrow();
+  });
+});
+
+describe('resolveWritePath', () => {
+  it('returns a path under the targeted docs dir with server-generated date prefix', async () => {
+    const p = await resolveWritePath(root, 'specs', 'my-slug', 'md');
+    expect(p).toMatch(/docs\/superpowers\/specs\/\d{4}-\d{2}-\d{2}-my-slug\.md$/);
+  });
+
+  it('rejects slug with path separator', async () => {
+    await expect(resolveWritePath(root, 'specs', '../escape', 'md')).rejects.toThrow();
+  });
+});

--- a/src/voice/__tests__/path-scope.test.ts
+++ b/src/voice/__tests__/path-scope.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { mkdtemp, mkdir, writeFile, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { resolveReadPath, resolveWritePath, sanitizeSlug } from '../path-scope';
+import { resolveReadPath, resolveWritePath, sanitizeSlug } from '../path-scope.js';
 
 let root: string;
 

--- a/src/voice/__tests__/path-scope.test.ts
+++ b/src/voice/__tests__/path-scope.test.ts
@@ -11,7 +11,9 @@ beforeEach(async () => {
   await mkdir(path.join(root, 'src'), { recursive: true });
   await writeFile(path.join(root, 'src', 'a.ts'), 'x');
   await writeFile(path.join(root, '.env'), 'SECRET=1');
-  await mkdir(path.join(root, 'docs', 'superpowers', 'specs'), { recursive: true });
+  await mkdir(path.join(root, 'docs', 'superpowers', 'specs'), {
+    recursive: true,
+  });
 });
 
 describe('sanitizeSlug', () => {
@@ -19,7 +21,13 @@ describe('sanitizeSlug', () => {
     expect(sanitizeSlug('voice-chat-v1')).toBe('voice-chat-v1');
   });
   it.each([
-    [''], ['a'.repeat(81)], ['has slash/bad'], ['UPPER'], ['dot.bad'], ['..'], [' pad '],
+    [''],
+    ['a'.repeat(81)],
+    ['has slash/bad'],
+    ['UPPER'],
+    ['dot.bad'],
+    ['..'],
+    [' pad '],
   ])('rejects invalid slug %s', (bad) => {
     expect(() => sanitizeSlug(bad)).toThrow();
   });
@@ -36,11 +44,15 @@ describe('resolveReadPath', () => {
   });
 
   it('rejects absolute path outside root', async () => {
-    await expect(resolveReadPath(root, '/etc/passwd')).rejects.toThrow(/out of scope/);
+    await expect(resolveReadPath(root, '/etc/passwd')).rejects.toThrow(
+      /out of scope/,
+    );
   });
 
   it('rejects parent traversal', async () => {
-    await expect(resolveReadPath(root, '../etc/passwd')).rejects.toThrow(/out of scope/);
+    await expect(resolveReadPath(root, '../etc/passwd')).rejects.toThrow(
+      /out of scope/,
+    );
   });
 
   it('rejects symlink escapes', async () => {
@@ -52,10 +64,14 @@ describe('resolveReadPath', () => {
 describe('resolveWritePath', () => {
   it('returns a path under the targeted docs dir with server-generated date prefix', async () => {
     const p = await resolveWritePath(root, 'specs', 'my-slug', 'md');
-    expect(p).toMatch(/docs\/superpowers\/specs\/\d{4}-\d{2}-\d{2}-my-slug\.md$/);
+    expect(p).toMatch(
+      /docs\/superpowers\/specs\/\d{4}-\d{2}-\d{2}-my-slug\.md$/,
+    );
   });
 
   it('rejects slug with path separator', async () => {
-    await expect(resolveWritePath(root, 'specs', '../escape', 'md')).rejects.toThrow();
+    await expect(
+      resolveWritePath(root, 'specs', '../escape', 'md'),
+    ).rejects.toThrow();
   });
 });

--- a/src/voice/__tests__/voice-log.test.ts
+++ b/src/voice/__tests__/voice-log.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { createVoiceLogger } from '../voice-log';
+
+let dir: string;
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(os.tmpdir(), 'voice-log-'));
+});
+
+describe('voice-log', () => {
+  it('writes one JSON line per event', async () => {
+    const log = createVoiceLogger(path.join(dir, 'voice.log'));
+    await log({ event: 'session.start', voiceSessionId: 'abc', persona: 'dev' });
+    await log({ event: 'tool.call', voiceSessionId: 'abc', tool: 'read_file' });
+    const body = await readFile(path.join(dir, 'voice.log'), 'utf8');
+    const lines = body.trim().split('\n').map((l) => JSON.parse(l));
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatchObject({ event: 'session.start', voiceSessionId: 'abc' });
+    expect(lines[0].ts).toBeDefined();
+  });
+
+  it('includes a timestamp', async () => {
+    const log = createVoiceLogger(path.join(dir, 'voice.log'));
+    await log({ event: 'session.end', voiceSessionId: 'x' });
+    const body = await readFile(path.join(dir, 'voice.log'), 'utf8');
+    const line = JSON.parse(body.trim());
+    expect(line.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/src/voice/__tests__/voice-log.test.ts
+++ b/src/voice/__tests__/voice-log.test.ts
@@ -12,12 +12,22 @@ beforeEach(async () => {
 describe('voice-log', () => {
   it('writes one JSON line per event', async () => {
     const log = createVoiceLogger(path.join(dir, 'voice.log'));
-    await log({ event: 'session.start', voiceSessionId: 'abc', persona: 'dev' });
+    await log({
+      event: 'session.start',
+      voiceSessionId: 'abc',
+      persona: 'dev',
+    });
     await log({ event: 'tool.call', voiceSessionId: 'abc', tool: 'read_file' });
     const body = await readFile(path.join(dir, 'voice.log'), 'utf8');
-    const lines = body.trim().split('\n').map((l) => JSON.parse(l));
+    const lines = body
+      .trim()
+      .split('\n')
+      .map((l) => JSON.parse(l));
     expect(lines).toHaveLength(2);
-    expect(lines[0]).toMatchObject({ event: 'session.start', voiceSessionId: 'abc' });
+    expect(lines[0]).toMatchObject({
+      event: 'session.start',
+      voiceSessionId: 'abc',
+    });
     expect(lines[0].ts).toBeDefined();
   });
 

--- a/src/voice/__tests__/voice-log.test.ts
+++ b/src/voice/__tests__/voice-log.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { mkdtemp, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
-import { createVoiceLogger } from '../voice-log';
+import { createVoiceLogger } from '../voice-log.js';
 
 let dir: string;
 beforeEach(async () => {

--- a/src/voice/path-scope.ts
+++ b/src/voice/path-scope.ts
@@ -3,7 +3,13 @@ import path from 'node:path';
 
 const SLUG_RE = /^[a-z0-9-]{1,80}$/;
 
-const ALLOWED_TOP_DIRS = new Set(['src', 'container', 'docs', 'scripts', 'public']);
+const ALLOWED_TOP_DIRS = new Set([
+  'src',
+  'container',
+  'docs',
+  'scripts',
+  'public',
+]);
 
 const ALLOWED_ROOT_CONFIGS = new Set([
   'package.json',
@@ -60,7 +66,10 @@ function isDeniedSegment(seg: string): boolean {
   return DENIED_SEGMENTS.has(seg);
 }
 
-export async function resolveReadPath(repoRoot: string, requested: string): Promise<string> {
+export async function resolveReadPath(
+  repoRoot: string,
+  requested: string,
+): Promise<string> {
   const outOfScope = (): never => {
     throw new Error('out of scope: ' + requested);
   };
@@ -72,7 +81,8 @@ export async function resolveReadPath(repoRoot: string, requested: string): Prom
 
   // Reject parent traversal after normalization.
   const normalized = path.normalize(requested);
-  if (normalized.startsWith('..' + path.sep) || normalized === '..') outOfScope();
+  if (normalized.startsWith('..' + path.sep) || normalized === '..')
+    outOfScope();
 
   const candidate = path.join(repoRoot, requested);
 
@@ -141,7 +151,10 @@ export async function resolveWritePath(
   const expectedRoot = await fs.realpath(repoRoot);
   const expectedTarget = path.join(expectedRoot, 'docs', 'superpowers', kind);
 
-  if (realTarget !== expectedTarget && !realTarget.startsWith(expectedTarget + path.sep)) {
+  if (
+    realTarget !== expectedTarget &&
+    !realTarget.startsWith(expectedTarget + path.sep)
+  ) {
     throw new Error('out of scope: ' + kind + '/' + slug);
   }
 

--- a/src/voice/path-scope.ts
+++ b/src/voice/path-scope.ts
@@ -1,0 +1,149 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const SLUG_RE = /^[a-z0-9-]{1,80}$/;
+
+const ALLOWED_TOP_DIRS = new Set(['src', 'container', 'docs', 'scripts', 'public']);
+
+const ALLOWED_ROOT_CONFIGS = new Set([
+  'package.json',
+  'tsconfig.json',
+  'next.config.ts',
+  'vitest.config.ts',
+  'eslint.config.mjs',
+  'postcss.config.mjs',
+  'README.md',
+  'CLAUDE.md',
+  'CONTRIBUTING.md',
+]);
+
+const DENIED_SEGMENTS = new Set([
+  'store',
+  'onecli',
+  'groups',
+  'data',
+  'node_modules',
+  '.venv',
+  '.git',
+]);
+
+export function sanitizeSlug(slug: string): string {
+  if (!SLUG_RE.test(slug)) {
+    const truncated = slug.length > 40 ? slug.slice(0, 40) + '...' : slug;
+    throw new Error('invalid slug: ' + truncated);
+  }
+  return slug;
+}
+
+/**
+ * Resolve the longest existing prefix of `p` via fs.realpath, then re-append
+ * any non-existent suffix. Prevents ENOENT crashes on missing final segments
+ * while still following symlinks for existing portions.
+ */
+async function safeRealpath(p: string): Promise<string> {
+  const parts = p.split(path.sep);
+  for (let i = parts.length; i > 0; i--) {
+    const prefix = parts.slice(0, i).join(path.sep) || path.sep;
+    try {
+      const real = await fs.realpath(prefix);
+      return path.join(real, ...parts.slice(i));
+    } catch (e: unknown) {
+      const code = (e as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') throw e;
+    }
+  }
+  return p;
+}
+
+function isDeniedSegment(seg: string): boolean {
+  if (seg.startsWith('.env')) return true;
+  return DENIED_SEGMENTS.has(seg);
+}
+
+export async function resolveReadPath(repoRoot: string, requested: string): Promise<string> {
+  const outOfScope = (): never => {
+    throw new Error('out of scope: ' + requested);
+  };
+
+  if (typeof requested !== 'string' || requested.length === 0) outOfScope();
+
+  // Reject absolute paths outright.
+  if (path.isAbsolute(requested)) outOfScope();
+
+  // Reject parent traversal after normalization.
+  const normalized = path.normalize(requested);
+  if (normalized.startsWith('..' + path.sep) || normalized === '..') outOfScope();
+
+  const candidate = path.join(repoRoot, requested);
+
+  let resolved: string;
+  try {
+    resolved = await safeRealpath(candidate);
+  } catch {
+    outOfScope();
+    return ''; // unreachable
+  }
+
+  const realRoot = await fs.realpath(repoRoot);
+
+  // Must be within the repo root.
+  if (resolved !== realRoot && !resolved.startsWith(realRoot + path.sep)) {
+    outOfScope();
+  }
+
+  const relative = path.relative(realRoot, resolved);
+  if (relative === '' || relative === '.') outOfScope();
+
+  const segments = relative.split(path.sep);
+
+  // Denied-segment check first (defense in depth).
+  for (const seg of segments) {
+    if (isDeniedSegment(seg)) outOfScope();
+  }
+
+  const first = segments[0];
+
+  // Allow-list check.
+  let allowed = false;
+  if (ALLOWED_TOP_DIRS.has(first)) {
+    allowed = true;
+  } else if (first === 'dashboard') {
+    if (segments.length >= 2 && segments[1] === 'src') {
+      allowed = true;
+    }
+  } else if (segments.length === 1 && ALLOWED_ROOT_CONFIGS.has(first)) {
+    allowed = true;
+  }
+
+  if (!allowed) outOfScope();
+
+  // Return the joined candidate (preserving caller's root form) rather than
+  // the realpath — we've already verified via realpath that this points to
+  // an in-scope location.
+  return candidate;
+}
+
+export async function resolveWritePath(
+  repoRoot: string,
+  kind: 'specs' | 'plans' | 'mockups',
+  slug: string,
+  ext: string,
+): Promise<string> {
+  sanitizeSlug(slug);
+
+  const today = new Date().toISOString().slice(0, 10);
+  const targetDir = path.join(repoRoot, 'docs', 'superpowers', kind);
+  await fs.mkdir(targetDir, { recursive: true });
+
+  const dest = path.join(targetDir, today + '-' + slug + '.' + ext);
+
+  const realTarget = await fs.realpath(targetDir);
+  const expectedRoot = await fs.realpath(repoRoot);
+  const expectedTarget = path.join(expectedRoot, 'docs', 'superpowers', kind);
+
+  if (realTarget !== expectedTarget && !realTarget.startsWith(expectedTarget + path.sep)) {
+    throw new Error('out of scope: ' + kind + '/' + slug);
+  }
+
+  return dest;
+}

--- a/src/voice/subsystem-map.ts
+++ b/src/voice/subsystem-map.ts
@@ -16,7 +16,8 @@ export const SUBSYSTEMS: SubsystemEntry[] = [
   },
   {
     path: 'src/study/',
-    purpose: 'Study engine, session builder, SM-2 spacing, scaffolding, audio pipeline.',
+    purpose:
+      'Study engine, session builder, SM-2 spacing, scaffolding, audio pipeline.',
   },
   {
     path: 'src/vault/',
@@ -24,15 +25,18 @@ export const SUBSYSTEMS: SubsystemEntry[] = [
   },
   {
     path: 'src/channels/',
-    purpose: 'Channel registry and per-channel adapters (telegram, web, slack, etc.).',
+    purpose:
+      'Channel registry and per-channel adapters (telegram, web, slack, etc.).',
   },
   {
     path: 'src/profile/',
-    purpose: 'Student profile: progress tracking, knowledge map, study-log rotation.',
+    purpose:
+      'Student profile: progress tracking, knowledge map, study-log rotation.',
   },
   {
     path: 'src/db/schema/',
-    purpose: 'Canonical Drizzle schema (snake_case SQL columns, camelCase TS properties).',
+    purpose:
+      'Canonical Drizzle schema (snake_case SQL columns, camelCase TS properties).',
   },
   {
     path: 'src/voice/',

--- a/src/voice/subsystem-map.ts
+++ b/src/voice/subsystem-map.ts
@@ -1,0 +1,72 @@
+export interface SubsystemEntry {
+  path: string;
+  purpose: string;
+}
+
+export const SUBSYSTEMS: SubsystemEntry[] = [
+  {
+    path: 'src/ingestion/',
+    purpose:
+      'File watcher → Docling extraction → Claude note generation → auto-promotion to vault.',
+  },
+  {
+    path: 'src/rag/',
+    purpose:
+      'LightRAG hybrid retrieval with SQLite-tracked indexing; chokidar watcher with content-hash dedup.',
+  },
+  {
+    path: 'src/study/',
+    purpose: 'Study engine, session builder, SM-2 spacing, scaffolding, audio pipeline.',
+  },
+  {
+    path: 'src/vault/',
+    purpose: 'Direct Obsidian vault file I/O (gray-matter + wikilinks).',
+  },
+  {
+    path: 'src/channels/',
+    purpose: 'Channel registry and per-channel adapters (telegram, web, slack, etc.).',
+  },
+  {
+    path: 'src/profile/',
+    purpose: 'Student profile: progress tracking, knowledge map, study-log rotation.',
+  },
+  {
+    path: 'src/db/schema/',
+    purpose: 'Canonical Drizzle schema (snake_case SQL columns, camelCase TS properties).',
+  },
+  {
+    path: 'src/voice/',
+    purpose:
+      'Server-side voice helpers: path-scope guards, voice-log JSON writer, subsystem map.',
+  },
+  {
+    path: 'dashboard/src/app/voice/',
+    purpose:
+      'Live voice chat UI (/voice page): VoiceSession, audio I/O, cost tracker, captions, preview pane.',
+  },
+  {
+    path: 'dashboard/src/app/study/',
+    purpose: 'Dashboard UI for study sessions, plans, analytics.',
+  },
+  {
+    path: 'dashboard/src/app/vault/',
+    purpose: 'Dashboard UI for browsing and editing vault notes.',
+  },
+  {
+    path: 'dashboard/src/app/read/',
+    purpose: 'Speed reader (RSVP) and book (EPUB) reading surfaces.',
+  },
+  {
+    path: 'dashboard/src/lib/',
+    purpose: 'Dashboard-side DB helpers, study math, session builder.',
+  },
+  {
+    path: 'container/',
+    purpose:
+      'Agent-runner container definition (Dockerfile + TS entrypoint + MCP tool surface).',
+  },
+  {
+    path: 'docs/superpowers/',
+    purpose: 'Design specs and implementation plans for major features.',
+  },
+];

--- a/src/voice/voice-log.ts
+++ b/src/voice/voice-log.ts
@@ -1,0 +1,17 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export function createVoiceLogger(
+  filePath: string,
+): (record: Record<string, unknown>) => Promise<void> {
+  let parentEnsured = false;
+
+  return async (record: Record<string, unknown>): Promise<void> => {
+    if (!parentEnsured) {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      parentEnsured = true;
+    }
+    const entry = { ts: new Date().toISOString(), ...record };
+    await fs.appendFile(filePath, JSON.stringify(entry) + '\n', 'utf8');
+  };
+}


### PR DESCRIPTION
## ⚠️ v1 status — fake server only

The browser `VoiceSession` speaks an opaque-JSON frame format (`{type: 'audio'|'usage'|'tool_call'|…}`) that matches the in-repo fake Gemini server, **not** Gemini Live's real `BidiGenerateContent` wire protocol. The production WS URL (`wss://generativelanguage.googleapis.com/?access_token=…`) in `voice-session.ts:171-175` is a placeholder. A real `GEMINI_API_KEY` will not make a working audio session until a v1.1 adapter lands that uses `@google/genai`'s `ai.live.connect()` and mirrors Gemini's real `serverContent`/`toolCall`/`usageMetadata` frame shapes.

Everything except the live-audio path is usable today: token minting, the tool dispatcher + scope guards, session-close persistence, cost rollups, and the fake-server e2e. See `docs/voice-dogfood-checklist.md` for which rows exercise v1 vs require v1.1.

## Summary

Ships a dashboard `/voice` page that hosts a real-time voice brainstorming session with a Gemini-powered **Dev Assistant** persona — live dollar tracker, captions, a preview pane for mockups and mermaid diagrams, durable transcripts, and strict read/write scoping.

- **Architecture:** browser opens a WebSocket to Gemini Live using a short-lived ephemeral token minted by the dashboard backend. A `VoiceSession` abstraction owns the WS lifecycle and fires UI events. Server routes execute tool calls (read from scoped roots, write to `docs/superpowers/`), persist transcripts, and write session/cost records to a new `voice_sessions` SQLite table. No Claude container in the loop.
- **Tech stack:** Next.js 16, React 19, `@google/genai`, `mermaid`, Drizzle + `better-sqlite3`, Web Audio API (`AudioWorklet`), Vitest.
- **Spec:** [`docs/superpowers/specs/2026-04-18-live-voice-chat-design.md`](docs/superpowers/specs/2026-04-18-live-voice-chat-design.md)
- **Plan:** [`docs/superpowers/plans/2026-04-18-live-voice-chat-v1.md`](docs/superpowers/plans/2026-04-18-live-voice-chat-v1.md)

## What's in the box

### Server (Next.js route handlers)
- `POST /api/voice/token` — mints an ephemeral Gemini Live token (loopback-gated, supports `GEMINI_API_KEY` + legacy `google_api_key` fallback until the parallel migration lands). Emits `session.start` / `error.token_mint` voice-log entries.
- `GET /api/voice/context/dev` — startup payload: CLAUDE.md, docs/ARCHITECTURE.md (if present), curated subsystem map, root + dashboard npm scripts, current branch, `git status --short`, last 10 commits, filenames in `docs/superpowers/specs` and `docs/superpowers/plans`.
- `POST /api/voice/tools/dev/[tool]` — single dispatcher for 11 tools, emits `tool.call` / `tool.result` / `tool.error` voice-log entries (args with `content`/`html`/`mermaid` are redacted to `{length}` in logs).
  - **Read:** `read_file` (256 KB cap + truncation marker), `glob`, `grep` (200-match cap), `git_log`, `git_status`, `list_docs`, `read_doc`. All paths pass through `resolveReadPath` (realpath + allow/deny lists, symlink escape protection).
  - **Write:** `write_spec`, `write_plan`, `write_mockup`, `write_diagram`. Slugs sanitized to `^[a-z0-9-]{1,80}$`, server-generated date prefix, 256 KB content cap, no-overwrite guard that returns `existingContent` for conflict resolution.
- `POST /api/voice/session-close` — writes transcript markdown (with YAML frontmatter) to `docs/superpowers/brainstorm-sessions/` and inserts a `voice_sessions` row with cost computed from `rates.ts`. Emits `session.end` / `error.db_insert` voice-log entries.
- `GET /api/voice/stats` — today/month rollups + optional `VOICE_MONTHLY_BUDGET_USD` threshold.
- `GET /voice/preview?file=…` — serves mockup/diagram files to the iframe (scoped to `docs/superpowers/mockups/`). Direct route tests cover 403/400/404/200 paths.

### Client (`dashboard/src/app/voice/`)
- `VoiceSession` — owns the WS lifecycle, transcript buffer (finals only), tool dispatch, cost tracker, soft-cap timer, idempotent stop + session-close POST.
- `CostTracker` — token accumulator with change events.
- `audio-io.ts` + `pcm-capture.js` — 16 kHz mic capture via `AudioWorklet` and 24 kHz PCM playback.
- `Captions`, `PreviewPane`, `CostPanel`, `page.tsx` — UI components.
- Dev-only nav link (`NODE_ENV === 'development'`).

### Schema + infra
- New `voice_sessions` table (`id`, `persona`, `started_at`, `ended_at`, `duration_seconds`, token counts by modality, `cost_usd`, `rates_version`, `transcript_path`, `artifacts`) with `idx_voice_sessions_started` index.
- Canonical schema at `src/db/schema/voice.ts` + mirror in `dashboard/src/lib/db/schema.ts`.
- Drizzle migration `0003_dry_caretaker.sql` (generated, applied).
- Structured voice logger singleton at `dashboard/src/lib/voice-logger.ts` → `data/voice.log` (JSON-lines).
- `.env.example` documents `VOICE_MONTHLY_BUDGET_USD`.
- `docs/superpowers/brainstorm-sessions/.gitkeep`, `.../mockups/.gitkeep`, `.../research/.gitkeep`.

### Pricing (Gemini 3.1 Flash Live Preview, paid tier, retrieved 2026-04-18 from ai.google.dev/gemini-api/docs/pricing)
- text in: \$0.75 / M tokens
- text out: \$4.50 / M tokens
- audio in: \$3.00 / M tokens
- audio out: \$12.00 / M tokens

### Privacy
- Brainstorm transcripts and mockups live under `docs/superpowers/` which is **outside the RAG indexer's watch scope** (`src/rag/indexer.ts` watches `VAULT_DIR` only — verified, noted in the dogfood checklist).
- All voice endpoints gate on loopback (`localhost`, `127.0.0.1`, `::1`).

## Tests

- **955 of 956 tests pass** across 79 files (root `npm test`). The single failure (`src/claw-skill.test.ts` 5 s timeout) is pre-existing on main since commit `724fe72` and unrelated to this branch.
- New voice-specific coverage (85 tests across 12 files): rates (3), path-scope (15), voice-log (2), cost-tracker (8), VoiceSession (4), token endpoint (8), context endpoint (3), read tools (16), write tools (9), session-close (5), stats (3), preview route (8), e2e against fake server (1).
- E2E test drives `VoiceSession` against the fake WS server + a routed-fetch mock that dispatches to the real Next.js route handlers — confirms full session lifecycle.

## Deferred / out of scope (v1 → v2+)

- **v1.1 priority**: real-Gemini adapter so `/voice` actually talks to Gemini Live (see warning at top).
- Mr. Rogers Live persona (separate spec, `2026-04-18-mr-rogers-live-design.md`).
- Session resumption beyond the 15-minute hard cap.
- Soft-cap countdown + 30 s warning prompt (only the terminal cutoff is implemented today).
- Subagent research queue.
- `/voice/history` page.
- Phone / Twilio / mobile.
- Dashboard auth (flagged in the localhost banner).
- Hard dollar cap per session.
- DRY the duplicated `isLoopback` / `getRepoRoot` helpers across 6 route files.

## Test plan

- [x] `npm test` — 955/956 passing (one pre-existing failure noted above).
- [x] `npm run typecheck` — clean.
- [x] `cd dashboard && npx tsc --noEmit` — clean.
- [x] Voice-dir lint — 0 errors, 0 warnings after review fixes.
- [ ] Manual smoke test per [`docs/voice-dogfood-checklist.md`](docs/voice-dogfood-checklist.md) — deferred until v1.1 real-Gemini adapter lands (v1 is fake-server only per warning above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)