### PR TITLE
feat(zotero): watch configured group libraries alongside the personal library

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,10 @@ ZOTERO_USER_ID=
 # ZOTERO_POLL_INTERVAL=60000
 # ZOTERO_EXCLUDE_COLLECTION=Do Not Process
 # ZOTERO_LOCAL_URL=http://localhost:23119
+# Comma-separated Zotero GROUP library IDs to also watch (in addition to the
+# personal library). Find a group's ID at zotero.org/groups/<id>. Leave empty
+# to watch only the personal library.
+# ZOTERO_GROUP_IDS=6515112
 
 # --- Voice (live Gemini chat at /voice) ---
 # GEMINI_API_KEY is shared with TTS/STT. The voice feature also reads the

--- a/scripts/ingest-zotero-group.ts
+++ b/scripts/ingest-zotero-group.ts
@@ -1,0 +1,201 @@
+/**
+ * One-shot enqueue of all PDF attachments in a Zotero GROUP library.
+ *
+ * The normal Zotero watcher polls only the personal library (/api/users/0).
+ * This script mirrors `ZoteroWatcher.processItem` for a single group library
+ * so its PDFs are enqueued into the ingestion pipeline with full metadata
+ * (title, creators, DOI, tags, abstract) from their parent items.
+ *
+ * Usage:
+ *   npx tsx scripts/ingest-zotero-group.ts <groupId>
+ *   npx tsx scripts/ingest-zotero-group.ts 6515112   # TDMA4007
+ *
+ * Safe to run while NanoClaw is live: SQLite is in WAL mode, the drainer
+ * will pick up the new pending jobs on its next 5s tick.
+ */
+import { randomUUID, createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+import {
+  initDatabase,
+  createIngestionJob,
+  getCompletedJobByHash,
+  getIngestionJobByZoteroKey,
+} from '../src/db.js';
+import { ZOTERO_LOCAL_URL } from '../src/config.js';
+import type { ZoteroMetadata } from '../src/ingestion/types.js';
+
+const REQUEST_TIMEOUT = 10_000;
+
+interface ZGroupItem {
+  key: string;
+  data: {
+    itemType: string;
+    title?: string;
+    contentType?: string;
+    filename?: string;
+    parentItem?: string;
+    creators?: { firstName: string; lastName: string; creatorType: string }[];
+    date?: string;
+    DOI?: string;
+    url?: string;
+    publicationTitle?: string;
+    tags?: { tag: string }[];
+    abstractNote?: string;
+  };
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { signal: AbortSignal.timeout(REQUEST_TIMEOUT) });
+  if (!res.ok) throw new Error(`${url} → ${res.status}`);
+  return (await res.json()) as T;
+}
+
+async function getGroupItems(groupId: string): Promise<ZGroupItem[]> {
+  return fetchJson<ZGroupItem[]>(
+    `${ZOTERO_LOCAL_URL}/api/groups/${groupId}/items?format=json&limit=500`,
+  );
+}
+
+async function getGroupItem(
+  groupId: string,
+  key: string,
+): Promise<ZGroupItem> {
+  return fetchJson<ZGroupItem>(
+    `${ZOTERO_LOCAL_URL}/api/groups/${groupId}/items/${key}?format=json`,
+  );
+}
+
+async function getFilePath(
+  groupId: string,
+  attachmentKey: string,
+): Promise<string | null> {
+  const res = await fetch(
+    `${ZOTERO_LOCAL_URL}/api/groups/${groupId}/items/${attachmentKey}/file/view/url`,
+    { signal: AbortSignal.timeout(REQUEST_TIMEOUT) },
+  );
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`file URL fetch error: ${res.status}`);
+  const url = (await res.text()).trim();
+  if (url.startsWith('file://')) {
+    return decodeURIComponent(new URL(url).pathname);
+  }
+  return url || null;
+}
+
+function buildMetadata(parent: ZGroupItem['data']): ZoteroMetadata {
+  return {
+    title: parent.title ?? '',
+    creators: parent.creators ?? [],
+    date: parent.date ?? '',
+    DOI: parent.DOI,
+    url: parent.url,
+    publicationTitle: parent.publicationTitle,
+    tags: (parent.tags ?? []).map((t) => t.tag),
+    abstractNote: parent.abstractNote,
+    itemType: parent.itemType,
+  };
+}
+
+async function main(): Promise<void> {
+  const groupId = process.argv[2];
+  if (!groupId) {
+    console.error('Usage: npx tsx scripts/ingest-zotero-group.ts <groupId>');
+    process.exit(1);
+  }
+
+  initDatabase();
+
+  const items = await getGroupItems(groupId);
+  const pdfs = items.filter(
+    (i) =>
+      i.data.itemType === 'attachment' &&
+      i.data.contentType === 'application/pdf',
+  );
+
+  console.log(
+    `Group ${groupId}: ${items.length} items, ${pdfs.length} PDF attachments`,
+  );
+
+  let enqueued = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const pdf of pdfs) {
+    const existing = getIngestionJobByZoteroKey(pdf.key);
+    if (existing) {
+      console.log(`  skip ${pdf.key} (existing job ${existing.id} [${existing.status}])`);
+      skipped++;
+      continue;
+    }
+
+    let filePath: string | null;
+    try {
+      filePath = await getFilePath(groupId, pdf.key);
+    } catch (err) {
+      console.warn(`  fail ${pdf.key} (file URL):`, err);
+      failed++;
+      continue;
+    }
+    if (!filePath) {
+      console.warn(`  skip ${pdf.key} (no local file)`);
+      skipped++;
+      continue;
+    }
+
+    let metadata: ZoteroMetadata;
+    try {
+      if (pdf.data.parentItem) {
+        const parent = await getGroupItem(groupId, pdf.data.parentItem);
+        metadata = buildMetadata(parent.data);
+      } else {
+        metadata = buildMetadata({
+          ...pdf.data,
+          title: pdf.data.title ?? pdf.data.filename ?? pdf.key,
+          itemType: 'attachment',
+        });
+      }
+    } catch (err) {
+      console.warn(`  fail ${pdf.key} (parent fetch):`, err);
+      failed++;
+      continue;
+    }
+
+    let contentHash: string;
+    try {
+      contentHash = createHash('sha256')
+        .update(readFileSync(filePath))
+        .digest('hex');
+    } catch (err) {
+      console.warn(`  fail ${pdf.key} (read file):`, err);
+      failed++;
+      continue;
+    }
+
+    const dup = getCompletedJobByHash(contentHash);
+    if (dup) {
+      console.log(`  skip ${pdf.key} (content-hash matches completed job ${dup.id})`);
+      skipped++;
+      continue;
+    }
+
+    const jobId = randomUUID();
+    createIngestionJob(jobId, filePath, basename(filePath), contentHash, {
+      source_type: 'zotero',
+      zotero_key: pdf.key,
+      zotero_metadata: JSON.stringify(metadata),
+    });
+
+    console.log(`  enq  ${pdf.key} → ${jobId}  "${metadata.title.slice(0, 70)}"`);
+    enqueued++;
+  }
+
+  console.log(
+    `\nDone: ${enqueued} enqueued, ${skipped} skipped, ${failed} failed`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ const envConfig = readEnvFile([
   'ZOTERO_POLL_INTERVAL',
   'ZOTERO_EXCLUDE_COLLECTION',
   'ZOTERO_LOCAL_URL',
+  'ZOTERO_GROUP_IDS',
 ]);
 
 export const ASSISTANT_NAME =
@@ -164,3 +165,11 @@ export const ZOTERO_LOCAL_URL =
   process.env.ZOTERO_LOCAL_URL ||
   envConfig.ZOTERO_LOCAL_URL ||
   'http://localhost:23119';
+export const ZOTERO_GROUP_IDS = (
+  process.env.ZOTERO_GROUP_IDS ||
+  envConfig.ZOTERO_GROUP_IDS ||
+  ''
+)
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -919,21 +919,29 @@ export function getCitedBy(targetSlug: string): string[] {
 // Zotero sync
 // ====================================================================
 
-export function getZoteroSyncVersion(): number | null {
+export function getZoteroSyncVersion(
+  key: string = 'library_version',
+): number | null {
   const row = db
     .select({ value: schema.zotero_sync.value })
     .from(schema.zotero_sync)
-    .where(eq(schema.zotero_sync.key, 'library_version'))
+    .where(eq(schema.zotero_sync.key, key))
     .get();
   return row ? parseInt(row.value, 10) : null;
 }
 
-export function setZoteroSyncVersion(version: number): void {
+export function setZoteroSyncVersion(
+  versionOrKey: number | string,
+  version?: number,
+): void {
+  // Back-compat: setZoteroSyncVersion(123) still works for the user library.
+  const key = typeof versionOrKey === 'string' ? versionOrKey : 'library_version';
+  const value = typeof versionOrKey === 'string' ? version! : versionOrKey;
   db.insert(schema.zotero_sync)
-    .values({ key: 'library_version', value: String(version) })
+    .values({ key, value: String(value) })
     .onConflictDoUpdate({
       target: schema.zotero_sync.key,
-      set: { value: String(version) },
+      set: { value: String(value) },
     })
     .run();
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -935,7 +935,8 @@ export function setZoteroSyncVersion(
   version?: number,
 ): void {
   // Back-compat: setZoteroSyncVersion(123) still works for the user library.
-  const key = typeof versionOrKey === 'string' ? versionOrKey : 'library_version';
+  const key =
+    typeof versionOrKey === 'string' ? versionOrKey : 'library_version';
   const value = typeof versionOrKey === 'string' ? version! : versionOrKey;
   db.insert(schema.zotero_sync)
     .values({ key, value: String(value) })

--- a/src/ingestion/index.ts
+++ b/src/ingestion/index.ts
@@ -716,7 +716,11 @@ export class IngestionPipeline {
         );
       }
 
-      const libraries: { libraryPath: string; syncKey: string; label: string }[] = [
+      const libraries: {
+        libraryPath: string;
+        syncKey: string;
+        label: string;
+      }[] = [
         { libraryPath: 'users/0', syncKey: 'library_version', label: 'user' },
         ...ZOTERO_GROUP_IDS.map((id) => ({
           libraryPath: `groups/${id}`,

--- a/src/ingestion/index.ts
+++ b/src/ingestion/index.ts
@@ -43,6 +43,7 @@ import {
   ZOTERO_POLL_INTERVAL,
   ZOTERO_EXCLUDE_COLLECTION,
   ZOTERO_LOCAL_URL,
+  ZOTERO_GROUP_IDS,
 } from '../config.js';
 import { ZoteroWatcher } from './zotero-watcher.js';
 import { ZoteroWriteBack } from './zotero-writeback.js';
@@ -81,7 +82,7 @@ export class IngestionPipeline {
   private reviewAgentGroup: RegisteredGroup;
   private drainer: PipelineDrainer;
   private notify: ((message: string) => void) | undefined;
-  private zoteroWatcher: ZoteroWatcher | null = null;
+  private zoteroWatchers: ZoteroWatcher[] = [];
   private zoteroWriteBack: ZoteroWriteBack | null = null;
 
   constructor(opts: IngestionPipelineOpts) {
@@ -704,10 +705,8 @@ export class IngestionPipeline {
     await this.watcher.start();
     this.drainer.drain();
 
-    // Start Zotero watcher if enabled
+    // Start Zotero watchers if enabled — one per library (user + each configured group)
     if (ZOTERO_ENABLED) {
-      const localClient = new ZoteroLocalClient(ZOTERO_LOCAL_URL);
-
       if (ZOTERO_API_KEY && ZOTERO_USER_ID) {
         const webClient = new ZoteroWebClient(ZOTERO_API_KEY, ZOTERO_USER_ID);
         this.zoteroWriteBack = new ZoteroWriteBack(webClient);
@@ -717,25 +716,44 @@ export class IngestionPipeline {
         );
       }
 
-      this.zoteroWatcher = new ZoteroWatcher({
-        client: localClient,
-        excludeCollection: ZOTERO_EXCLUDE_COLLECTION,
-        onItem: (filePath, zoteroKey, metadata) => {
-          this.enqueueZotero(filePath, zoteroKey, metadata);
-        },
-        pollIntervalMs: ZOTERO_POLL_INTERVAL,
-      });
-      await this.zoteroWatcher.start();
-      logger.info('Zotero integration enabled');
+      const libraries: { libraryPath: string; syncKey: string; label: string }[] = [
+        { libraryPath: 'users/0', syncKey: 'library_version', label: 'user' },
+        ...ZOTERO_GROUP_IDS.map((id) => ({
+          libraryPath: `groups/${id}`,
+          syncKey: `group:${id}:library_version`,
+          label: `group:${id}`,
+        })),
+      ];
+
+      for (const lib of libraries) {
+        const client = new ZoteroLocalClient(ZOTERO_LOCAL_URL, lib.libraryPath);
+        const watcher = new ZoteroWatcher({
+          client,
+          excludeCollection: ZOTERO_EXCLUDE_COLLECTION,
+          onItem: (filePath, zoteroKey, metadata) => {
+            this.enqueueZotero(filePath, zoteroKey, metadata);
+          },
+          pollIntervalMs: ZOTERO_POLL_INTERVAL,
+          syncKey: lib.syncKey,
+          label: lib.label,
+        });
+        await watcher.start();
+        this.zoteroWatchers.push(watcher);
+      }
+      logger.info(
+        { libraries: libraries.map((l) => l.label) },
+        'Zotero integration enabled',
+      );
     }
 
     logger.info(`Watching ${this.uploadDir} for new files`);
   }
 
   async stop(): Promise<void> {
-    if (this.zoteroWatcher) {
-      this.zoteroWatcher.stop();
+    for (const w of this.zoteroWatchers) {
+      w.stop();
     }
+    this.zoteroWatchers = [];
     await this.drainer.stop();
     await this.watcher.stop();
   }

--- a/src/ingestion/zotero-client.test.ts
+++ b/src/ingestion/zotero-client.test.ts
@@ -99,10 +99,7 @@ describe('ZoteroLocalClient (group library)', () => {
   let client: ZoteroLocalClient;
 
   beforeEach(() => {
-    client = new ZoteroLocalClient(
-      'http://localhost:23119',
-      'groups/6515112',
-    );
+    client = new ZoteroLocalClient('http://localhost:23119', 'groups/6515112');
     vi.restoreAllMocks();
   });
 

--- a/src/ingestion/zotero-client.test.ts
+++ b/src/ingestion/zotero-client.test.ts
@@ -95,6 +95,53 @@ describe('ZoteroLocalClient', () => {
   });
 });
 
+describe('ZoteroLocalClient (group library)', () => {
+  let client: ZoteroLocalClient;
+
+  beforeEach(() => {
+    client = new ZoteroLocalClient(
+      'http://localhost:23119',
+      'groups/6515112',
+    );
+    vi.restoreAllMocks();
+  });
+
+  it('getItems targets /api/groups/{id}/items', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify([]), {
+        headers: { 'Last-Modified-Version': '42' },
+      }),
+    );
+    await client.getItems(10);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://localhost:23119/api/groups/6515112/items?since=10&itemType=-attachment+-note&format=json',
+      expect.any(Object),
+    );
+  });
+
+  it('getChildren, getCollections, getFileUrl all use group path', async () => {
+    const spy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify([])))
+      .mockResolvedValueOnce(new Response(JSON.stringify([])))
+      .mockResolvedValueOnce(new Response('', { status: 404 }));
+
+    await client.getChildren('X');
+    await client.getCollections();
+    await client.getFileUrl('Y');
+
+    expect(spy.mock.calls[0][0]).toBe(
+      'http://localhost:23119/api/groups/6515112/items/X/children?format=json',
+    );
+    expect(spy.mock.calls[1][0]).toBe(
+      'http://localhost:23119/api/groups/6515112/collections?format=json',
+    );
+    expect(spy.mock.calls[2][0]).toBe(
+      'http://localhost:23119/api/groups/6515112/items/Y/file/view/url',
+    );
+  });
+});
+
 describe('ZoteroWebClient', () => {
   let client: ZoteroWebClient;
 

--- a/src/ingestion/zotero-client.ts
+++ b/src/ingestion/zotero-client.ts
@@ -3,7 +3,15 @@ import { logger } from '../logger.js';
 const REQUEST_TIMEOUT = 10_000;
 
 export class ZoteroLocalClient {
-  constructor(private readonly baseUrl: string) {}
+  /**
+   * @param baseUrl e.g. http://localhost:23119
+   * @param libraryPath path segment identifying the library — `users/0` for the
+   *   personal library (default, back-compat) or `groups/{groupId}` for a group.
+   */
+  constructor(
+    private readonly baseUrl: string,
+    private readonly libraryPath: string = 'users/0',
+  ) {}
 
   async getItems(
     since?: number,
@@ -15,9 +23,10 @@ export class ZoteroLocalClient {
     parts.push('itemType=-attachment+-note', 'format=json');
     const query = parts.join('&');
 
-    const res = await fetch(`${this.baseUrl}/api/users/0/items?${query}`, {
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT),
-    });
+    const res = await fetch(
+      `${this.baseUrl}/api/${this.libraryPath}/items?${query}`,
+      { signal: AbortSignal.timeout(REQUEST_TIMEOUT) },
+    );
     if (!res.ok) throw new Error(`Zotero local API error: ${res.status}`);
 
     const items = (await res.json()) as unknown[];
@@ -30,7 +39,7 @@ export class ZoteroLocalClient {
 
   async getChildren(itemKey: string): Promise<unknown[]> {
     const res = await fetch(
-      `${this.baseUrl}/api/users/0/items/${itemKey}/children?format=json`,
+      `${this.baseUrl}/api/${this.libraryPath}/items/${itemKey}/children?format=json`,
       { signal: AbortSignal.timeout(REQUEST_TIMEOUT) },
     );
     if (!res.ok) throw new Error(`Zotero children fetch error: ${res.status}`);
@@ -39,7 +48,7 @@ export class ZoteroLocalClient {
 
   async getCollections(): Promise<unknown[]> {
     const res = await fetch(
-      `${this.baseUrl}/api/users/0/collections?format=json`,
+      `${this.baseUrl}/api/${this.libraryPath}/collections?format=json`,
       { signal: AbortSignal.timeout(REQUEST_TIMEOUT) },
     );
     if (!res.ok)
@@ -49,7 +58,7 @@ export class ZoteroLocalClient {
 
   async getFileUrl(attachmentKey: string): Promise<string | null> {
     const res = await fetch(
-      `${this.baseUrl}/api/users/0/items/${attachmentKey}/file/view/url`,
+      `${this.baseUrl}/api/${this.libraryPath}/items/${attachmentKey}/file/view/url`,
       { signal: AbortSignal.timeout(REQUEST_TIMEOUT) },
     );
     if (res.status === 404) return null;

--- a/src/ingestion/zotero-db.test.ts
+++ b/src/ingestion/zotero-db.test.ts
@@ -61,4 +61,20 @@ describe('Zotero DB functions', () => {
     setZoteroSyncVersion(1900);
     expect(getZoteroSyncVersion()).toBe(1900);
   });
+
+  it('get/setZoteroSyncVersion supports per-library keys without clashing', () => {
+    setZoteroSyncVersion(100);
+    setZoteroSyncVersion('group:6515112:library_version', 500);
+    setZoteroSyncVersion('group:9999:library_version', 77);
+
+    expect(getZoteroSyncVersion()).toBe(100);
+    expect(getZoteroSyncVersion('group:6515112:library_version')).toBe(500);
+    expect(getZoteroSyncVersion('group:9999:library_version')).toBe(77);
+
+    // Updating one library key doesn't disturb others.
+    setZoteroSyncVersion('group:6515112:library_version', 600);
+    expect(getZoteroSyncVersion('group:6515112:library_version')).toBe(600);
+    expect(getZoteroSyncVersion()).toBe(100);
+    expect(getZoteroSyncVersion('group:9999:library_version')).toBe(77);
+  });
 });

--- a/src/ingestion/zotero-watcher.test.ts
+++ b/src/ingestion/zotero-watcher.test.ts
@@ -77,7 +77,7 @@ describe('ZoteroWatcher', () => {
 
     await watcher.poll();
 
-    expect(setZoteroSyncVersion).toHaveBeenCalledWith(200);
+    expect(setZoteroSyncVersion).toHaveBeenCalledWith('library_version', 200);
     expect(enqueuedItems).toHaveLength(0);
   });
 
@@ -129,7 +129,7 @@ describe('ZoteroWatcher', () => {
       '/Users/test/Zotero/storage/ATT1/paper.pdf',
     );
     expect(enqueuedItems[0].zoteroKey).toBe('NEW1');
-    expect(setZoteroSyncVersion).toHaveBeenCalledWith(150);
+    expect(setZoteroSyncVersion).toHaveBeenCalledWith('library_version', 150);
   });
 
   it('skips items already ingested (dedup by zotero_key)', async () => {
@@ -243,6 +243,29 @@ describe('ZoteroWatcher', () => {
     expect(enqueuedItems).toHaveLength(0);
     // Verify getChildren was NOT called — item was filtered before PDF resolution
     expect(mockClient.getChildren).not.toHaveBeenCalled();
+  });
+
+  it('uses custom syncKey when reading and writing the sync version', async () => {
+    vi.mocked(getZoteroSyncVersion).mockReturnValue(null);
+    mockClient.getItems.mockResolvedValue({ items: [], version: 321 });
+
+    const groupWatcher = new ZoteroWatcher({
+      client: mockClient as unknown as ZoteroLocalClient,
+      excludeCollection: '',
+      onItem: () => {},
+      syncKey: 'group:6515112:library_version',
+      label: 'group:6515112',
+    });
+
+    await groupWatcher.poll();
+
+    expect(getZoteroSyncVersion).toHaveBeenCalledWith(
+      'group:6515112:library_version',
+    );
+    expect(setZoteroSyncVersion).toHaveBeenCalledWith(
+      'group:6515112:library_version',
+      321,
+    );
   });
 
   it('picks largest PDF when multiple attachments exist', async () => {

--- a/src/ingestion/zotero-watcher.ts
+++ b/src/ingestion/zotero-watcher.ts
@@ -16,6 +16,11 @@ export interface ZoteroWatcherOpts {
     metadata: ZoteroMetadata,
   ) => void;
   pollIntervalMs?: number;
+  /** Sync-version key in the `zotero_sync` table. Default `library_version`
+   *  (personal library). Use `group:{id}:library_version` for group libraries. */
+  syncKey?: string;
+  /** Label used in log messages to identify the library (e.g. "user", "group:6515112"). */
+  label?: string;
 }
 
 export class ZoteroWatcher {
@@ -25,12 +30,16 @@ export class ZoteroWatcher {
   private onItem: ZoteroWatcherOpts['onItem'];
   private timer: ReturnType<typeof setInterval> | null = null;
   private pollIntervalMs: number;
+  private syncKey: string;
+  private label: string;
 
   constructor(opts: ZoteroWatcherOpts) {
     this.client = opts.client;
     this.excludeCollection = opts.excludeCollection;
     this.onItem = opts.onItem;
     this.pollIntervalMs = opts.pollIntervalMs ?? 60_000;
+    this.syncKey = opts.syncKey ?? 'library_version';
+    this.label = opts.label ?? 'user';
   }
 
   async start(): Promise<void> {
@@ -41,11 +50,11 @@ export class ZoteroWatcher {
     await this.poll();
     this.timer = setInterval(() => {
       this.poll().catch((err) => {
-        logger.warn({ err }, 'Zotero poll error');
+        logger.warn({ err, library: this.label }, 'Zotero poll error');
       });
     }, this.pollIntervalMs);
 
-    logger.info('Zotero watcher started');
+    logger.info({ library: this.label }, 'Zotero watcher started');
   }
 
   stop(): void {
@@ -82,27 +91,34 @@ export class ZoteroWatcher {
   }
 
   async poll(): Promise<void> {
-    const storedVersion = getZoteroSyncVersion();
+    const storedVersion = getZoteroSyncVersion(this.syncKey);
 
     let result: { items: unknown[]; version: number };
     try {
       result = await this.client.getItems(storedVersion ?? undefined);
     } catch (err) {
-      logger.warn({ err }, 'Zotero not reachable — will retry next cycle');
+      logger.warn(
+        { err, library: this.label },
+        'Zotero not reachable — will retry next cycle',
+      );
       return;
     }
 
     if (storedVersion === null) {
-      setZoteroSyncVersion(result.version);
+      setZoteroSyncVersion(this.syncKey, result.version);
       logger.info(
-        { version: result.version, itemCount: result.items.length },
+        {
+          library: this.label,
+          version: result.version,
+          itemCount: result.items.length,
+        },
         'Zotero first connect — stored version, skipping existing items',
       );
       return;
     }
 
     if (result.items.length === 0) {
-      setZoteroSyncVersion(result.version);
+      setZoteroSyncVersion(this.syncKey, result.version);
       return;
     }
 
@@ -132,13 +148,13 @@ export class ZoteroWatcher {
         await this.processItem(item);
       } catch (err) {
         logger.warn(
-          { key: item.key, title: item.data.title, err },
+          { library: this.label, key: item.key, title: item.data.title, err },
           'Failed to process Zotero item',
         );
       }
     }
 
-    setZoteroSyncVersion(result.version);
+    setZoteroSyncVersion(this.syncKey, result.version);
   }
 
   private async processItem(item: {


### PR DESCRIPTION
## Summary

- Adds `ZOTERO_GROUP_IDS` env var (comma-separated) so each configured Zotero group library is polled alongside `/api/users/0`.
- `ZoteroLocalClient` now takes a `libraryPath` arg (defaults to `users/0`) and threads it through every endpoint, so the same class targets user or group libraries cleanly.
- `ZoteroWatcher` takes an optional `syncKey` + `label`; each library's sync version is stored under its own row in the existing `zotero_sync` K/V table (`group:{id}:library_version`) — **no schema migration needed**.
- `IngestionPipeline` builds one watcher per library on startup and stops them all on shutdown. First-poll-skip is per-library, so enabling a group never triggers a mass reprocess of existing items.

## Why

The watcher previously only queried `/api/users/0`, so group libraries synced locally by Zotero were invisible. That's how we noticed: TDMA4007 (a group library with 11 PDFs) sat unwatched. This PR is the proper fix; a one-shot backfill script (`scripts/ingest-zotero-group.ts`) handles pre-existing items that the watcher's first-poll will skip.

## Known limitation

Zotero write-back still posts to `/users/{userId}/items/...`, so the summary-note + `vault:ingested` tag silently 404s for group items. Ingestion itself succeeds (write-back is already wrapped in try/catch). Follow-up: route write-back to `/groups/{id}/items/...` for group-sourced jobs (needs tracking the library per job — small follow-up PR).

## Rollout

After merge, set `ZOTERO_GROUP_IDS=6515112` in `.env` and restart NanoClaw to start watching TDMA4007.

## Test plan

- [x] `npx vitest run src/ingestion/zotero-client.test.ts src/ingestion/zotero-watcher.test.ts src/ingestion/zotero-db.test.ts` — 25/25 pass (new tests cover group-library URLs, keyed sync version, and watcher syncKey plumbing)
- [x] `npm run build` — clean
- [x] `npm test` — 990 pass; one unrelated flake (`src/claw-skill.test.ts` times out only when run with the full suite, passes in isolation; present on `main`)
- [ ] Manual: set `ZOTERO_GROUP_IDS=6515112`, restart NanoClaw, confirm log shows `libraries: ["user","group:6515112"]` and `group:6515112 library_version` is stored in `zotero_sync` after first poll
- [ ] Manual: add a new item to TDMA4007 in Zotero, confirm it's picked up on the next 60s tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)