### PR TITLE
fix(rag): await processing confirmation before marking docs indexed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,8 +142,8 @@ npm run dev
 ### Stop Everything
 
 ```bash
-# Find and kill Node/Python processes
-pkill -f "lightrag.api.lightrag_server"
+# Stop services (script uses the PID file written by --daemon)
+./scripts/lightrag-server.sh --stop
 pkill -f "tsx src/index.ts"
 pkill -f "next dev.*dashboard"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ universityClaw runs as a stack of 4 services. All must be running for full funct
 | Service | What it does | How to start | How to stop | Port |
 |---------|-------------|--------------|-------------|------|
 | **NanoClaw** | Main orchestrator (Node.js) | `npm run dev` | Ctrl+C or `kill <pid>` | — |
-| **LightRAG** | RAG server (Python, venv) | `.venv/bin/python3 -m lightrag.api.lightrag_server --port 9621 --working-dir ./data/lightrag` | `pkill -f lightrag` | 9621 |
+| **LightRAG** | RAG server (Python, venv) | `./scripts/lightrag-server.sh --daemon` | `./scripts/lightrag-server.sh --stop` | 9621 |
 | **OneCLI** | Credential proxy (Docker) | `docker restart onecli-app-1 onecli-postgres-1` | `docker stop onecli-app-1 onecli-postgres-1` | 10254 |
 | **Dashboard** | Web UI (Next.js) | `cd dashboard && npm run dev` | Ctrl+C or `kill <pid>` | 3100 |
 
@@ -128,8 +128,8 @@ universityClaw runs as a stack of 4 services. All must be running for full funct
 # 1. OneCLI (credential proxy — restart existing containers)
 docker restart onecli-app-1 onecli-postgres-1
 
-# 2. LightRAG (RAG server — uses .venv, reads config from .env)
-.venv/bin/python3 -m lightrag.api.lightrag_server --port 9621 --working-dir ./data/lightrag &
+# 2. LightRAG (RAG server — script sets working-dir to ./store/rag and reads config from .env)
+./scripts/lightrag-server.sh --daemon
 
 # 3. Dashboard (web UI — background)
 cd dashboard && npm run dev &

--- a/src/rag/indexer.ts
+++ b/src/rag/indexer.ts
@@ -117,7 +117,7 @@ export class RagIndexer {
 
     // Index new content
     try {
-      await this.ragClient.index(indexed);
+      await this.ragClient.index(indexed, { fileSource: relPath });
     } catch (err) {
       logger.warn({ err, relPath }, 'Failed to index file');
       return; // Don't update tracker — will retry on next event/restart

--- a/src/rag/rag-client.test.ts
+++ b/src/rag/rag-client.test.ts
@@ -85,19 +85,129 @@ describe('RagClient HTTP', () => {
     expect(result.answer).toBe('');
   });
 
-  it('index posts to /documents/text', async () => {
-    fetchSpy.mockResolvedValue(new Response('OK', { status: 200 }));
+  const jsonResponse = (data: unknown, status = 200): Response =>
+    new Response(JSON.stringify(data), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
 
-    await client.index('Hello world');
+  it('index posts to /documents/text and polls until processed', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(
+        jsonResponse({ status: 'success', track_id: 't1', message: 'ok' }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ status_summary: { 'DocStatus.PENDING': 1 } }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ status_summary: { 'DocStatus.PROCESSED': 1 } }),
+      );
 
-    const [url, opts] = fetchSpy.mock.calls[0];
-    expect(url).toBe('http://localhost:9621/documents/text');
-    expect(opts?.method).toBe('POST');
-    const body = JSON.parse(opts?.body as string);
+    await client.index('Hello world', { pollIntervalMs: 1 });
+
+    const [postUrl, postOpts] = fetchSpy.mock.calls[0];
+    expect(postUrl).toBe('http://localhost:9621/documents/text');
+    expect(postOpts?.method).toBe('POST');
+    const body = JSON.parse(postOpts?.body as string);
     expect(body.text).toBe('Hello world');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(fetchSpy.mock.calls[1][0]).toBe(
+      'http://localhost:9621/documents/track_status/t1',
+    );
   });
 
-  it('index throws on non-ok response', async () => {
+  it('index sends file_source when provided', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(
+        jsonResponse({ status: 'success', track_id: 't2', message: 'ok' }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ status_summary: { 'DocStatus.PROCESSED': 1 } }),
+      );
+
+    await client.index('text', {
+      fileSource: 'concepts/foo.md',
+      pollIntervalMs: 1,
+    });
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1]?.body as string);
+    expect(body.file_source).toBe('concepts/foo.md');
+  });
+
+  it('index returns immediately on duplicated (no polling)', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({
+        status: 'duplicated',
+        track_id: 't3',
+        message: 'already exists',
+      }),
+    );
+
+    await client.index('duplicate', { pollIntervalMs: 1 });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('index throws on failure status from POST', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({
+        status: 'failure',
+        track_id: 't4',
+        message: 'empty text',
+      }),
+    );
+
+    await expect(client.index('bad', { pollIntervalMs: 1 })).rejects.toThrow(
+      'LightRAG index rejected: empty text',
+    );
+  });
+
+  it('index throws when track_status reports FAILED', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(
+        jsonResponse({ status: 'success', track_id: 't5', message: 'ok' }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ status_summary: { 'DocStatus.FAILED': 1 } }),
+      );
+
+    await expect(
+      client.index('will-fail', { pollIntervalMs: 1 }),
+    ).rejects.toThrow('LightRAG indexing failed for track t5');
+  });
+
+  it('index keeps polling when track_status summary is initially empty', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(
+        jsonResponse({ status: 'success', track_id: 't7', message: 'ok' }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ status_summary: {} }))
+      .mockResolvedValueOnce(
+        jsonResponse({ status_summary: { 'DocStatus.PROCESSING': 1 } }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ status_summary: { 'DocStatus.PROCESSED': 1 } }),
+      );
+
+    await client.index('eventual', { pollIntervalMs: 1 });
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it('index throws on polling timeout', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(
+        jsonResponse({ status: 'success', track_id: 't6', message: 'ok' }),
+      )
+      .mockImplementation(async () =>
+        jsonResponse({ status_summary: { 'DocStatus.PROCESSING': 1 } }),
+      );
+
+    await expect(
+      client.index('stuck', { pollIntervalMs: 5, pollTimeoutMs: 20 }),
+    ).rejects.toThrow(/timed out after 20ms for track t6/);
+  });
+
+  it('index throws on non-ok HTTP response from POST', async () => {
     fetchSpy.mockResolvedValue(new Response('Bad', { status: 400 }));
 
     await expect(client.index('test')).rejects.toThrow('LightRAG index failed');

--- a/src/rag/rag-client.ts
+++ b/src/rag/rag-client.ts
@@ -65,17 +65,84 @@ export class RagClient {
     }
   }
 
-  async index(text: string): Promise<void> {
+  async index(
+    text: string,
+    options: {
+      fileSource?: string;
+      pollIntervalMs?: number;
+      pollTimeoutMs?: number;
+    } = {},
+  ): Promise<void> {
+    const {
+      fileSource,
+      pollIntervalMs = 2000,
+      pollTimeoutMs = 300_000,
+    } = options;
+
     const res = await fetch(`${this.serverUrl}/documents/text`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text }),
-      signal: AbortSignal.timeout(120_000),
+      body: JSON.stringify({ text, file_source: fileSource }),
+      signal: AbortSignal.timeout(30_000),
     });
     if (!res.ok) {
       const body = await res.text().catch(() => '');
       throw new Error(`LightRAG index failed (${res.status}): ${body}`);
     }
+
+    const { status, track_id, message } = (await res.json()) as {
+      status: 'success' | 'duplicated' | 'partial_success' | 'failure';
+      track_id: string;
+      message: string;
+    };
+
+    if (status === 'failure') {
+      throw new Error(`LightRAG index rejected: ${message}`);
+    }
+    if (status === 'duplicated') {
+      return;
+    }
+
+    const deadline = Date.now() + pollTimeoutMs;
+    while (Date.now() < deadline) {
+      const statusRes = await fetch(
+        `${this.serverUrl}/documents/track_status/${encodeURIComponent(track_id)}`,
+        { signal: AbortSignal.timeout(10_000) },
+      );
+      if (!statusRes.ok) {
+        const body = await statusRes.text().catch(() => '');
+        throw new Error(
+          `LightRAG track_status failed (${statusRes.status}): ${body}`,
+        );
+      }
+      const { status_summary } = (await statusRes.json()) as {
+        status_summary: Record<string, number>;
+      };
+      const pending =
+        (status_summary['DocStatus.PENDING'] ?? 0) +
+        (status_summary['DocStatus.PROCESSING'] ?? 0) +
+        (status_summary['DocStatus.PREPROCESSED'] ?? 0);
+      const failed = status_summary['DocStatus.FAILED'] ?? 0;
+      const processed = status_summary['DocStatus.PROCESSED'] ?? 0;
+      const total = pending + failed + processed;
+
+      // Empty summary means the doc hasn't been registered with the track_id
+      // yet — LightRAG processes POSTs asynchronously. Keep polling.
+      if (total > 0 && pending === 0) {
+        if (failed > 0) {
+          throw new Error(
+            `LightRAG indexing failed for track ${track_id}: ${JSON.stringify(status_summary)}`,
+          );
+        }
+        if (processed > 0) return;
+      }
+
+      await new Promise((r) => setTimeout(r, pollIntervalMs));
+    }
+
+    throw new Error(
+      `LightRAG indexing timed out after ${pollTimeoutMs}ms for track ${track_id}`,
+    );
   }
 
   async deleteDocument(docId: string): Promise<void> {

--- a/src/rag/rag-client.ts
+++ b/src/rag/rag-client.ts
@@ -102,6 +102,12 @@ export class RagClient {
     if (status === 'duplicated') {
       return;
     }
+    if (status === 'partial_success') {
+      logger.warn(
+        { track_id, message },
+        'LightRAG reported partial_success on insert; polling for final status',
+      );
+    }
 
     const deadline = Date.now() + pollTimeoutMs;
     while (Date.now() < deadline) {


### PR DESCRIPTION
## Summary

- `RagClient.index()` now polls `GET /documents/track_status/{track_id}` until a terminal `DocStatus` (PROCESSED or FAILED) before returning. Previously it trusted LightRAG's 200 on POST, which only means the doc was queued — actual pipeline failures (restarts, rate limits, crashes) silently lost 78% of vault ingests (836 of 1078 tracker rows had no corresponding LightRAG doc).
- Fixes `Start Everything` in `CLAUDE.md` to run `./scripts/lightrag-server.sh` which uses the correct `./store/rag` working directory. The prior command pointed at `./data/lightrag`, an empty sibling that every ingest silently landed in — rendering RAG queries useless.
- Empty `status_summary` (doc not yet registered with the track_id) is now treated as "keep polling" instead of a terminal failure — fixes a race I hit during dogfooding.
- Duplicate content short-circuits on LightRAG's `duplicated` status so re-indexing is cheap.
- Indexer now passes vault `relPath` as `file_source` so LightRAG populates `file_path` instead of `unknown_source`.

## Why this matters

Before this PR, the RAG subsystem was effectively broken: tracker said 1078 docs were indexed, but LightRAG storage had only ~200. Queries returned `[no-context]` for content that was meant to be searchable. Post-fix we verified tracker (1088) matches LightRAG processed (1088) with zero failures, and a sanity `hybrid` query returns 124 KB of real entity context.

## Test plan

- [x] `npx vitest run src/rag/` — 53/53 pass (7 new tests cover polling, file_source, duplicated, failure, FAILED, empty-summary race, timeout)
- [x] `npx tsc --noEmit` — no type errors
- [x] Full suite `npx vitest run` — 996/996 pass
- [x] Dogfood: wiped `store/rag` and `rag_index_tracker`, restarted services per new CLAUDE.md, watched 1078 vault files land in LightRAG with 0 persistent failures (10 OpenAI rate-limit blips auto-recovered via `/documents/reprocess_failed`)
- [x] Sanity query `digitalisering forretningsprosesser modellering` returns 124 KB context with expected entities

## Follow-ups (not in this PR)

- Parallelize `RagIndexer.enqueue` with `p-limit(8)` — single-threaded queue only uses 1/8 of LightRAG's insert capacity
- Surface LightRAG FAILED docs on the dashboard so gaps are visible instead of silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)